### PR TITLE
explicitly state the dpo loss from bt model

### DIFF
--- a/chapters/12-direct-alignment.md
+++ b/chapters/12-direct-alignment.md
@@ -186,10 +186,10 @@ Finally, with the definition of a sigmoid function as $\sigma(x) = \frac{1}{1+e^
 
 $$p^*(y_1 \succ y_2 \mid x) = \sigma\left(\beta \log \frac{\pi^*(y_1 \mid x)}{\pi_{\text{ref}}(y_1 \mid x)} - \beta \log \frac{\pi^*(y_2 \mid x)}{\pi_{\text{ref}}(y_2 \mid x)}\right) $$ {#eq:dpo_loss_deriv3}
 
-This is the likelihood of preference data under the Bradley-Terry model, given the optimal policy $\pi^*$. Recall from Chapter 7 on Reward Modeling, we have derived the Bradley-Terry objective as maximizing the aforementioned likelihood, or equivalently minimizing the negative log-likelihood, which gives us the loss:
+This is the likelihood of preference data under the Bradley-Terry model, given the optimal policy $\pi^*$. Recall from Chapter 7 on Reward Modeling, we have derived the Bradley-Terry objective as maximizing the likelihood, or equivalently minimizing the negative log-likelihood, which gives us the loss:
 $$
 \begin{aligned}
-\mathcal{L}_{\text{DPO}}(\pi_{\theta}; \pi_{\text{ref}}) &= -\mathbb{E}_{(x,y_c,y_r)\sim\mathcal{D}}\left[ \log p^*(y_c \succ y_r \mid x)  \right] \\
+\mathcal{L}_{\text{DPO}}(\pi_{\theta}; \pi_{\text{ref}}) &= -\mathbb{E}_{(x,y_c,y_r)\sim\mathcal{D}}\left[ \log p(y_c \succ y_r \mid x)  \right] \\
 &= -\mathbb{E}_{(x,y_c,y_r)\sim\mathcal{D}}\left[ \log \sigma\left(\beta \log \frac{\pi_{\theta}(y_c|x)}{\pi_{\text{ref}}(y_c|x)} - \beta \log \frac{\pi_{\theta}(y_r|x)}{\pi_{\text{ref}}(y_r|x)}\right)\right]
 \end{aligned}
 $${#eq:dpo_loss_deriv4}


### PR DESCRIPTION
Currently, Chapter 12 (DPO) incorrectly states that we take the derivative of the optimal likelihood, instead of the loss derived from the optimal likelihood:
<img width="1126" height="640" alt="image" src="https://github.com/user-attachments/assets/bb624c86-49ec-4d0d-a3ad-ddaf6c489cfa" />

To fix this, I explicitly wrote down the loss, and then reference this equation in the calculation of the derivative 

<img width="1075" height="958" alt="image" src="https://github.com/user-attachments/assets/ea29a87b-3911-403f-9a3b-83bb8b343837" />
