### PR TITLE
Load open graph image from githubusercontent

### DIFF
--- a/templates/chapter.html
+++ b/templates/chapter.html
@@ -7,7 +7,7 @@
   <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
 
   <!-- Add Open Graph meta tags for share image -->
-  <meta property="og:image" content="https://github.com/natolambert/rlhf-book/blob/main/images/rlhf-book-share.png" />
+  <meta property="og:image" content="https://raw.githubusercontent.com/natolambert/rlhf-book/main/images/rlhf-book-share.png" />
   <meta property="og:image:width" content="1920" />
   <meta property="og:image:height" content="1080" />
   

--- a/templates/html.html
+++ b/templates/html.html
@@ -7,7 +7,7 @@
   <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
 
   <!-- Add Open Graph meta tags for share image -->
-  <meta property="og:image" content="https://github.com/natolambert/rlhf-book/blob/main/images/rlhf-book-share.png" />
+  <meta property="og:image" content="https://raw.githubusercontent.com/natolambert/rlhf-book/main/images/rlhf-book-share.png" />
   <meta property="og:image:width" content="1920" />
   <meta property="og:image:height" content="1080" />
 


### PR DESCRIPTION
## PR Summary
PR #146 fixed the link, but Open Graph still fails to load it since the URL pointed to a GitHub HTML page instead of the raw image. This PR switches to the `raw.githubusercontent.com` image URL (and keeps it absolute) so scrapers can fetch the actual PNG. Sorry for previous PR.