### PR TITLE
Added missing +1 to subscript in return equation.

### DIFF
--- a/chapters/11-policy-gradients.md
+++ b/chapters/11-policy-gradients.md
@@ -27,7 +27,7 @@ The objective of the agent, often called the *return*, is the sum of discounted,
 $$G_t = R_{t+1} + \gamma R_{t+2} + \cdots = \sum_{k=o}^\infty \gamma^k R_{t+k+1}.$$
 
 The return definition can also be estimated as:
-$$G_{t} = \gamma{G_{t+1}} + R_{t}.$$
+$$G_{t} = \gamma{G_{t+1}} + R_{t+1}.$$
 
 This return is the basis for learning a value function $V(s)$ that is the estimated future return given a current state:
 


### PR DESCRIPTION
Hi Nathan, I've been getting a bunch of value out of your textbook so far! I want to see if you think the change I suggested is appropriate, or for notational reasons, if it would make more sense to make it elsewhere:

In Chapter 11 we have the following text:

$$G_t = R_{t+1} + \gamma R_{t+2} + \cdots = \sum_{k=o}^\infty \gamma^k R_{t+k+1}.$$

The return definition can also be estimated as:

$$G_{t} = \gamma G_{t+1}  + R_{t}.$$

### My change

According to the first equation's setup, I think the second equation should actually read 

$$G_{t} = \gamma{G_{t+1}} + R_{t+1}.$$

### My reasoning

If we take the equation 

$$G_t = R_{t+1} + \gamma R_{t+2} + \cdots = \sum_{k=o}^\infty \gamma^k R_{t+k+1}. $$

We have that 

$$ G_{t+1} = R_{t+2} + \gamma R_{t+3} + \gamma^2 R_{t+4} + ... $$

So 

$$ \gamma G_{t+1} = \gamma R_{t+2} + \gamma^{2} R_{t+3} + \gamma^{3} R_{t+4} + ... $$

So from our original equation

$$ G_t = R_{t+1} + \gamma G_{t+1} $$