### PR TITLE
Remove .html from internal links and navigation

### DIFF
--- a/chapters/01-introduction.md
+++ b/chapters/01-introduction.md
@@ -3,7 +3,7 @@ prev-chapter: "Home"
 prev-url: "https://rlhfbook.com/"
 page-title: Introduction
 next-chapter: "Key Related Works"
-next-url: "02-related-works.html"
+next-url: "02-related-works"
 ---
 
 # Introduction
@@ -250,4 +250,3 @@ As more successes of fine-tuning language models with RL emerge, such as OpenAI'
 At the same time, while the spotlight of focus may be more intense on the RL portion of RLHF in the near future -- as a way to maximize performance on valuable tasks -- the core of RLHF is that it is a lens for studying the grand problems facing modern forms of AI.
 How do we map the complexities of human values and objectives into systems we use on a regular basis?
 This book hopes to be the foundation of decades of research and lessons on these problems.
-

--- a/chapters/02-related-works.md
+++ b/chapters/02-related-works.md
@@ -1,9 +1,9 @@
 ---
 prev-chapter: "Introduction"
-prev-url: "01-introduction.html"
+prev-url: "01-introduction"
 page-title: Related Works
 next-chapter: "Definitions & Background"
-next-url: "03-setup.html"
+next-url: "03-setup"
 ---
 
 # Key Related Works

--- a/chapters/03-setup.md
+++ b/chapters/03-setup.md
@@ -1,9 +1,9 @@
 ---
 prev-chapter: "Key Related Works"
-prev-url: "02-related-works.html"
+prev-url: "02-related-works"
 page-title: Definitions & Background
 next-chapter: "Training Overview"
-next-url: "04-optimization.html"
+next-url: "04-optimization"
 ---
 
 # Definitions & Background

--- a/chapters/04-optimization.md
+++ b/chapters/04-optimization.md
@@ -1,9 +1,9 @@
 ---
 prev-chapter: "Definitions & Background"
-prev-url: "03-setup.html"
+prev-url: "03-setup"
 page-title: Training Overview
 next-chapter: "The Nature of Preferences"
-next-url: "05-preferences.html"
+next-url: "05-preferences"
 ---
 
 # Training Overview
@@ -119,5 +119,4 @@ The DeepSeek recipe follows:
 
 As above, there are evolutions of the recipe, particularly with steps 3 and 4 to finalize the model before exposing it to users.
 Many models start with tailored instruction datasets with Chain of Thought sequences that are heavily filtered and polished from existing models, providing a fast step to strong behaviors with SFT alone before moving onto RL [@seed2025seed].
-
 

--- a/chapters/05-preferences.md
+++ b/chapters/05-preferences.md
@@ -1,9 +1,9 @@
 ---
 prev-chapter: "Problem Formulation"
-prev-url: "04-optimization.html"
+prev-url: "04-optimization"
 page-title: The Nature of Preferences
 next-chapter: "Preference Data"
-next-url: "06-preference-data.html"
+next-url: "06-preference-data"
 ---
 
 # The Nature of Preferences
