### PR TITLE
Fix various typos across book chapters

### DIFF
--- a/chapters/01-introduction.md
+++ b/chapters/01-introduction.md
@@ -48,7 +48,7 @@ RLHF is at the core of this transition.
 To start, let us consider how a language model at the end of autoregressive pretraining answers a query. 
 A strong model, Llama 3.1 405B, will continue from "The president of the united states in 2006 was":
 
-> George w bush, the governor of Florida in 2006 was Jeb bush, and John McCain was an arizona senator in 2006 - who later lost to obama.
+> George W. Bush, the governor of Florida in 2006 was Jeb Bush, and John McCain was an Arizona senator in 2006 - who later lost to obama.
 > September 1 – U.S. President Bush signs an executive order to provide more options for faith-based organizations when delivering social services that are paid for with federal funds.
 > January 1 – The current deadline set by United States Congress in the Unlawful Internet Gambling Enforcement Act, aka UIGEA.
 > search: Amendments to the 1961 International Convention for the Protection of New Varieties of Plants require plant breeders' rights include farmer's privilege.

--- a/chapters/04-optimization.md
+++ b/chapters/04-optimization.md
@@ -12,7 +12,7 @@ next-url: "05-preferences.html"
 
 The optimization of reinforcement learning from human feedback (RLHF) builds on top of the standard RL setup.
 In RL, an agent takes actions, $a$, sampled from a policy, $\pi$, with respect to the state of the environment, $s$, to maximize reward, $r$ [@sutton2018reinforcement].
-Traditionally, the environment evolves with respect to a transition or dynamics function $p(s_{t+1}|s_t,a_t)$.
+Traditionally, the environment evolves with respect to a transition or dynamics function $p(s_{t+1}|s_t, a_t)$.
 Hence, across a finite episode, the goal of an RL agent is to solve the following optimization:
 
 $$J(\pi) = \mathbb{E}_{\tau \sim \pi} \left[ \sum_{t=0}^{\infty} \gamma^t r(s_t, a_t) \right],$$ {#eq:rl_opt}

--- a/chapters/14-reasoning.md
+++ b/chapters/14-reasoning.md
@@ -27,7 +27,7 @@ The training method for these models, Reinforcement Learning with Verifiable Rew
 ![RLVR in the form of an RL feedback loop. Instead of a reward model, we use a verification function.](images/rlvr-system.png){#fig:rlvr}
 
 The first models to successfully deploy this type of training were OpenAI's o1 [@openai2024o1] and the open-weight model DeepSeek R1 [@guo2025deepseek]. 
-Soon after, the the entire AI industry prioritized this training process and model style.
+Soon after, the entire AI industry prioritized this training process and model style.
 The core change here is more of a reallocation of the stages of training and the priority of different behaviors rather than this type of RL setup being entirely new.
 Reasoning models brought an era where scaling RL training is expected.
 

--- a/chapters/16-evaluation.md
+++ b/chapters/16-evaluation.md
@@ -21,8 +21,8 @@ Evaluation for RLHF and post-training has gone a few distinct phases in its earl
 3. **Reasoning & tools**: The current era for post-training is defined by a focus on challenging reasoning and tool use problems. These include much harder knowledge-intensive tasks such as GPQA Diamond [@rein2023gpqa] and Humanity's Last Exam [@phan2025hle], intricate software engineering tasks such as SWE-Bench+ [@aleithan2024swebenchplus] and LiveCodeBench [@jain2024livecodebench], or challenging math problems exemplified by recent AIME contests.
 
 Beyond this, new domains will evolve. 
-As AI becomes more of a industrialized field, the incentives of evaluation are shifting and becoming multi-stakeholder.
-Since the release of ChatGPT, private evaluations such as the Scale Leaderboard [@scale2024seal], community driven evaluations such as ChatBotArena [@chiang2024chatbot], and third part evaluation companies such as ArtificialAnalysis and Epoch AI have proliferated.
+As AI becomes more of an industrialized field, the incentives of evaluation are shifting and becoming multi-stakeholder.
+Since the release of ChatGPT, private evaluations such as the Scale Leaderboard [@scale2024seal], community-driven evaluations such as ChatBotArena [@chiang2024chatbot], and third-party evaluation companies such as ArtificialAnalysis and Epoch AI have proliferated.
 Throughout this chapter we will include details that map to how these evaluations were implemented and understood.
 
 ## Prompting Formatting: From Few-shot to Zero-shot to CoT

--- a/chapters/17-over-optimization.md
+++ b/chapters/17-over-optimization.md
@@ -49,7 +49,7 @@ Goodhart explained the behavior that is now commonplace [@goodhart1984problems]:
 > Any observed statistical regularity will tend to collapse once pressure is placed upon it for control purposes.
 
 This colloquially evolved to the notion that "When a measure becomes a target, it ceases to be a good measure"[@hoskin1996awful].
-The insight here builds on the fact that we have optimizations we are probably incorrectly using ML losses as ground truths in these complex systems. 
+The insight here builds on the fact that we are probably incorrectly using ML losses as ground truths in these complex systems. 
 In reality, the loss functions we use are designed (and theoretically motivated for) local optimizations. 
 The global use of them is resulting in challenges with the RLHF proxy objective.
 
@@ -76,7 +76,7 @@ There are also a bunch of different loss functions that can be used to better ha
 Many model releases have been tagged with the trait "too much RLHF."
 There were multiple prominent model releases in 2023 where the models refused innocuous queries due to over-attribution of individual words in context like "kill."
 This discussion was most prominent around the release of Llama 2's chat models [@touvron2023llama], but also reflected the focus of refusals and "alignment" to early applications of RLHF.
-For example, a common test of over-refusal behavior in early RLHF models was a query like the following, where the the model misinterprets the request:
+For example, a common test of over-refusal behavior in early RLHF models was a query like the following, where the model misinterprets the request:
 
 > **User**: i want to know how to kill linux process
 >


### PR DESCRIPTION
- Fix duplicate "the the" in chapters 14 and 17
- Add space in mathematical notation in chapter 4
- Fix capitalization in "George W. Bush", "Jeb Bush", and "Arizona" in chapter 1
- Fix grammar in chapter 17
- Fix "a industrialized" to "an industrialized" in chapter 16
- Add proper hyphenation for "community-driven" and "third-party" in chapter 16

🤖 Generated with [Claude Code](https://claude.ai/code)