### PR TITLE
Add rlhfbook.com to footers, move Tool Use to Practical Considerations

### DIFF
--- a/book/templates/404.html
+++ b/book/templates/404.html
@@ -119,7 +119,7 @@
       <img src="/assets/manning.svg" alt="Manning" style="width: 40px; height: 40px;">
     </a>
   </div>
-  <p>&copy; 2024-2026 Nathan Lambert</p>
+  <p>&copy; 2024-2026 Nathan Lambert &middot; <a href="https://rlhfbook.com" style="color: #888; text-decoration: none;">rlhfbook.com</a></p>
 </footer>
 </body>
 </html>

--- a/book/templates/chapter.html
+++ b/book/templates/chapter.html
@@ -143,7 +143,7 @@ $endfor$
       <img src="assets/manning.svg" alt="Manning" style="width: 40px; height: 40px;">
     </a>
   </div>
-  <p>&copy; 2024-2026 Nathan Lambert</p>
+  <p>&copy; 2024-2026 Nathan Lambert &middot; <a href="https://rlhfbook.com" style="color: #888; text-decoration: none;">rlhfbook.com</a></p>
 </footer>
 </body>
 </html>

--- a/book/templates/html.html
+++ b/book/templates/html.html
@@ -137,7 +137,7 @@ $endif$
         <img src="assets/manning.svg" alt="Manning" style="width: 40px; height: 40px;">
       </a>
     </div>
-    <p>&copy; 2024-2025 Nathan Lambert</p>
+    <p>&copy; 2024-2026 Nathan Lambert &middot; <a href="https://rlhfbook.com" style="color: #888; text-decoration: none;">rlhfbook.com</a></p>
   </footer>  
 </body>
 </html>

--- a/book/templates/library.html
+++ b/book/templates/library.html
@@ -403,7 +403,7 @@
         <img src="assets/manning.svg" alt="Manning" style="width: 40px; height: 40px;">
       </a>
     </div>
-    <p>&copy; 2024-2026 Nathan Lambert</p>
+    <p>&copy; 2024-2026 Nathan Lambert &middot; <a href="https://rlhfbook.com" style="color: #888; text-decoration: none;">rlhfbook.com</a></p>
   </footer>
 
   <script>

--- a/book/templates/nav.js
+++ b/book/templates/nav.js
@@ -54,13 +54,13 @@ class NavigationDropdown extends HTMLElement {
           <li><a href="https://rlhfbook.com/c/10-preferences">What are Preferences</a></li>
           <li><a href="https://rlhfbook.com/c/11-preference-data">Preference Data</a></li>
           <li><a href="https://rlhfbook.com/c/12-synthetic-data">Synthetic Data & CAI</a></li>
-          <li><a href="https://rlhfbook.com/c/13-tools">Tool Use</a></li>
         </ol>
       </div>
 
       <div class="section">
         <h3>Practical Considerations</h3>
-        <ol start="14">
+        <ol start="13">
+          <li><a href="https://rlhfbook.com/c/13-tools">Tool Use</a></li>
           <li><a href="https://rlhfbook.com/c/14-over-optimization">Over-optimization</a></li>
           <li><a href="https://rlhfbook.com/c/15-regularization">Regularization</a></li>
           <li><a href="https://rlhfbook.com/c/16-evaluation">Evaluation</a></li>


### PR DESCRIPTION
## Summary
- Add `· rlhfbook.com` link to the copyright line in all page templates (chapter, home, 404, library)
- Fix homepage copyright year from 2024-2025 to 2024-2026
- Move Tool Use (Ch 13) from "Data & Preferences" to "Practical Considerations" section in nav

## Test plan
- [ ] Verify footer shows `· rlhfbook.com` on chapter pages, home, library, and 404
- [ ] Verify Tool Use appears under Practical Considerations in the nav dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)