### PR TITLE
Update copyright to include 2026

### DIFF
--- a/LICENSE-Code.md
+++ b/LICENSE-Code.md
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 =====================
 
-Copyright © `2025` `Nathan Lambert`
+Copyright © `2025-2026` `Nathan Lambert`
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/templates/chapter.html
+++ b/templates/chapter.html
@@ -136,7 +136,7 @@ $endfor$
       <img src="assets/manning.svg" alt="Manning" style="width: 40px; height: 40px;">
     </a>
   </div>
-  <p>&copy; 2024-2025 Nathan Lambert</p>
+  <p>&copy; 2024-2026 Nathan Lambert</p>
 </footer>
 </body>
 </html>

--- a/templates/library.html
+++ b/templates/library.html
@@ -396,7 +396,7 @@
         <img src="assets/manning.svg" alt="Manning" style="width: 40px; height: 40px;">
       </a>
     </div>
-    <p>&copy; 2024-2025 Nathan Lambert</p>
+    <p>&copy; 2024-2026 Nathan Lambert</p>
   </footer>
 
   <script>


### PR DESCRIPTION
## Summary
- Updates copyright year range in `LICENSE-Code.md` from 2025 to 2025-2026
- Updates footer copyright in `templates/chapter.html` and `templates/library.html` from 2024-2025 to 2024-2026

## Test plan
- [ ] Verify copyright displays correctly in rendered pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)