### PR TITLE
Fix Plausible analytics script URL (was returning 404)

### DIFF
--- a/book/templates/chapter.html
+++ b/book/templates/chapter.html
@@ -66,7 +66,7 @@ $endfor$
 <script src="table-scroll.js" defer></script>
 
 <!-- Privacy-friendly analytics by Plausible -->
-<script async src="https://plausible.io/js/pa-Rr3_iGtVZcPHhxkdbyDIb.file-downloads.js"></script>
+<script async src="https://plausible.io/js/pa-Rr3_iGtVZcPHhxkdbyDIb.js"></script>
 <script>
   window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
   plausible.init()

--- a/book/templates/html.html
+++ b/book/templates/html.html
@@ -61,7 +61,7 @@ $endfor$
 <script src="table-scroll.js" defer></script>
 
 <!-- Privacy-friendly analytics by Plausible -->
-<script async src="https://plausible.io/js/pa-Rr3_iGtVZcPHhxkdbyDIb.file-downloads.js"></script>
+<script async src="https://plausible.io/js/pa-Rr3_iGtVZcPHhxkdbyDIb.js"></script>
 <script>
   window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
   plausible.init()

--- a/book/templates/library.html
+++ b/book/templates/library.html
@@ -318,7 +318,7 @@
   <script src="table-scroll.js" defer></script>
 
   <!-- Privacy-friendly analytics by Plausible -->
-  <script async src="https://plausible.io/js/pa-Rr3_iGtVZcPHhxkdbyDIb.file-downloads.js"></script>
+  <script async src="https://plausible.io/js/pa-Rr3_iGtVZcPHhxkdbyDIb.js"></script>
   <script>
     window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
     plausible.init()


### PR DESCRIPTION
## Summary
- Fixed Plausible script URL from `.file-downloads.js` to `.js`
- The file-downloads extension is enabled via Plausible dashboard settings, not the script URL suffix
- The previous URL was returning 404, which is why analytics weren't being detected

## Test plan
- [ ] Merge and verify Plausible detects the site
- [ ] Check that file downloads tracking works (enable in Plausible dashboard settings)

Generated with Claude Code