### PR TITLE
Remove pdflatex dependency from make html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ ECHO_BUILT = @echo "$@ was built\n"
 
 all:	book
 
-book:	epub kindle html pdf docx
+book:	epub kindle html pdf docx rl-cheatsheet
 
 clean:
 	$(RMDIR_CMD) $(BUILD)
@@ -105,7 +105,7 @@ $(info JS files found: $(JS_FILES))
 
 epub:	$(BUILD)/epub/$(OUTPUT_FILENAME).epub
 
-html:	nested_html $(BUILD)/html/$(OUTPUT_FILENAME_HTML).html $(BUILD)/html/library.html rl-cheatsheet
+html:	nested_html $(BUILD)/html/$(OUTPUT_FILENAME_HTML).html $(BUILD)/html/library.html
 	
 pdf:	$(BUILD)/pdf/$(OUTPUT_FILENAME).pdf
 


### PR DESCRIPTION
## Summary
- Removes `rl-cheatsheet` from the `html:` target dependencies
- `make html` no longer requires pdflatex, restoring prior behavior where only `make pdf` needs LaTeX
- The cheatsheet PDF can still be built via `make rl-cheatsheet` separately

Fixes the regression noted in #265 where HTML-only builds (CI, contributors without TeX) would fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)