### PR TITLE
Ensure preorder redirect deployed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,12 +213,13 @@ $(BUILD)/pdf/$(OUTPUT_FILENAME).pdf:	$(PDF_DEPENDENCIES)
 # also copy from build/pdf/book.pdf into build/html/
 # then copy images dir to build/html/chapters/
 files:
-	test -f favicon.ico || (echo "favicon.ico not found" && exit 1)
-	mkdir -p $(BUILD)/html/c/
-	cp favicon.ico $(BUILD)/html/ || echo "Failed to copy to $(BUILD)/html/"
-	cp favicon.ico $(BUILD)/html/c/ || echo "Failed to copy to $(BUILD)/html/c/"
-	cp $(BUILD)/pdf/book.pdf $(BUILD)/html/ || echo "Failed to copy to $(BUILD)/html/"
-	cp $(BUILD)/epub/book.epub $(BUILD)/html/ || echo "Failed to copy EPUB to $(BUILD)/html/"
+        test -f favicon.ico || (echo "favicon.ico not found" && exit 1)
+        mkdir -p $(BUILD)/html/c/
+        cp favicon.ico $(BUILD)/html/ || echo "Failed to copy to $(BUILD)/html/"
+        cp favicon.ico $(BUILD)/html/c/ || echo "Failed to copy to $(BUILD)/html/c/"
+        cp -R preorder $(BUILD)/html/ || echo "Failed to copy preorder static pages"
+        cp $(BUILD)/pdf/book.pdf $(BUILD)/html/ || echo "Failed to copy to $(BUILD)/html/"
+        cp $(BUILD)/epub/book.epub $(BUILD)/html/ || echo "Failed to copy EPUB to $(BUILD)/html/"
 	cp -r images $(BUILD)/html/c/ || echo "Failed to copy to $(BUILD)/html/chapters/"
 	cp ./templates/nav.js $(BUILD)/html/ || echo "Failed to copy nav.js to $(BUILD)/html/"
 	cp ./templates/nav.js $(BUILD)/html/c/ || echo "Failed to copy nav.js to $(BUILD)/html/c/"

--- a/preorder/index.html
+++ b/preorder/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting to RLHF Book Pre-order</title>
+    <meta http-equiv="refresh" content="0; url=https://hubs.la/Q03Tc3cf0" />
+    <link rel="canonical" href="https://hubs.la/Q03Tc3cf0" />
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        display: flex;
+        min-height: 100vh;
+        align-items: center;
+        justify-content: center;
+        background: #0b0b0f;
+        color: #f8f8f8;
+        text-align: center;
+      }
+      a {
+        color: #7fd1ff;
+      }
+    </style>
+    <script>
+      window.location.replace("https://hubs.la/Q03Tc3cf0");
+    </script>
+  </head>
+  <body>
+    <main>
+      <h1>Redirecting to the RLHF Book pre-order page…</h1>
+      <p>
+        If you are not redirected automatically, <a href="https://hubs.la/Q03Tc3cf0">click here to
+        pre-order the book</a>.
+      </p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a static `/preorder` page so GitHub Pages can serve a redirect to the pre-order link
- include HTML meta refresh, JS redirect, and a fallback link so users can always reach the preorder landing page
- copy the `preorder` directory into the built `build/html` output so the GitHub Pages action deploys the redirect page

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918ed4f3f108325bf85e1ff3a829cc2)