### PR TITLE
Fix assistant role description typo

### DIFF
--- a/chapters/09-instruction-tuning.md
+++ b/chapters/09-instruction-tuning.md
@@ -59,7 +59,7 @@ The `system` tag is only used for the first message of the conversation which ho
 These **system prompts** are used to provide additional context to the models, such as the date and time, or to patch behaviors.
 As a fun example, models can be told things such as "You are a friendly chatbot who always responds in the style of a pirate."
 
-Next, the two other roles are logical, as **user** is the messages from the one using the AI, and **assistant** holds the responses from the user.
+Next, the two other roles are logical, as **user** is the messages from the one using the AI, and **assistant** holds the responses from the AI.
 
 In order to translate all this information into tokens, we use the code listing above that we started with.
 The model has a series of *special tokens* that separate the various messages from each other.


### PR DESCRIPTION
## Summary
- correct the assistant role description to state that it contains responses from the AI

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e4b749a008325ab00f87db1ab9fd1)