### PR TITLE
Add Appendices heading, drop ieee.csl from arXiv bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,9 +188,8 @@ $(BUILD)/latex/$(OUTPUT_FILENAME).tex: $(PDF_DEPENDENCIES)
 	# 3e. Drop XeTeX/LuaTeX-only branch so arXiv's pdfLaTeX build doesn't demand Unicode engines
 	uv run python book/scripts/strip_xetex_branch.py $@
 
-	# 4. Copy bibliography and CSL files required by arXiv
-	cp book/chapters/bib.bib    $(BUILD)/latex/
-	cp book/templates/ieee.csl  $(BUILD)/latex/
+	# 4. (bib.bib and ieee.csl are only used by pandoc-citeproc at build
+	#    time; the .tex already has resolved/inlined citations)
 
 	# 5. Warn (but don\'t fail) if any non-ASCII bytes remain
 	uv run python book/scripts/report_non_ascii.py $@


### PR DESCRIPTION
## Summary
- Adds a `\chapter*{Appendices}` heading before the appendix sections in LaTeX/PDF output (no extra ToC entry since each appendix already appears individually)
- Stops copying `ieee.csl` into the arXiv zip — pandoc-citeproc resolves all citations at build time, so arXiv's pdflatex doesn't need it (this is the file arXiv always deletes)

## Test plan
- [ ] Run `make latex` and verify `\chapter*{Appendices}` appears before Appendix A in `build/latex/book.tex`
- [ ] Verify `ieee.csl` is not in `build/arxiv.zip`
- [ ] Run `make pdf` and confirm the Appendices heading renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)