### PR TITLE
Fix bibliography citation errors and hallucinations

### DIFF
--- a/chapters/14-reasoning.md
+++ b/chapters/14-reasoning.md
@@ -220,7 +220,7 @@ STaR effectively approximates the policy gradient algorithm, but in practice fil
 TRICE [@hoffman2023training] also improves upon reasoning by generating traces and then optimizing with a custom Markov chain Monte Carlo inspired expectation maximization algorithm. 
 VinePPO [@VinePPO] followed these and used a setup that shifted closer to modern reasoning models. 
 VinePPO uses a PPO-based algorithm with binary rewards for math question correctness, training on GSM8K and MATH.
-Other work before OpenAI's o1 and DeepSeek R1 used code execution as a feedback signal for training [@gehring2024rlefgroundingcodellms], [@xudpoppo] or verification for theorem proving (called Reinforcement Learning from Verifier Feedback, RLVF, here) [@amit2024models]. 
+Other work before OpenAI's o1 and DeepSeek R1 used code execution as a feedback signal for training [@gehring2024rlefgroundingcodellms], [@xu2024dpo] or verification for theorem proving (called Reinforcement Learning from Verifier Feedback, RLVF, here) [@amit2024models]. 
 Tülu 3 expanded upon these methods by using a simple PPO trainer to reward completions with correct answers -- most importantly while maintaining the model's overall performance on a broad suite of evaluations.
 The binary rewards of Tülu 3 and modern reasoning training techniques can be contrasted to the iterative approach of STaR or the log-likelihood rewards of Quiet-STaR.
 

--- a/chapters/bib.bib
+++ b/chapters/bib.bib
@@ -2555,14 +2555,6 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   year = {2024}
 }
 
-@inproceedings{xudpoppo,
-  author={Shusheng Xu and Wei Fu and Jiaxuan Gao and Wenjie Ye and Weilin Liu and Zhiyu Mei and Guangju Wang and Chao Yu and Yi Wu},
-  title={Is DPO Superior to PPO for LLM Alignment? A Comprehensive Study},
-  year={2024},
-  cdate={1704067200000},
-  url={https://openreview.net/forum?id=6XH8R7YrSk},
-  booktitle={ICML}
-}
 
 @misc{wang2025ragenunderstandingselfevolutionllm,
   title={RAGEN: Understanding Self-Evolution in LLM Agents via Multi-Turn Reinforcement Learning},


### PR DESCRIPTION
## Summary
- Verified all citations against arXiv and official proceedings (working back-to-front through chapters 19→12)
- Fixed incorrect venues and years that were likely DBLP hallucinations
- Upgraded arXiv preprints to peer-reviewed versions where available
- Consolidated duplicate citation entries

## Fixes by chapter

**Chapter 18 (Style):**
- `yuan2025selfrewardinglanguagemodels`: ACL 2025 → **ICML 2024**

**Chapter 16 (Evaluation):**
- `hendrycks2020measuring` (MMLU): NAACL 2025 → **ICLR 2021**
- `liang2023helm` (HELM): ACL 2025 → **TMLR 2023** (also fixed syntax error)
- `gu2024olmes`: Fixed BibTeX syntax error

**Chapter 15 (Synthetic):**
- `hsieh2023distilling`: Upgraded from arXiv to **ACL Findings 2023**

**Chapter 14 (Reasoning):**
- Consolidated duplicate entries `xudpoppo` → `xu2024dpo`

**Chapters 1-11** (by other Claude working forward):
- Various fixes to early chapter citations

## Test plan
- [ ] Build book and verify citations render correctly
- [ ] Spot check a few citations in rendered PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)