### PR TITLE
Fix equation formatting with proper auto-sizing delimiters (claude)

### DIFF
--- a/chapters/04-optimization.md
+++ b/chapters/04-optimization.md
@@ -12,10 +12,10 @@ next-url: "05-preferences.html"
 
 The optimization of reinforcement learning from human feedback (RLHF) builds on top of the standard RL setup.
 In RL, an agent takes actions, $a$, sampled from a policy, $\pi$, with respect to the state of the environment, $s$, to maximize reward, $r$ [@sutton2018reinforcement].
-Traditionally, the environment evolves with respect to a transition or dynamics function $p(s_{t+1}|s_t,a_t)$.
+Traditionally, the environment evolves with respect to a transition or dynamics function $p\left(s_{t+1}|s_t,a_t\right)$.
 Hence, across a finite episode, the goal of an RL agent is to solve the following optimization:
 
-$$J(\pi) = \mathbb{E}_{\tau \sim \pi} \left[ \sum_{t=0}^{\infty} \gamma^t r(s_t, a_t) \right],$$ {#eq:rl_opt}
+$$J(\pi) = \mathbb{E}_{\tau \sim \pi} \left[ \sum_{t=0}^{\infty} \gamma^t r\left(s_t, a_t\right) \right],$$ {#eq:rl_opt}
 
 where $\gamma$ is a discount factor from 0 to 1 that balances the desirability of near- versus future-rewards.
 Multiple methods for optimizing this expression are discussed in Chapter 11.
@@ -28,12 +28,12 @@ A standard illustration of the RL loop is shown in @fig:rl and how it compares t
 
 There are multiple core changes from the standard RL setup to that of RLHF:
 
-1. Switching from a reward function to a reward model. In RLHF, a learned model of human preferences, $r_\theta(s_t, a_t)$ (or any other classification model) is used instead of an environmental reward function. This gives the designer a substantial increase in the flexibility of the approach and control over the final results.
+1. Switching from a reward function to a reward model. In RLHF, a learned model of human preferences, $r_\theta\left(s_t, a_t\right)$ (or any other classification model) is used instead of an environmental reward function. This gives the designer a substantial increase in the flexibility of the approach and control over the final results.
 2. No state transitions exist. In RLHF, the initial states for the domain are prompts sampled from a training dataset and the "action" is the completion to said prompt. During standard practices, this action does not impact the next state and is only scored by the reward model.
 3. Response level rewards. Often referred to as a bandit problem, RLHF attribution of reward is done for an entire sequence of actions, composed of multiple generated tokens, rather than in a fine-grained manner. 
 
 Given the single-turn nature of the problem, the optimization can be re-written without the time horizon and discount factor (and the reward models):
-$$J(\pi) = \mathbb{E}_{\tau \sim \pi} \left[r_\theta(s_t, a_t) \right].$$ {#eq:rl_opt_int}
+$$J(\pi) = \mathbb{E}_{\tau \sim \pi} \left[r_\theta\left(s_t, a_t\right) \right].$$ {#eq:rl_opt_int}
 
 In many ways, the result is that while RLHF is heavily inspired by RL optimizers and problem formulations, the action implementation is very distinct from traditional RL.
 
@@ -76,7 +76,7 @@ RLHF is implemented from a strong base model, which induces a need to control th
 In order to succeed in a finetuning regime, RLHF techniques employ multiple types of regularization to control the optimization.
 The most common change to the optimization function is to add a distance penalty on the difference between the current RLHF policy and the starting point of the optimization:
 
-$$J(\pi) = \mathbb{E}_{\tau \sim \pi} \left[r_\theta(s_t, a_t)\right] - \beta  \mathcal{D}_{KL}(\pi^{\text{RL}}(\cdot|s_t) \| \pi^{\text{ref}}(\cdot|s_t)).$$ {#eq:rlhf_opt_eq}
+$$J(\pi) = \mathbb{E}_{\tau \sim \pi} \left[r_\theta\left(s_t, a_t\right)\right] - \beta  \mathcal{D}_{KL}\left(\pi^{\text{RL}}(\cdot|s_t) \| \pi^{\text{ref}}(\cdot|s_t)\right).$$ {#eq:rlhf_opt_eq}
 
 Within this formulation, a lot of study into RLHF training goes into understanding how to spend a certain "KL budget" as measured by a distance from the initial model.
 For more details, see Chapter 8 on Regularization.

--- a/chapters/07-reward-models.md
+++ b/chapters/07-reward-models.md
@@ -31,7 +31,7 @@ Thus, we can take the score of this model with two samples, the $i$ and $j$ abov
 
 The probability of success for a given reward model in a pairwise comparison, becomes:
 
-$$P(y_1 > y_2) = \frac{\exp(r(y_1))}{\exp(r(y_1)) + \exp(r(y_2))}$$ {#eq:bradterryrm}
+$$P(y_1 > y_2) = \frac{\exp\left(r(y_1)\right)}{\exp\left(r(y_1)\right) + \exp\left(r(y_2)\right)}$$ {#eq:bradterryrm}
 
 Then, by taking the gradient with respect to the model parameters, we can arrive at the loss function to train a reward model.
 The first form, as in [@ouyang2022training] and other works:
@@ -84,7 +84,7 @@ To do this, they weight the loss updates per comparison per prompt.
 At an implementation level, this can be done automatically by including all examples with the same prompt in the same training batch, naturally weighing the different pairs -- not doing this caused overfitting to the prompts.
 The loss function becomes:
 
-$$\mathcal{L}(\theta) = - \frac{1}{(\frac{K}{2})} \mathbb{E}_{(x, y_w, y_l)\sim D} \log \left( \sigma \left( r_{\theta}(x, y_w) - r_{\theta}(x, y_l) \right) \right)$$ {#eq:rewardmodelinginstructgpt}
+$$\mathcal{L}(\theta) = - \frac{1}{\left(\frac{K}{2}\right)} \mathbb{E}_{(x, y_w, y_l)\sim D} \log \left( \sigma \left( r_{\theta}(x, y_w) - r_{\theta}(x, y_l) \right) \right)$$ {#eq:rewardmodelinginstructgpt}
 
 
 ### K-wise Loss Function
@@ -96,7 +96,7 @@ Following Zhu et al. 2023 formalizes the setup [@zhu2023principled], following a
 With a prompt, or state, $s^i$, $K$ actions $(a_0^i, a_1^i, \cdots, a_{K-1}^i)$ are sampled from $P(a_0,\cdots,a_{K-1}|s^i)$.
 Then, labelers are used to rank preferences with $\sigma^i: [K] \mapsto [K]$ is a function representing action rankings, where $\sigma^i(0)$ is the most preferred action. This yields a preference model capturing the following:
 
-$$P(\sigma^i|s^i,a_0^i,a_1^i,\ldots,a_{K-1}^i) = \prod_{k=0}^{K-1} \frac{\exp(r_{\theta\star}(s^i,a_{\sigma^i(k)}^i))}{\sum_{j=k}^{K-1}\exp(r_{\theta\star}(s^i,a_{\sigma^i(j)}^i))}$$ {#eq:kwise_rm}
+$$P(\sigma^i|s^i,a_0^i,a_1^i,\ldots,a_{K-1}^i) = \prod_{k=0}^{K-1} \frac{\exp\left(r_{\theta\star}(s^i,a_{\sigma^i(k)}^i)\right)}{\sum_{j=k}^{K-1}\exp\left(r_{\theta\star}(s^i,a_{\sigma^i(j)}^i)\right)}$$ {#eq:kwise_rm}
 
 When $K = 2$, this reduces to the Bradley-Terry (BT) model for pairwise comparisons.
 Regardless, once trained, these models are used similarly to other reward models during RLHF training.
@@ -120,9 +120,9 @@ are language models, with a small scalar head that outputs predictions on a per-
 To translate, this is implemented as a language modeling head that can predict two classes per token (1 for correct, 0 for incorrect), rather than a classification head of a traditional RM that outputs one token for the entire sequence.
 Formally, following [@lyu2025exploring] this can be shown as:
 
-$$\mathcal{L}_{\text{CE}} = -\mathbb{E}_{(s,r)\sim \mathcal{D}}[r\log p_\theta(s) + (1-r)\log(1-p_\theta(s))]$$ {#eq:orm_loss}
+$$\mathcal{L}_{\text{CE}} = -\mathbb{E}_{(s,r)\sim \mathcal{D}}\left[r\log p_\theta(s) + (1-r)\log(1-p_\theta(s))\right]$$ {#eq:orm_loss}
 
-where $r \in {0,1}$ is a binary label where 1 applies to a correct answer to a given prompt and 0 applies to an incorrect, and $p_\theta(s)$ is the scalar proportional to predicted probability of correctness from the model being trained.
+where $r \in \{0,1\}$ is a binary label where 1 applies to a correct answer to a given prompt and 0 applies to an incorrect, and $p_\theta(s)$ is the scalar proportional to predicted probability of correctness from the model being trained.
 
 These models have continued in use, but are less supported in open-source RLHF tools. 
 For example, the same type of ORM was used in the seminal work *Let's Verify Step by Step* [@lightman2023let], but without the language modeling prediction piece of the loss.

--- a/chapters/11-policy-gradients.md
+++ b/chapters/11-policy-gradients.md
@@ -29,14 +29,14 @@ For definitions of symbols, see the problem setup chapter.
 Reinforcement learning algorithms are designed to maximize the future, discounted reward across a trajectory of states, $s \in \mathcal{S}$, and actions, $a \in \mathcal{A}$ (for more notation, see Chapter 3, Definitions).
 The objective of the agent, often called the *return*, is the sum of discounted, future rewards (where $\gamma\in [0,1)$ is a factor that prioritizes near term rewards) at a given time $t$:
 
-$$G_t = R_{t+1} + \gamma R_{t+2} + \cdots = \sum_{k=o}^\infty \gamma^k R_{t+k+1}.$$
+$$G_t = R_{t+1} + \gamma R_{t+2} + \cdots = \sum_{k=0}^\infty \gamma^k R_{t+k+1}.$$
 
 The return definition can also be estimated as:
 $$G_{t} = \gamma{G_{t+1}} + R_{t+1}.$$
 
 This return is the basis for learning a value function $V(s)$ that is the estimated future return given a current state:
 
-$$V(s) = \mathbb{E}\big[G_t | S_t = s \big].$$
+$$V(s) = \mathbb{E}\left[G_t | S_t = s \right].$$
 
 All policy gradient algorithms solve an objective for such a value function induced from a specific policy, $\pi(s|a)$. 
 
@@ -54,9 +54,9 @@ $$\theta \leftarrow \theta + \alpha \nabla_\theta J(\theta)$$
 
 The core implementation detail is how to compute said gradient.
 Schulman et al. 2015 provides an overview of the different ways that policy gradients can be computed [@schulman2015high].
-The goal is to *estimate* the exact gradient $g := \nabla_\theta \mathbb{E}[\sum_{t=0}^\infty r_t]$, of which, there are many forms similar to:
+The goal is to *estimate* the exact gradient $g := \nabla_\theta \mathbb{E}\left[\sum_{t=0}^\infty r_t\right]$, of which, there are many forms similar to:
 
-$$ g = \mathbb{E}\Big[\sum_{t=0}^\infty \Psi_t \nabla_\theta \text{log} \pi_\theta(a_t|s_t) \Big], $$
+$$ g = \mathbb{E}\left[\sum_{t=0}^\infty \Psi_t \nabla_\theta \text{log} \pi_\theta(a_t|s_t) \right], $$
 
 Where $\Psi_t$ can be the following:
 
@@ -129,10 +129,10 @@ With more modern notation and the generalized return $G$, the REINFORCE operator
 $$
 \nabla_{\theta}\,J(\theta)
 \;=\;
-\mathbb{E}_{\tau \sim \pi_{\theta}}\!\Big[
+\mathbb{E}_{\tau \sim \pi_{\theta}}\!\left[
     \sum_{t=0}^{T}
     \nabla_{\theta} \log \pi_{\theta}(a_t \mid s_t)\,G_t
-\Big],
+\right],
 $$
 
 
@@ -160,7 +160,7 @@ For example, with the KL divergence distance penalty, RLOO sums it over the comp
 Proximal Policy Optimization (PPO) [@schulman2017proximal] is one of the foundational algorithms to Deep RL's successes (such as OpenAI's DOTA 5 [@berner2019dota] and large amounts of research).
 The loss function is as follows:
 
-$$J(\theta) = \frac{1}{G}\sum_{i=1}^G \min\left(\frac{\pi_\theta(a_i|s)}{\pi_{\theta_{old}}(a_i|s)}A_i, \text{clip} \left( \frac{\pi_\theta(a_i|s)}{\pi_{\theta_{old}}(a_i|s)}, 1-\varepsilon, 1+\varepsilon \right) A_i \right)).$$ {#eq:PPO_EQN}
+$$J(\theta) = \frac{1}{G}\sum_{i=1}^G \min\left(\frac{\pi_\theta(a_i|s)}{\pi_{\theta_{old}}(a_i|s)}A_i, \text{clip} \left( \frac{\pi_\theta(a_i|s)}{\pi_{\theta_{old}}(a_i|s)}, 1-\varepsilon, 1+\varepsilon \right) A_i \right).$$ {#eq:PPO_EQN}
 
 Here we will explain the difference cases this loss function triggers given various advantages and policy ratios.
 At an implementation level, the inner computations for PPO involve standard policy gradient and a clipped policy gradient.
@@ -224,7 +224,7 @@ $$J(\theta) = \frac{1}{G}\sum_{i=1}^G \left(\min\left(\frac{\pi_\theta(a_i|s)}{\
 Note that relative to PPO, the standard implementation of GRPO includes the KL distance in the loss.
 With the advantage computation for the completion index $i$:
 
-$$A_i = \frac{r_i - \text{mean}({r_1, r_2, \cdots, r_G})}{\text{std}({r_1, r_2, \cdots, r_G})}.$$ {#eq:GRPO_ADV}
+$$A_i = \frac{r_i - \text{mean}\left({r_1, r_2, \cdots, r_G}\right)}{\text{std}\left({r_1, r_2, \cdots, r_G}\right)}.$$ {#eq:GRPO_ADV}
 
 Intuitively, the GRPO update is comparing multiple answers to a single question within a batch.
 The model learns to become more like the answers marked as correct and less like the others. 

--- a/chapters/12-direct-alignment.md
+++ b/chapters/12-direct-alignment.md
@@ -75,61 +75,61 @@ Next, they show how to arrive at that solution from pairwise preference data (i.
 
 To start, we should consider the RLHF optimization objective once again, here indicating we wish to maximize this quantity:
 
-$$ \max_{\pi} \mathbb{E}_{\tau \sim \pi} \left[r_\theta(s_t, a_t)\right] - \beta  \mathcal{D}_{KL}(\pi^{\text{RL}}(\cdot|s_t) \| \pi^{\text{ref}}(\cdot|s_t)).$$ {#eq:rlhf_opt_eq_repeat}
+$$ \max_{\pi} \mathbb{E}_{\tau \sim \pi} \left[r_\theta\left(s_t, a_t\right)\right] - \beta  \mathcal{D}_{KL}\left(\pi^{\text{RL}}(\cdot|s_t) \| \pi^{\text{ref}}(\cdot|s_t)\right).$$ {#eq:rlhf_opt_eq_repeat}
 
 First, let us expand the definition of KL-divergence,
 
-$$\max_{\pi} \mathbb{E}_{x \sim \mathcal{D}}\mathbb{E}_{y \sim \pi(y|x)}\left[r(x,y)-\beta\log\frac{\pi(y|x)}{\pi_{\text{ref}}(y|x)}\right] $$ {#eq:dpo_deriv_1}
+$$\max_{\pi} \mathbb{E}_{x \sim \mathcal{D}}\mathbb{E}_{y \sim \pi(y|x)}\left[r\left(x,y\right)-\beta\log\frac{\pi\left(y|x\right)}{\pi_{\text{ref}}\left(y|x\right)}\right] $$ {#eq:dpo_deriv_1}
 
 Next, pull the negative sign out of the difference in brackets. To do this, split it into two terms:
 
-$$ = \max_{\pi}\left(\mathbb{E}_{x \sim \mathcal{D}}\mathbb{E}_{y \sim \pi(y|x)}[r(x,y)] - \beta\,\mathbb{E}_{x \sim \mathcal{D}}\mathbb{E}_{y \sim \pi(y|x)}\left[\log\frac{\pi(y|x)}{\pi_{\text{ref}}(y|x)}\right]\right) $$ {#eq:dpo_deriv_2}
+$$ = \max_{\pi}\left(\mathbb{E}_{x \sim \mathcal{D}}\mathbb{E}_{y \sim \pi(y|x)}[r\left(x,y\right)] - \beta\,\mathbb{E}_{x \sim \mathcal{D}}\mathbb{E}_{y \sim \pi(y|x)}\left[\log\frac{\pi\left(y|x\right)}{\pi_{\text{ref}}\left(y|x\right)}\right]\right) $$ {#eq:dpo_deriv_2}
 
 Then, remove the factor of $-1$ and $\beta$,
 
-$$ = \min_{\pi}\left(-\mathbb{E}_{x \sim \mathcal{D}}\mathbb{E}_{y \sim \pi(y|x)}[r(x,y)] + \beta\,\mathbb{E}_{x \sim \mathcal{D}}\mathbb{E}_{y \sim \pi(y|x)}\left[\log\frac{\pi(y|x)}{\pi_{\mathrm{ref}}(y|x)}\right]\right) $$ {#eq:dpo_deriv_3}
+$$ = \min_{\pi}\left(-\mathbb{E}_{x \sim \mathcal{D}}\mathbb{E}_{y \sim \pi(y|x)}[r\left(x,y\right)] + \beta\,\mathbb{E}_{x \sim \mathcal{D}}\mathbb{E}_{y \sim \pi(y|x)}\left[\log\frac{\pi\left(y|x\right)}{\pi_{\mathrm{ref}}\left(y|x\right)}\right]\right) $$ {#eq:dpo_deriv_3}
 
 Divide by $\beta$ and recombine:
 
-$$ = \min_{\pi}\left(\mathbb{E}_{x \sim \mathcal{D}}\mathbb{E}_{y \sim \pi(y|x)}\left[ \log\frac{\pi(y|x)}{\pi_{\text{ref}}(y|x)} - \frac{1}{\beta}r(x,y) \right]\right) $$ {#eq:dpo_deriv_4}
+$$ = \min_{\pi}\left(\mathbb{E}_{x \sim \mathcal{D}}\mathbb{E}_{y \sim \pi(y|x)}\left[ \log\frac{\pi\left(y|x\right)}{\pi_{\text{ref}}\left(y|x\right)} - \frac{1}{\beta}r\left(x,y\right) \right]\right) $$ {#eq:dpo_deriv_4}
 
 
 Next, we must introduce a partition function, $Z(x)$:
 
-$$ Z(x) = \sum_y \pi_{\text{ref}}(y|x)\exp\left(\frac{1}{\beta}r(x,y)\right) $$ {#eq:dpo_partition}
+$$ Z(x) = \sum_y \pi_{\text{ref}}\left(y|x\right)\exp\left(\frac{1}{\beta}r\left(x,y\right)\right) $$ {#eq:dpo_partition}
 
 The partition function acts as a normalization factor over the reference policy, summing over all possible responses $y$ to a prompt $x$.
 With this substituted in, we obtain our intermediate transformation:
 
-$$ \min_{\pi}\mathbb{E}_{x\sim\mathcal{D}}\mathbb{E}_{y\sim\pi(y|x)}\left[\log\frac{\pi(y|x)}{\frac{1}{Z(x)}\pi_{\text{ref}}(y|x)\exp\left(\frac{1}{\beta}r(x,y)\right)} - \log Z(x)\right] $$ {#eq:dpo_deriv_5}
+$$ \min_{\pi}\mathbb{E}_{x\sim\mathcal{D}}\mathbb{E}_{y\sim\pi(y|x)}\left[\log\frac{\pi\left(y|x\right)}{\frac{1}{Z(x)}\pi_{\text{ref}}\left(y|x\right)\exp\left(\frac{1}{\beta}r\left(x,y\right)\right)} - \log Z(x)\right] $$ {#eq:dpo_deriv_5}
 
 To see how this is obtained, consider the internal part of the optimization in brackets of @eq:dpo_deriv_4:
 
-$$ \log\frac{\pi(y|x)}{\pi_{\text{ref}}(y|x)} - \frac{1}{\beta}r(x,y) $$ {#eq:dpo_deriv_6}
+$$ \log\frac{\pi\left(y|x\right)}{\pi_{\text{ref}}\left(y|x\right)} - \frac{1}{\beta}r\left(x,y\right) $$ {#eq:dpo_deriv_6}
 
 Then, add $\log Z(x) - \log Z(x)$ to both sides:
 
-$$ = \log\frac{\pi(y|x)}{\pi_{\text{ref}}(y|x)} - \frac{1}{\beta}r(x,y) + \log Z(x) - \log Z(x) $$ {#eq:dpo_deriv_7}
+$$ = \log\frac{\pi\left(y|x\right)}{\pi_{\text{ref}}\left(y|x\right)} - \frac{1}{\beta}r\left(x,y\right) + \log Z(x) - \log Z(x) $$ {#eq:dpo_deriv_7}
 
 Then, we group the terms:
 
-$$ = \left( \log \frac{\pi(y|x)}{\pi_{\text{ref}}(y|x)} + \log Z(x) \right) - \log Z(x) - \frac{1}{\beta}r(x,y) $$ {#eq:dpo_deriv_8}
+$$ = \left( \log \frac{\pi\left(y|x\right)}{\pi_{\text{ref}}\left(y|x\right)} + \log Z(x) \right) - \log Z(x) - \frac{1}{\beta}r\left(x,y\right) $$ {#eq:dpo_deriv_8}
 
 With $\log(x) + \log(y) = \log(x\cdot y)$ (and moving $Z$ to the denominator), we get:
 
-$$ = \log \frac{\pi(y|x)}{\frac{1}{Z(x)}\pi_{\text{ref}}(y|x)}- \log Z(x) - \frac{1}{\beta}r(x,y) $$ {#eq:dpo_deriv_9}
+$$ = \log \frac{\pi\left(y|x\right)}{\frac{1}{Z(x)}\pi_{\text{ref}}\left(y|x\right)}- \log Z(x) - \frac{1}{\beta}r\left(x,y\right) $$ {#eq:dpo_deriv_9}
 
 Next, we expand $\frac{1}{\beta}r(x,y)$ to $\log \exp \frac{1}{\beta}r(x,y)$ and do the same operation to get @eq:dpo_deriv_5.
 With this optimization form, we need to actually solve for the optimal policy $\pi^*$.
 To do so, let us consider the above optimization as a KL distance:
 
-$$ \min_{\pi}\mathbb{E}_{x\sim\mathcal{D}}\left[\mathbb{D}_\text{KL} \left(\pi(y|x)||\frac{1}{Z(x)}\pi_{\text{ref}}(y|x)\exp\left(\frac{1}{\beta}r(x,y)\right) \right) - \log Z(x)\right] $$ {#eq:dpo_deriv_10}
+$$ \min_{\pi}\mathbb{E}_{x\sim\mathcal{D}}\left[\mathbb{D}_\text{KL} \left(\pi\left(y|x\right)||\frac{1}{Z(x)}\pi_{\text{ref}}\left(y|x\right)\exp\left(\frac{1}{\beta}r\left(x,y\right)\right) \right) - \log Z(x)\right] $$ {#eq:dpo_deriv_10}
 
 Since the partition function $Z(x)$ does not depend on the final answer, we can ignore it. This leaves us with just the KL distance between our policy we are learning and a form relating the partition, $\beta$, reward, and reference policy.
 The Gibb's inequality tells this is minimized at a distance of 0, only when the two quantities are equal!
 Hence, we get an optimal policy:
 
-$$ \pi^*(y|x) = \pi(y|x) = \frac{1}{Z(x)}\pi_{\text{ref}}(y|x)\exp\left(\frac{1}{\beta}r(x,y)\right) $$ {#eq:dpo_opt_policy}
+$$ \pi^*(y|x) = \pi(y|x) = \frac{1}{Z(x)}\pi_{\text{ref}}\left(y|x\right)\exp\left(\frac{1}{\beta}r\left(x,y\right)\right) $$ {#eq:dpo_opt_policy}
 
 
 #### 2. Deriving DPO Objective for Bradley Terry Models


### PR DESCRIPTION
- Add \left( and \right) delimiters for proper parentheses sizing in pandoc
- Fix nested delimiters in complex math expressions
- Ensure consistent formatting across policy gradients, reward modeling, optimization, and direct alignment chapters
- Fix set notation from {0,1} to \{0,1\} in reward models chapter
- Fix summation index from k=o to k=0 in return equation

🤖 Generated with [Claude Code](https://claude.ai/code)