### PR TITLE
Update cheatsheet PDF footer URL

### DIFF
--- a/book/rl-cheatsheet/inside_cover_back.tex
+++ b/book/rl-cheatsheet/inside_cover_back.tex
@@ -125,7 +125,7 @@ r_\theta(y \mid x) & Reward model score & & \\
 
 \vspace*{\fill}
 \begin{center}
-\small Nathan Lambert\enspace--\enspace\texttt{rlhfbook.com}
+\small Nathan Lambert\enspace--\enspace\texttt{rlhfbook.com/rl-cheatsheet}
 \end{center}
 
 \end{document}


### PR DESCRIPTION
## Summary
- Changes the footer in the cheatsheet TeX from `rlhfbook.com` to `rlhfbook.com/rl-cheatsheet`
- Makes it easy to find the web version if someone downloads/prints the PDF

One-line change. Manning repo already has this update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)