### PR TITLE
Make library page title clickable to homepage

### DIFF
--- a/book/templates/library.html
+++ b/book/templates/library.html
@@ -319,7 +319,7 @@
 </head>
 <body>
   <header id="title-block-header">
-    <h1 class="title">Reinforcement Learning from Human Feedback</h1>
+    <h1 class="title"><a href="https://rlhfbook.com/" style="color: inherit; text-decoration: none;">Reinforcement Learning from Human Feedback</a></h1>
     <p class="subtitle">A short introduction to RLHF and post-training focused on language models.</p>
     <p class="author">Nathan Lambert</p>
     <navigation-dropdown expanded="false"></navigation-dropdown>


### PR DESCRIPTION
## Summary
- Makes the main title on the library page (`/library`) clickable, linking to the homepage
- Matches the existing behavior on all chapter pages

## Test plan
- [ ] Visit https://rlhfbook.com/library after deploy
- [ ] Click the "Reinforcement Learning from Human Feedback" title
- [ ] Verify it navigates to the homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)