### PR TITLE
Add rlhfbook.com/code redirect

### DIFF
--- a/book/code/index.html
+++ b/book/code/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting to RLHF Book Code Examples</title>
+    <meta http-equiv="refresh" content="0; url=https://github.com/natolambert/rlhf-book/tree/main/code" />
+    <link rel="canonical" href="https://github.com/natolambert/rlhf-book/tree/main/code" />
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        display: flex;
+        min-height: 100vh;
+        align-items: center;
+        justify-content: center;
+        background: #0b0b0f;
+        color: #f8f8f8;
+        text-align: center;
+      }
+      a {
+        color: #7fd1ff;
+      }
+    </style>
+    <script>
+      window.location.replace("https://github.com/natolambert/rlhf-book/tree/main/code");
+    </script>
+  </head>
+  <body>
+    <main>
+      <h1>Redirecting to RLHF Book code examples…</h1>
+      <p>
+        If you are not redirected automatically, <a href="https://github.com/natolambert/rlhf-book/tree/main/code">click here to
+        view the code examples</a>.
+      </p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Adds a redirect page at `book/code/index.html` so that `rlhfbook.com/code` redirects to the GitHub code examples directory
- Follows the same pattern as the existing `preorder/` redirect
- Enables a short, memorable URL for referencing code examples in the book text

## Test plan
- [ ] Deploy preview and verify `rlhfbook.com/code` redirects to `https://github.com/natolambert/rlhf-book/tree/main/code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)