### PR TITLE
feat(chapter 11): Full policy gradient derivation

### DIFF
--- a/chapters/11-policy-gradients.md
+++ b/chapters/11-policy-gradients.md
@@ -118,7 +118,7 @@ $$
 g = \nabla_\theta J(\pi_\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \sum_{t=0}^\infty \nabla_\theta \log \pi_\theta(a_t|s_t) \Psi_t \right]
 $$ {#eq:general_gradient}
 
-Where $\Psi_t$ can be the following (where the rewards can also often be discounted by $\gamma$):
+Where $\Psi_t$ can be the following (where the rewards can also often be discounted by $\gamma$), a taxonomy adopted from Schulman et al. 2015 [@schulman2015high]:
 
 1. $R(\tau) = \sum_{t=0}^{\infty} r_t$: total reward of the trajectory.
 2. $\sum_{t'=t}^{\infty} r_{t'}$: reward following action $a_t$, also described as the return, $G$.


### PR DESCRIPTION
This PR adds the full derivation of the policy gradient objective: 
<img width="859" height="1363" alt="Screenshot 2025-07-13 at 19 43 14" src="https://github.com/user-attachments/assets/9dbe3fa7-8c29-4211-b74b-da2fea161021" />

Also, in the next subsection it is said that the log-derivative trick will come in handy later, but is never used, so I removed it from there (as I also introduce it in this section for the derivation). 

Let me know if you feel this can be shortened in any way! Personally, I found it useful in my study notes, so thought others will benefit from this 