### PR TITLE
Fix title text wrapping on mobile devices

### DIFF
--- a/templates/style.css
+++ b/templates/style.css
@@ -114,6 +114,14 @@ h1 {
     font-size: 2.5em;
 }
 
+h1.title {
+    hyphens: none;
+    -webkit-hyphens: none;
+    -moz-hyphens: none;
+    -ms-hyphens: none;
+    word-break: keep-all;
+}
+
 h2 {
     font-size: 2em;
 }


### PR DESCRIPTION
## Summary
- Prevents title text from breaking mid-word on mobile devices
- Ensures "Learning", "Human", and "Feedback" stay as complete words without splitting

## Changes
- Added CSS rules to `h1.title` to disable hyphenation (`hyphens: none`)
- Set `word-break: keep-all` to prevent word breaks within the title
- Applied vendor prefixes for cross-browser compatibility

## Test plan
- [x] Build the site with `make`
- [x] Test on mobile viewport to verify title doesn't break mid-word
- [x] Verify no visual changes on desktop viewports

🤖 Generated with [Claude Code](https://claude.ai/code)