### PR TITLE
Uppercase the ratio term R_t in PPO objective

### DIFF
--- a/chapters/11-policy-gradients.md
+++ b/chapters/11-policy-gradients.md
@@ -287,7 +287,7 @@ $$
 J(\theta)
 =
 \mathbb{E}_{t}\left[
-\min\left(r_t(\theta)A_t,\ \text{clip}(r_t(\theta),1-\varepsilon,1+\varepsilon)A_t\right)
+\min\left(R_t(\theta)A_t,\ \text{clip}(R_t(\theta),1-\varepsilon,1+\varepsilon)A_t\right)
 \right],
 \qquad
 R_t(\theta)=\frac{\pi_\theta(a_t\mid s_t)}{\pi_{\theta_{\text{old}}}(a_t\mid s_t)}.


### PR DESCRIPTION
The issue seems to be that in the objective the ratio term is lowercase `r_t`, and in the expanded term on the right it is uppercase `R_t`

<img width="1038" height="330" alt="image" src="https://github.com/user-attachments/assets/0be20228-8317-431e-ad36-f09ce01a3ada" />
