### PR TITLE
Fix typo in chapter 7

### DIFF
--- a/chapters/07-reward-models.md
+++ b/chapters/07-reward-models.md
@@ -65,7 +65,7 @@ Note, when training reward models, the most common practice is to train for only
 ## Variants
 
 Reward modeling is a relatively under-explored area of RLHF.
-The traditional reward modeling loss has been modified in many popular works, but the modifications have no solidified into a single best practice.
+The traditional reward modeling loss has been modified in many popular works, but the modifications have not solidified into a single best practice.
 
 ### Preference Margin Loss
 

--- a/chapters/08-regularization.md
+++ b/chapters/08-regularization.md
@@ -87,7 +87,7 @@ $$
 \text{objective} (\theta) = \mathbb{E}_{(x,y) \sim \mathcal{D}_{\pi^{\text{RL}}_{\theta}}} \left[ r_{\theta}(x, y) - \lambda r_{\text{reg.}} \right] + \gamma \mathbb{E}_{x \sim \mathcal{D}_{\text{pretrain}}} \left[ \log(\pi^{\text{RL}}_{\theta}(x)) \right]
 $$
 
-Recent work proposed using using a negative log likelihood term to balance the optimization of Direct Preference Optimization (DPO) [@pang2024iterative].
+Recent work proposed using a negative log likelihood term to balance the optimization of Direct Preference Optimization (DPO) [@pang2024iterative].
 Given the pairwise nature of the DPO loss, the same loss modification can be made to reward model training, constraining the model to predict accurate text (rumors from laboratories that did not publish the work).
 
 The optimization follows as a modification to DPO.


### PR DESCRIPTION
Fixing a minor typo I encountered when reading Chapter 7

<img width="938" alt="image" src="https://github.com/user-attachments/assets/a87c50e5-8151-4d99-9221-5fa60bf99ce0" />
