### PR TITLE
Various typos

### DIFF
--- a/chapters/01-introduction.md
+++ b/chapters/01-introduction.md
@@ -60,7 +60,7 @@ The most compelling view of how RLHF works is to think of how *style* applies to
 The style, or format, of information presented is crucial to how it is learned.
 This has always been the case for examples such as coursework, but is normally applied in the background and not considered directly.
 
-Continuing the above example, a model trained with RLHF (and other post-training tools), would answer the question very differently. Asking Tülu 3 405B the same question "The president of the united states in 2006 was," is says concisely:
+Continuing the above example, a model trained with RLHF (and other post-training tools), would answer the question very differently. Asking Tülu 3 405B the same question "The president of the united states in 2006 was," it says concisely:
 
 > George W. Bush was the president of the United States in 2006. He served two terms in office, from January 20, 2001, to January 20, 2009.
 

--- a/chapters/04-optimization.md
+++ b/chapters/04-optimization.md
@@ -97,7 +97,7 @@ This can even include techniques that train specialized models and then merge th
 
 ![A summary of the Tülu 3 recipe with target skills and multi-step training recipe. Lambert et al. 2024, License CC-BY.](images/tulu3.png){#fig:tulu-3}
 
-A fully example version of this multi-stage version of post-training where RLHF plays a major role is Tülu 3.
+A fully open example version of this multi-stage version of post-training where RLHF plays a major role is Tülu 3.
 The Tülu 3 recipe consists of three stages:
 
 1. **Instruction tuning on ~1M examples**: This primarily synthetic data from a mix of frontier models such as GPT-4o and Llama 3.1 405B teaches the model general instruction following and serves as the foundation of a variety of capabilities such as mathematics or coding.

--- a/chapters/10-rejection-sampling.md
+++ b/chapters/10-rejection-sampling.md
@@ -15,7 +15,7 @@ The name originates from computational statistics  [@gilks1992adaptive], where o
 To alleviate this, one samples from a simpler to model distribution and uses a heuristic to check if the sample is permissible.
 With language models, the target distribution is high-quality answers to instructions, the filter is a reward model, and the sampling distribution is the current model.
 
-Many prominent RLHF and preference fine-tuning papers have used rejection sampling as a baseline, but a canonical implementation and documentation does not exist
+Many prominent RLHF and preference fine-tuning papers have used rejection sampling as a baseline, but a canonical implementation and documentation does not exist.
 
 WebGPT [@nakano2021webgpt], Anthropic's Helpful and Harmless agent[@bai2022training], OpenAI's popular paper on process reward models [@lightman2023let], Llama 2 Chat models [@touvron2023llama], and other seminal works all use this baseline.
 

--- a/chapters/11-policy-gradients.md
+++ b/chapters/11-policy-gradients.md
@@ -612,7 +612,7 @@ This leads to PPO or GRPO implementations where the second policy gradient and c
 ### Group Relative Policy Optimization
 
 The DeepSeekMath paper details some implementation details of GRPO that differ from PPO [@shao2024deepseekmath], especially if comparing to a standard application of PPO from Deep RL rather than language models.
-For example, the KL penalty within the RLHF optimization (recall the KL penalty is also used when training reasoning models on verifiable rewards without a reward model) is applied directly in the loss update rather to the reward function.
+For example, the KL penalty within the RLHF optimization (recall the KL penalty is also used when training reasoning models on verifiable rewards without a reward model) is applied directly in the loss update rather than to the reward function.
 Where the standard KL penalty application for RLHF is applied as $r=r_\theta + \beta D_{KL}$, the GRPO implementation is along the lines of:
 
 $$ L = L_{\text{policy gradient}} - \beta * D_{KL} $$

--- a/chapters/11-policy-gradients.md
+++ b/chapters/11-policy-gradients.md
@@ -200,7 +200,7 @@ $$ J(\theta) = \frac{1}{|a|} \sum_{t=0}^{|a|} \min\left(\frac{\pi_\theta(a_{t}|s
 This is the per-token version of PPO, which also applies to other policy-gradient methods, but is explored further later in the implementation section of this chapter.
 Here, the term for averaging by the number of tokens in the action, $\frac{1}{|a|}$, comes from common implementation practices, but is not in a formal derivation of the loss (shown in [@liu2025understanding]).
 
-Here we will explain the difference cases this loss function triggers given various advantages and policy ratios.
+Here we will explain the different cases this loss function triggers given various advantages and policy ratios.
 At an implementation level, the inner computations for PPO involve standard policy gradient and a clipped policy gradient.
 
 To understand how different situations emerge, we can define the policy ratio as:

--- a/chapters/11-policy-gradients.md
+++ b/chapters/11-policy-gradients.md
@@ -548,7 +548,6 @@ advantages = rewards - values.detach()  # Shape: (B*G, L)
 
 # Normalize advantages (optional but stable)
 advantages = (advantages - advantages.mean()) / (advantages.std() + 1e-8)
-advantages = advantages.unsqueeze(1)  # Shape: (B*G, 1)
 
 # Compute probability ratio between new and old policies
 ratio = torch.exp(new_per_token_logps - per_token_logps)  # Shape: (B*G, L)

--- a/chapters/11-policy-gradients.md
+++ b/chapters/11-policy-gradients.md
@@ -516,7 +516,7 @@ The primary challenges faced when making training more asynchronous are keeping 
 These systems are designed and implemented with the presumption that nearly on-policy data is good enough for stable learning. 
 Here, the generation and update phases can easily be synced to avoid idle compute on either piece of the training system.
 With reasoning models, the extremely long inference characteristics of problems requiring 10K to 100K+ tokens per answer makes the generation of roll-outs a far stronger bottleneck.
-A common problem when training reasoning models on more synchronous RL infrastructure is that an answer to one answer in the batch can take substantially more time to generate (either through more tokens or more tool calls), resulting in the majority of the allocated compute being idle until it completes. 
+A common problem when training reasoning models on more synchronous RL infrastructure is that an answer to one prompt in the batch can take substantially more time to generate (either through more tokens or more tool calls), resulting in the majority of the allocated compute being idle until it completes. 
 A second solution to this, called sequence-level packing, length mismatch issue within a batch is to stack shorter samples within a batch with clever masking to enable continued roll-outs from the model and better distributed length normalization of samples within a batch.
 The full complexity of distributed RL infrastructure is out of scope for this book, as it can cause many other subtle issues that slow down training or cause instability.
 

--- a/chapters/15-synthetic.md
+++ b/chapters/15-synthetic.md
@@ -52,6 +52,6 @@ With open models, common practice is to distill training data from closed API mo
 Within this, curating high-quality prompts and filtering responses from the teacher model is crucial to maximize performance.
 
 Transferring specific skills into smaller language models uses the same principles of distillation -- get the best data possible for training.
-Here, many papers have studying using limited datasets from stronger models to improve alignment
+Here, many papers have studied using limited datasets from stronger models to improve alignment
 [@zhou2023lima], mathematic reasoning [@shridhar2023distilling] [@hsieh2023distilling], 
  and test-time scaling [@muennighoff2025s1].

--- a/chapters/16-evaluation.md
+++ b/chapters/16-evaluation.md
@@ -9,7 +9,7 @@ next-url: "17-over-optimization.html"
 # Evaluation
 
 Evaluation is an ever evolving approach.
-The key to understanding language model evaluation, particularly with post-training, is that the current popular evaluation regimes represents a reflection of the popular training best practices and goals.
+The key to understanding language model evaluation, particularly with post-training, is that the current popular evaluation regimes represent a reflection of the popular training best practices and goals.
 While challenging evaluations drive progress in language models to new areas, the majority of evaluation is designed around building useful signals for new models.
 
 In many ways, this chapter is designed to present vignettes of popular evaluation regimes throughout the early history of RLHF, so readers can understand the common themes, details, and failure modes.
@@ -169,7 +169,7 @@ Evaluation is moving to where the models are tested to respond in a generative m
 
 ![Report from Epoch AI showing how major AI evaluations are rapidly saturated over time. License CC-BY.](images/benchmark-performance.jpeg)
 
-Language model evaluations done within companies can only be compared to their peers with large error bars because the process that they use evaluations internally is not matched with external evaluations.
+Language model evaluations done within companies can only be compared to their peers with large error bars because the process that they use for evaluations internally is not matched with external evaluations.
 Internal evaluations are made to hillclimb on for training, as would be called a "training set" in traditional machine learning.
 The public evaluations that the community uses to compare leading models cannot be known if they were within said training set or as unseen "test sets" or "validation sets."
 

--- a/chapters/16-evaluation.md
+++ b/chapters/16-evaluation.md
@@ -220,7 +220,7 @@ Thus, controlling evaluation scores by the total number of tokens for inference 
 
 Depending on how your data is formatted in post-training, models will have substantial differences across evaluation formats. 
 For example, two popular, open math datasets  [@li2024numinamath] and MetaMath [@yu2023metamath] conflict with each other in training due to small differences in how the answers are formatted -- Numina puts the answer in `\boxed{XYZ}` and MetaMath puts the answer after `The answer is: XYZ` -— training on both can make performance worse than with just one. 
-Strong models are trained to be able to function with multiple formats, but the generally have a strongest format.
+Strong models are trained to be able to function with multiple formats, but they generally have a strongest format.
 
 In the end we are left with a few key points on the state of evaluating closed models:
 

--- a/chapters/18-style.md
+++ b/chapters/18-style.md
@@ -10,7 +10,7 @@ next-url: "19-character.html"
 
 Early developments in RLHF gave it a reputation for being "just style transfer" or other harsh critiques on how RLHF manipulates the way information is presented in outputs.
 
-Style transfer, has held back the RLHF narrative for two reasons. 
+Style transfer has held back the RLHF narrative for two reasons. 
 
 First, when people discuss style transfer, they don’t describe this as being important or exciting. 
 Style is a never-ending source of human value, it’s why retelling stories can result in new bestselling books (such as [Sapiens](https://en.wikipedia.org/wiki/Sapiens:_A_Brief_History_of_Humankind)), and it is a fundamental part of continuing to progress our intellectual ecosystem. 
@@ -78,4 +78,4 @@ Those among you who are familiar with RLHF methods may ask if the KL constraint 
 The KL constraint is a distance term between the distribution of the original model and the resulting model. 
 It helps make the optimization more robust to overoptimization, but that makes the border between good and bad models a bit more nuanced. 
 Hence, the prevalence of vibes-based evaluations. 
-Though, models tend to have enough parameters where they can change substantially and still satisfy the KL constraint on the data being measured — it can’t be the entire pertaining dataset, for example.
+Though, models tend to have enough parameters where they can change substantially and still satisfy the KL constraint on the data being measured — it can’t be the entire pretraining dataset, for example.

--- a/chapters/19-character.md
+++ b/chapters/19-character.md
@@ -61,6 +61,6 @@ Much more goes into making a model easy to use than just having the final model 
 RLHF research has become the interface where a lot of this is tested because of the framing where RLHF is a way to understand the user's preferences to products in real time and because it is the final training stage before release.
 The quickest way to add a new feature to a model is to try and incorporate it at post-training where training is faster and cheaper.
 This cycle has been seen with image understanding, tool use, better behavior, and more.
-What starts as a product question quickly becomes and RLHF modeling question, and if it is successful there it backpropagates to other earlier training stages.
+What starts as a product question quickly becomes an RLHF modeling question, and if it is successful there it backpropagates to other earlier training stages.
 
 


### PR DESCRIPTION
Hi,

Thanks for writing such a great book. It really helped me get up to speed in what's been happening in RLHF and RLVR!

I noticed a few typos as I was going through the text and figured I'd suggest fixes here.
Most of them are very minor but a few required inferring what word you had intended to use, so please let me know (or just don't merge a commit) if they don't align with your intent.

There is one non-writing change, which is in the code example for PPO:
```
advantages = (advantages - advantages.mean()) / (advantages.std() + 1e-8)
 - advantages = advantages.unsqueeze(1)  # Shape: (B*G, 1)
 ```
 
 I removed the second line because it is redundant (plus the comment is incorrect). Per the preceding code I believe `advantages` is assumed to be of shape `(B*G, L)`, and the line above won't change the shape since it's just elementwise scalar subtraction and division being broadcast over the entire `advantages` tensor.
 
 Hope this is helpful!