### PR TITLE
fix(chapter 11): Incorrect indexing in per-token GRPO objective

### DIFF
--- a/chapters/11-policy-gradients.md
+++ b/chapters/11-policy-gradients.md
@@ -321,7 +321,7 @@ $$J(\theta) = \frac{1}{G}\sum_{i=1}^G \left(\min\left(\frac{\pi_\theta(a_i|s)}{\
 
 As above, we can expand this into a per-token computation:
 
-$$ J(\theta) = \frac{1}{G}\sum_{i=1}^G  \frac{1}{|a_i|} \sum_{t=1}^{|a_i|} \left( \min\left(\frac{\pi_\theta(a_{i,t}|s_{i,t})}{\pi_{\theta_{old}}(a_{i,t}|s_{i,t})}A_{i,t}, \text{clip} \left( \frac{\pi_\theta(a_{i,t}|s_{i,t})}{\pi_{\theta_{old}}(a_{i,t}|s_{i,t})}, 1-\varepsilon, 1+\varepsilon \right) A_{i,t} \right) - \beta D_{KL}(\pi_\theta(\cdot|s_{i,t})||\pi_{ref}(\cdot|s_{i,t})) \right)  $$ {#eq:GRPO_token}
+$$ J(\theta) = \frac{1}{G}\sum_{i=1}^G  \frac{1}{|a_i|} \sum_{t=1}^{|a_i|} \left( \min\left(\frac{\pi_\theta(a_{i,t}|s_{i})}{\pi_{\theta_{old}}(a_{i,t}|s_{i})}A_{i,t}, \text{clip} \left( \frac{\pi_\theta(a_{i,t}|s_{i})}{\pi_{\theta_{old}}(a_{i,t}|s_{i})}, 1-\varepsilon, 1+\varepsilon \right) A_{i,t} \right) - \beta D_{KL}(\pi_\theta(\cdot|s_{i})||\pi_{ref}(\cdot|s_{i})) \right)  $$ {#eq:GRPO_token}
 
 
 Note that relative to PPO, the standard implementation of GRPO includes the KL distance in the loss.


### PR DESCRIPTION
The current version of the chapter is as follows:
<img width="858" height="369" alt="Screenshot 2025-07-18 at 23 58 14" src="https://github.com/user-attachments/assets/1cb04034-fbbe-4c7c-b0aa-22b3b4a970df" />

However, as you notice, we iterate `t` from `1` to `|a_i|` in order to access each token in the **completion**. However, the same index `t` is used to access elements in the input state/prompt `s`, i.e. `s_{i, t}`. 

This new version fixes it:
<img width="852" height="376" alt="Screenshot 2025-07-18 at 23 57 45" src="https://github.com/user-attachments/assets/5579285f-864a-47d9-aada-3f2306e65b95" />