@@ -106,4 +106,3 @@ Some of the most prominent critiques are summarized below:
 - **Preferences can change over time** [@pettigrew2019choosing].
 - **Preferences can vary across contexts**.
 - **The utility functions derived from aggregating preferences can reduce corrigibility** [@soares2015corrigibility] of downstream agents (i.e. the possibility of an agents' behavior to be corrected by the designer).
-

--- a/chapters/06-preference-data.md
+++ b/chapters/06-preference-data.md
@@ -1,9 +1,9 @@
 ---
 prev-chapter: "The Nature of Preferences"
-prev-url: "05-preferences.html"
+prev-url: "05-preferences"
 page-title: Preference Data
 next-chapter: "Reward Modeling"
-next-url: "07-reward-models.html"
+next-url: "07-reward-models"
 ---
 
 # Preference Data

--- a/chapters/07-reward-models.md
+++ b/chapters/07-reward-models.md
@@ -1,9 +1,9 @@
 ---
 prev-chapter: "Preference Data"
-prev-url: "06-preference-data.html"
+prev-url: "06-preference-data"
 page-title: Reward Modeling
 next-chapter: "Regularization"
-next-url: "08-regularization.html"
+next-url: "08-regularization"
 ---
 
 # Reward Modeling

--- a/chapters/08-regularization.md
+++ b/chapters/08-regularization.md
@@ -1,9 +1,9 @@
 ---
 prev-chapter: "Reward Modeling"
-prev-url: "07-reward-models.html"
+prev-url: "07-reward-models"
 page-title: Regularization
 next-chapter: "Instruction Tuning"
-next-url: "09-instruction-tuning.html"
+next-url: "09-instruction-tuning"
 ---
 
 # Regularization

--- a/chapters/09-instruction-tuning.md
+++ b/chapters/09-instruction-tuning.md
@@ -1,9 +1,9 @@
 ---
 prev-chapter: "Regularization"
-prev-url: "08-regularization.html"
+prev-url: "08-regularization"
 page-title: Instruction Finetuning
 next-chapter: "Rejection Sampling"
-next-url: "10-rejection-sampling.html"
+next-url: "10-rejection-sampling"
 ---
 
 # Instruction Finetuning

--- a/chapters/10-rejection-sampling.md
+++ b/chapters/10-rejection-sampling.md
@@ -1,9 +1,9 @@
 ---
 prev-chapter: "Instruction Tuning"
-prev-url: "09-instruction-tuning.html"
+prev-url: "09-instruction-tuning"
 page-title: Rejection Sampling
 next-chapter: "Policy Gradients"
-next-url: "11-policy-gradients.html"
+next-url: "11-policy-gradients"
 ---
 
 # Rejection Sampling
@@ -184,7 +184,7 @@ np.allclose(x, x_sorted[np.argsort(sorted_indices)])
 ### Fine-tuning
 
 With the selected completions, you then perform standard instruction fine-tuning on the current rendition of the model.
-More details can be found in the [chapter on instruction tuning](https://rlhfbook.com/c/instructions.html).
+More details can be found in the [chapter on instruction tuning](https://rlhfbook.com/c/instructions).
 
 ### Details
 
@@ -195,7 +195,7 @@ The core hyperparameters for performing this training are very intuitive:
 - **Completions per prompt**: Successful implementations of rejection sampling have included 10 to 30 or more completions for each prompt. Using too few completions will make training biased and or noisy.
 - **Instruction tuning details**: No clear training details for the instruction tuning during RS have been released. It is likely that they use slightly different settings than the initial instruction tuning phase of the model.
 - **Heterogeneous model generations**: Some implementations of rejection sampling include generations from multiple models rather than just the current model that is going to be trained. Best practices on how to do this are not established.
-- **Reward model training**: The reward model used will heavily impact the final result. For more resources on reward model training, see the [relevant chapter](https://rlhfbook.com/c/07-reward-models.html).
+- **Reward model training**: The reward model used will heavily impact the final result. For more resources on reward model training, see the [relevant chapter](https://rlhfbook.com/c/07-reward-models).
 
 #### Implementation Tricks
 

--- a/chapters/11-policy-gradients.md
+++ b/chapters/11-policy-gradients.md
@@ -1,9 +1,9 @@
 ---
 prev-chapter: "Rejection Sampling"
-prev-url: "10-rejection-sampling.html"
+prev-url: "10-rejection-sampling"
 page-title: Reinforcement Learning (i.e. Policy Gradient Algorithms)
 next-chapter: "Direct Alignment Algorithms"
-next-url: "12-direct-alignment.html"
+next-url: "12-direct-alignment"
 ---
 
 # Reinforcement Learning (i.e. Policy Gradient Algorithms)

--- a/chapters/12-direct-alignment.md
+++ b/chapters/12-direct-alignment.md
@@ -1,9 +1,9 @@
 ---
 prev-chapter: "Policy Gradients"
-prev-url: "11-policy-gradients.html"
+prev-url: "11-policy-gradients"
 page-title: Direct Alignment Algorithms
 next-chapter: "Constitutional AI"
-next-url: "13-cai.html"
+next-url: "13-cai"
 ---
 
 # Direct Alignment Algorithms

--- a/chapters/13-cai.md
+++ b/chapters/13-cai.md
@@ -1,9 +1,9 @@
 ---
 prev-chapter: "Direct Alignment"
-prev-url: "12-direct-alignment.html"
+prev-url: "12-direct-alignment"
 page-title: Constitutional AI & AI Feedback
 next-chapter: "Reasoning & Inference-Time Scaling"
-next-url: "14-reasoning.html"
+next-url: "14-reasoning"
 ---
 
 # Constitutional AI & AI Feedback

--- a/chapters/14-reasoning.md
+++ b/chapters/14-reasoning.md
@@ -1,9 +1,9 @@
 ---
 prev-chapter: "Constitutional AI & AI Feedback"
-prev-url: "13-cai.html"
+prev-url: "13-cai"
 page-title: Reasoning Training & Inference-Time Scaling
 next-chapter: "Tool Use & Function Calling"
-next-url: "14.5-tools.html"
+next-url: "14.5-tools"
 ---
 
 # Reasoning Training & Inference-Time Scaling

--- a/chapters/14.5-tools.md
+++ b/chapters/14.5-tools.md
@@ -1,9 +1,9 @@
 ---
 prev-chapter: "Reasoning & Inference-Time Scaling"
-prev-url: "14-reasoning.html"
+prev-url: "14-reasoning"
 page-title: Tool Use & Function Calling
 next-chapter: "Synthetic Data & Distillation"
-next-url: "15-synthetic.html"
+next-url: "15-synthetic"
 ---
 
 # Tool Use & Function Calling

--- a/chapters/15-synthetic.md
+++ b/chapters/15-synthetic.md
@@ -1,9 +1,9 @@
 ---
 prev-chapter: "Tool Use & Function Calling"
-prev-url: "14.5-tools.html"
+prev-url: "14.5-tools"
 page-title: Synthetic Data & Distillation
 next-chapter: "Evaluation & Prompting"
-next-url: "16-evaluation.html"
+next-url: "16-evaluation"
 ---
 
 # Synthetic Data & Distillation

--- a/chapters/16-evaluation.md
+++ b/chapters/16-evaluation.md
@@ -1,9 +1,9 @@
 ---
 prev-chapter: "Synthetic Data & Distillation"
-prev-url: "15-synthetic.html"
+prev-url: "15-synthetic"
 page-title: Evaluation
 next-chapter: "Over Optimization"
-next-url: "17-over-optimization.html"
+next-url: "17-over-optimization"
 ---
 
 # Evaluation
@@ -248,4 +248,3 @@ High variance on these perturbation benchmarks is not confirmation of contaminat
 
 There are many open-sourced evaluation tools for people to choose from. 
 There’s Inspect AI from the UK Safety Institute [@inspectAI2024], HuggingFace’s LightEval [@fourrier2023lighteval] that powered the Open LLM Leaderboard [@open-llm-leaderboard-v2], Eleuther AI’s evaluation harness [@gao2023evalharness] built on top of the infrastructure from their GPT-Neo-X model (around GPT-3 evaluation config) [@gpt-neox-20b], AI2’s library based on OLMES [@gu2024olmes], Stanford’s Center for Research on Foundation Model’s HELM [@liang2023helm], Mosaic’s (now Databricks’) Eval Gauntlet [@mosaicml2024gauntlet], and more.
-

--- a/chapters/17-over-optimization.md
+++ b/chapters/17-over-optimization.md
@@ -1,9 +1,9 @@
 ---
 prev-chapter: "Evaluation & Prompting"
-prev-url: "16-evaluation.html"
+prev-url: "16-evaluation"
 page-title: Over Optimization
 next-chapter: "Style and Information"
-next-url: "18-style.html"
+next-url: "18-style"
 ---
 
 # Over Optimization

--- a/chapters/18-style.md
+++ b/chapters/18-style.md
@@ -1,9 +1,9 @@
 ---
 prev-chapter: "Over Optimization"
-prev-url: "17-over-optimization.html"
+prev-url: "17-over-optimization"
 page-title: Style and Information
 next-chapter: "Character Training & Model Character"
-next-url: "19-character.html"
+next-url: "19-character"
 ---
 
 # Style and Information

--- a/chapters/19-character.md
+++ b/chapters/19-character.md
@@ -1,6 +1,6 @@
 ---
 prev-chapter: "Style & Information"
-prev-url: "18-style.html"
+prev-url: "18-style"
 page-title: Product, UX, Character, and Post-Training
 next-chapter: ""
 next-url: ""
@@ -62,5 +62,4 @@ RLHF research has become the interface where a lot of this is tested because of 
 The quickest way to add a new feature to a model is to try and incorporate it at post-training where training is faster and cheaper.
 This cycle has been seen with image understanding, tool use, better behavior, and more.
 What starts as a product question quickly becomes an RLHF modeling question, and if it is successful there it backpropagates to other earlier training stages.
-
 

--- a/templates/nav.js
+++ b/templates/nav.js
@@ -29,50 +29,50 @@ class NavigationDropdown extends HTMLElement {
       <div class="section">
         <h3>Introductions</h3>
         <ol start="1">
-          <li><a href="https://rlhfbook.com/c/01-introduction.html">Introduction</a></li>
-          <li><a href="https://rlhfbook.com/c/02-related-works.html">Seminal (Recent) Works</a></li>
-          <li><a href="https://rlhfbook.com/c/03-setup.html">Definitions</a></li>
+          <li><a href="https://rlhfbook.com/c/01-introduction">Introduction</a></li>
+          <li><a href="https://rlhfbook.com/c/02-related-works">Seminal (Recent) Works</a></li>
+          <li><a href="https://rlhfbook.com/c/03-setup">Definitions</a></li>
         </ol>
       </div>
 
       <div class="section">
         <h3>Problem Setup & Context</h3>
         <ol start="4">
-          <li><a href="https://rlhfbook.com/c/04-optimization.html">Training Overview</a></li>
-          <li><a href="https://rlhfbook.com/c/05-preferences.html">What are preferences?</a></li>
-          <li><a href="https://rlhfbook.com/c/06-preference-data.html">Preference Data</a></li>
+          <li><a href="https://rlhfbook.com/c/04-optimization">Training Overview</a></li>
+          <li><a href="https://rlhfbook.com/c/05-preferences">What are preferences?</a></li>
+          <li><a href="https://rlhfbook.com/c/06-preference-data">Preference Data</a></li>
         </ol>
       </div>
 
       <div class="section">
         <h3>Optimization Tools</h3>
         <ol start="7">
-          <li><a href="https://rlhfbook.com/c/07-reward-models.html">Reward Modeling</a></li>
-          <li><a href="https://rlhfbook.com/c/08-regularization.html">Regularization</a></li>
-          <li><a href="https://rlhfbook.com/c/09-instruction-tuning.html">Instruction Tuning (i.e. Supervised Finetuning)</a></li>
-          <li><a href="https://rlhfbook.com/c/10-rejection-sampling.html">Rejection Sampling</a></li>
-          <li><a href="https://rlhfbook.com/c/11-policy-gradients.html">Reinforcement Learning (i.e. Policy Gradients)</a></li>
-          <li><a href="https://rlhfbook.com/c/12-direct-alignment.html">Direct Alignment Algorithms</a></li>
+          <li><a href="https://rlhfbook.com/c/07-reward-models">Reward Modeling</a></li>
+          <li><a href="https://rlhfbook.com/c/08-regularization">Regularization</a></li>
+          <li><a href="https://rlhfbook.com/c/09-instruction-tuning">Instruction Tuning (i.e. Supervised Finetuning)</a></li>
+          <li><a href="https://rlhfbook.com/c/10-rejection-sampling">Rejection Sampling</a></li>
+          <li><a href="https://rlhfbook.com/c/11-policy-gradients">Reinforcement Learning (i.e. Policy Gradients)</a></li>
+          <li><a href="https://rlhfbook.com/c/12-direct-alignment">Direct Alignment Algorithms</a></li>
         </ol>
       </div>
 
       <div class="section">
         <h3>Advanced</h3>
         <ol start="13">
-          <li><a href="https://rlhfbook.com/c/13-cai.html">Constitutional AI and AI Feedback</a></li>
-          <li><a href="https://rlhfbook.com/c/14-reasoning.html">Reasoning and Inference-time Scaling</a></li>
-          <li><a href="https://rlhfbook.com/c/14.5-tools.html">Tool Use and Function Calling</a></li>
-          <li><a href="https://rlhfbook.com/c/15-synthetic.html">Synthetic Data & Distillation</a></li>
-          <li><a href="https://rlhfbook.com/c/16-evaluation.html">Evaluation</a></li>
+          <li><a href="https://rlhfbook.com/c/13-cai">Constitutional AI and AI Feedback</a></li>
+          <li><a href="https://rlhfbook.com/c/14-reasoning">Reasoning and Inference-time Scaling</a></li>
+          <li><a href="https://rlhfbook.com/c/14.5-tools">Tool Use and Function Calling</a></li>
+          <li><a href="https://rlhfbook.com/c/15-synthetic">Synthetic Data & Distillation</a></li>
+          <li><a href="https://rlhfbook.com/c/16-evaluation">Evaluation</a></li>
         </ol>
       </div>
 
       <div class="section">
         <h3>Open Questions</h3>
         <ol start="18">
-          <li><a href="https://rlhfbook.com/c/17-over-optimization.html">Over-optimization</a></li>
-          <li><a href="https://rlhfbook.com/c/18-style.html">Style & Information</a></li>
-          <li><a href="https://rlhfbook.com/c/19-character.html">Product, UX, Character, and Post-Training</a></li>
+          <li><a href="https://rlhfbook.com/c/17-over-optimization">Over-optimization</a></li>
+          <li><a href="https://rlhfbook.com/c/18-style">Style & Information</a></li>
+          <li><a href="https://rlhfbook.com/c/19-character">Product, UX, Character, and Post-Training</a></li>
         </ol>
       </div>
     </nav>


### PR DESCRIPTION
This PR removes the .html suffix from internal chapter links so URLs look cleaner:

- Updated navigation in templates/nav.js to link to /c/<slug> instead of /c/<slug>.html
- Updated prev-url/next-url front matter across chapters to be extensionless
- Fixed two inline chapter links to rlhfbook.com to be extensionless

No external links were changed. Build artifacts in build/ were not modified.