### PR TITLE
Clean up TikZ build artifacts

### DIFF
--- a/diagrams/Makefile
+++ b/diagrams/Makefile
@@ -71,7 +71,7 @@ tikz: | $(GENERATED_DIR)
 			else \
 				echo "  ERROR: PDF not generated for $${base}"; \
 			fi; \
-			rm -f tikz/*.aux tikz/*.log; \
+			rm -f tikz/$${base}.aux tikz/$${base}.log tikz/$${base}.pdf; \
 		fi \
 	done
 	@echo "TikZ diagrams generated in $(GENERATED_DIR)/{pdf,png,svg}/"

--- a/diagrams/tikz/.gitignore
+++ b/diagrams/tikz/.gitignore
@@ -1,0 +1,4 @@
+# Build artifacts - outputs go to ../generated/{pdf,png,svg}/
+*.pdf
+*.aux
+*.log


### PR DESCRIPTION
## Summary
- Makefile tikz target now removes intermediate `.pdf`/`.aux`/`.log` from `tikz/` after copying outputs to `generated/{pdf,png,svg}/`, keeping source directory clean
- Added `tikz/.gitignore` to prevent build artifacts from being accidentally committed

## Test plan
- [ ] Run `cd diagrams && make tikz` and verify outputs appear in `generated/{pdf,png,svg}/`
- [ ] Verify `tikz/` has no leftover `.pdf`, `.aux`, or `.log` files after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)