### PR TITLE
Fix: Include code redirect in build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,7 @@ files:
 	cp book/favicon.ico $(BUILD)/html/ || echo "Failed to copy to $(BUILD)/html/"
 	cp book/favicon.ico $(BUILD)/html/c/ || echo "Failed to copy to $(BUILD)/html/c/"
 	cp -R book/preorder $(BUILD)/html/ || echo "Failed to copy preorder static pages"
+	cp -R book/code $(BUILD)/html/ || echo "Failed to copy code redirect page"
 	cp $(BUILD)/pdf/book.pdf $(BUILD)/html/ || echo "Failed to copy to $(BUILD)/html/"
 	cp $(BUILD)/epub/book.epub $(BUILD)/html/ || echo "Failed to copy EPUB to $(BUILD)/html/"
 	cp -r book/images $(BUILD)/html/c/ || echo "Failed to copy images to $(BUILD)/html/c/"


### PR DESCRIPTION
## Summary
- Adds the `book/code` directory to the `make files` target so the redirect page gets copied to the build output
- The redirect page was added in #224 but was not included in the build step

## Test plan
- [ ] Run `make files` and verify `build/html/code/index.html` exists

Generated with [Claude Code](https://claude.com/claude-code)