### PR TITLE
Promote preorder link in navigation and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This is a work-in-progress textbook covering the fundamentals of Reinforcement L
 The code is licensed with the MIT license, but the content for the book found in `chapters/` is licensed under the [Creative Commons Non-Commercial ShareAlike Attribution License](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.en), CC-BY-NC-SA-4.0.
 This is meant for people with a basic ML and/or software background.
 
+👉 **[Pre-order the RLHF Book now!](https://hubs.la/Q03Tc3cf0)**
+
 ### Citation
 To cite this book, please use the following format.
 ```

--- a/templates/nav.js
+++ b/templates/nav.js
@@ -22,7 +22,7 @@ class NavigationDropdown extends HTMLElement {
           <li><a href="https://rlhfbook.com">Home</a></li>
           <li><a href="https://github.com/natolambert/rlhf-book">GitHub Repository</a></li>
           <li><a href="https://rlhfbook.com/book.pdf">PDF</a> / <a href="https://arxiv.org/abs/2504.12501">Arxiv</a> / <a href="https://rlhfbook.com/book.epub">EPUB</a></li>
-          <li class="inactive">Order a copy (Soon)</li>
+          <li><a href="https://hubs.la/Q03Tc3cf0">Pre-order now!</a></li>
           <li><a href="https://rlhfbook.com/library">Example Model Completions</a></li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- replace the inactive order link in the navigation dropdown with a "Pre-order now!" link to the affiliate URL
- highlight the pre-order link near the top of the README to make the option prominent

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691794c9aec483258a6747ac8ca0ce22)