### PR TITLE
Fix redirects: use _redirects file for Netlify CLI deploys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,7 @@ files:
 	mkdir -p $(BUILD)/html/c/
 	cp book/favicon.ico $(BUILD)/html/ || echo "Failed to copy to $(BUILD)/html/"
 	cp book/favicon.ico $(BUILD)/html/c/ || echo "Failed to copy to $(BUILD)/html/c/"
+	cp book/_redirects $(BUILD)/html/ || echo "Failed to copy _redirects to $(BUILD)/html/"
 	cp -R book/preorder $(BUILD)/html/ || echo "Failed to copy preorder static pages"
 	cp -R book/code $(BUILD)/html/ || echo "Failed to copy code redirect page"
 	cp $(BUILD)/pdf/book.pdf $(BUILD)/html/ || echo "Failed to copy to $(BUILD)/html/"

--- a/book/_redirects
+++ b/book/_redirects
@@ -1,0 +1,18 @@
+# Chapter Reorganization Redirects (January 2026)
+/c/03-setup /c/appendix-a-definitions 301
+/c/04-optimization /c/03-training-overview 301
+/c/05-preferences /c/10-preferences 301
+/c/06-preference-data /c/11-preference-data 301
+/c/07-reward-models /c/05-reward-models 301
+/c/08-regularization /c/15-regularization 301
+/c/09-instruction-tuning /c/04-instruction-tuning 301
+/c/10-rejection-sampling /c/09-rejection-sampling 301
+/c/11-policy-gradients /c/06-policy-gradients 301
+/c/12-direct-alignment /c/08-direct-alignment 301
+/c/13-cai /c/12-synthetic-data 301
+/c/14-reasoning /c/07-reasoning 301
+/c/14.5-tools /c/13-tools 301
+/c/15-synthetic /c/12-synthetic-data 301
+/c/17-over-optimization /c/14-over-optimization 301
+/c/18-style /c/appendix-b-style 301
+/c/19-character /c/17-product 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,102 +6,13 @@
 #
 # GitHub Actions builds the site and deploys via Netlify CLI.
 # See .github/workflows/static.yml for the build process.
+#
+# REDIRECTS: Handled by book/_redirects file (copied to build/html/ by Makefile)
+# The _redirects file is used because netlify.toml redirects aren't processed
+# when deploying via Netlify CLI.
 
 [build]
   publish = "build/html"
   # This command only runs if someone triggers a build from Netlify UI
   # Normal deploys come from GitHub Actions
   command = "echo 'Site is deployed via GitHub Actions, not Netlify build'"
-
-# =============================================================================
-# REDIRECTS - Chapter Reorganization (January 2026)
-# =============================================================================
-# Old URLs redirect to new chapter locations for SEO preservation
-
-# Renamed/moved chapters
-[[redirects]]
-  from = "/c/03-setup"
-  to = "/c/appendix-a-definitions"
-  status = 301
-
-[[redirects]]
-  from = "/c/04-optimization"
-  to = "/c/03-training-overview"
-  status = 301
-
-[[redirects]]
-  from = "/c/05-preferences"
-  to = "/c/10-preferences"
-  status = 301
-
-[[redirects]]
-  from = "/c/06-preference-data"
-  to = "/c/11-preference-data"
-  status = 301
-
-[[redirects]]
-  from = "/c/07-reward-models"
-  to = "/c/05-reward-models"
-  status = 301
-
-[[redirects]]
-  from = "/c/08-regularization"
-  to = "/c/15-regularization"
-  status = 301
-
-[[redirects]]
-  from = "/c/09-instruction-tuning"
-  to = "/c/04-instruction-tuning"
-  status = 301
-
-[[redirects]]
-  from = "/c/10-rejection-sampling"
-  to = "/c/09-rejection-sampling"
-  status = 301
-
-[[redirects]]
-  from = "/c/11-policy-gradients"
-  to = "/c/06-policy-gradients"
-  status = 301
-
-[[redirects]]
-  from = "/c/12-direct-alignment"
-  to = "/c/08-direct-alignment"
-  status = 301
-
-# CAI merged into Synthetic Data
-[[redirects]]
-  from = "/c/13-cai"
-  to = "/c/12-synthetic-data"
-  status = 301
-
-[[redirects]]
-  from = "/c/14-reasoning"
-  to = "/c/07-reasoning"
-  status = 301
-
-[[redirects]]
-  from = "/c/14.5-tools"
-  to = "/c/13-tools"
-  status = 301
-
-[[redirects]]
-  from = "/c/15-synthetic"
-  to = "/c/12-synthetic-data"
-  status = 301
-
-[[redirects]]
-  from = "/c/17-over-optimization"
-  to = "/c/14-over-optimization"
-  status = 301
-
-# Style moved to Appendix B
-[[redirects]]
-  from = "/c/18-style"
-  to = "/c/appendix-b-style"
-  status = 301
-
-[[redirects]]
-  from = "/c/19-character"
-  to = "/c/17-product"
-  status = 301


### PR DESCRIPTION
## Summary
- netlify.toml redirects aren't processed when deploying via Netlify CLI
- Added `book/_redirects` file with all 17 redirects
- Updated Makefile to copy it to build/html/

## Test plan
- [ ] Merge and wait for build
- [ ] Test: `rlhfbook.com/c/07-reward-models` → should 301 to `/c/05-reward-models`

Generated with Claude Code