### PR TITLE
(chapter 7): Add derivation of loss function based on Bradley Terry model of preferences

### DIFF
--- a/chapters/07-reward-models.md
+++ b/chapters/07-reward-models.md
@@ -33,7 +33,19 @@ The probability of success for a given reward model in a pairwise comparison, be
 
 $$P(y_1 > y_2) = \frac{\exp(r(y_1))}{\exp(r(y_1)) + \exp(r(y_2))}$$ {#eq:bradterryrm}
 
-Then, by taking the gradient with respect to the model parameters, we can arrive at the loss function to train a reward model.
+Then, by maximizing the log-likelihood of the above function (or alternatively minimizing the negative log-likelihood), we can arrive at the loss function to train a reward model:
+
+$$
+\begin{aligned}
+\theta^* = \arg\max_\theta P(y_w > y_l) &= \arg\max_\theta \frac{\exp(r_\theta(y_w))}{\exp(r_\theta(y_w)) + \exp(r_\theta(y_l))} \\
+&= \arg\max_\theta \frac{\exp(r_\theta(y_w))}{\exp(r_\theta(y_w))\left(1 + \frac{\exp(r_\theta(y_l))}{\exp(r_\theta(y_w))}\right)} \\
+&= \arg\max_\theta \frac{1}{1 + \frac{\exp(r_\theta(y_l))}{\exp(r_\theta(y_w))}} \\ 
+&= \arg\max_\theta \frac{1}{1 + \exp(-(r_\theta(y_w) - r_\theta(y_l)))} \\
+&= \arg\max_\theta \sigma \left( r_\theta(y_w) - r_\theta(y_l) \right) \\
+&= \arg\min_\theta - \log \left( \sigma \left(r_\theta(y_w) - r_\theta(y_l)\right) \right)
+\end{aligned}
+$$ 
+
 The first form, as in [@ouyang2022training] and other works:
 $$\mathcal{L}(\theta) = - \log \left( \sigma \left( r_{\theta}(x, y_w) - r_{\theta}(x, y_l) \right) \right)$$ {#eq:rewardmodeling1}
 


### PR DESCRIPTION
Another nitpick regarding the explanation of the loss function derived from Bradley-Terry's model of preferences. 

The current version says:
<img width="862" alt="old" src="https://github.com/user-attachments/assets/aaacddf0-d9c4-4964-aa78-dcdd17c61e19" />

I don't believe it is the case that "by taking the gradient (of the preference function) with respect to the model parameters, we can arrive at the loss function to train a reward model"

In contrast, I think that we arrive at the loss function to train a reward model by maximizing (log) likelihood of the preferences being ordered correctly (`P(y_w > y_l)`). Or analogously, by minimizing the negative log-likelihood, which turns out to be the loss!

<img width="811" alt="new" src="https://github.com/user-attachments/assets/c88e292d-2af7-497c-aea0-362d2001db98" />

Personally, I found I understood the loss much better with the derivation. If in turn you feel like the math breaks the reading flow or clutters the page, I can move it to an appendix at the end.