### PR TITLE
Fix capitalization.

### DIFF
--- a/chapters/14.5-tools.md
+++ b/chapters/14.5-tools.md
@@ -91,7 +91,7 @@ You are a function-calling AI model. You are provided with function signatures w
 ...
 </user>
 ``` 
-While the language model is generating, if following the above example, it would generate the tokens `search_torrents("Star Wars")` to search for star wars.
+While the language model is generating, if following the above example, it would generate the tokens `search_torrents("Star Wars")` to search for Star Wars.
 This is often encoded inside special formatting tokens, and then the next tokens inserted into the sequence will contain the tool outputs.
 With this, models can learn to accomplish more challenging tasks than many simple standalone models.
 


### PR DESCRIPTION
Matches proper noun in text with the proper noun shown in `search_torrents("Star Wars")`.

Also, I may have missed something, but I didn't understand why it follows that the model would invoke this function. Are we missing something? 

```
<user>
Are there any torrents of the Star Wars movies? 
</user>
```