### PR TITLE
Update code blocks style

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,10 +144,12 @@ $(BUILD)/html/$(OUTPUT_FILENAME_HTML).html:	$(HTML_DEPENDENCIES)
 	$(COPY_CMD) book/templates/header-anchors.js $(BUILD)/html/
 	$(COPY_CMD) book/templates/table-scroll.js $(BUILD)/html/
 	$(COPY_CMD) book/templates/citation-tooltips.js $(BUILD)/html/
+	$(COPY_CMD) book/templates/copy-code.js $(BUILD)/html/
 	$(COPY_CMD) book/templates/nav.js $(BUILD)/html/c/
 	$(COPY_CMD) book/templates/header-anchors.js $(BUILD)/html/c/
 	$(COPY_CMD) book/templates/table-scroll.js $(BUILD)/html/c/
 	$(COPY_CMD) book/templates/citation-tooltips.js $(BUILD)/html/c/
+	$(COPY_CMD) book/templates/copy-code.js $(BUILD)/html/c/
 	cp book/templates/style.css $(BUILD)/html/style.css || echo "Failed to copy style.css"
 	@mkdir -p $(BUILD)/html/data
 	@test -f book/data/library.json && cp book/data/library.json $(BUILD)/html/data/library.json || echo "No library data to copy"
@@ -252,6 +254,8 @@ files:
 	cp ./book/templates/table-scroll.js $(BUILD)/html/c/ || echo "Failed to copy table-scroll.js to $(BUILD)/html/c/"
 	cp ./book/templates/citation-tooltips.js $(BUILD)/html/ || echo "Failed to copy citation-tooltips.js to $(BUILD)/html/"
 	cp ./book/templates/citation-tooltips.js $(BUILD)/html/c/ || echo "Failed to copy citation-tooltips.js to $(BUILD)/html/c/"
+	cp ./book/templates/copy-code.js $(BUILD)/html/ || echo "Failed to copy copy-code.js to $(BUILD)/html/"
+	cp ./book/templates/copy-code.js $(BUILD)/html/c/ || echo "Failed to copy copy-code.js to $(BUILD)/html/c/"
 	mkdir -p $(BUILD)/html/rl-cheatsheet
 	cp book/favicon.ico $(BUILD)/html/rl-cheatsheet/ || echo "Failed to copy favicon to rl-cheatsheet"
 	cp book/templates/style.css $(BUILD)/html/rl-cheatsheet/style.css || echo "Failed to copy style.css to rl-cheatsheet"

--- a/book/templates/chapter.html
+++ b/book/templates/chapter.html
@@ -67,6 +67,7 @@ $endfor$
 <script src="header-anchors.js" defer></script>
 <script src="table-scroll.js" defer></script>
 <script src="citation-tooltips.js" defer></script>
+<script src="copy-code.js" defer></script>
 
 <!-- Privacy-friendly analytics by Plausible -->
 <script async src="https://plausible.io/js/pa-Rr3_iGtVZcPHhxkdbyDIb.js"></script>

--- a/book/templates/copy-code.js
+++ b/book/templates/copy-code.js
@@ -1,0 +1,42 @@
+/**
+ * Adds a copy-to-clipboard button to all code blocks.
+ * On hover the button fades in; on click it copies the code and shows a checkmark.
+ */
+document.addEventListener('DOMContentLoaded', function() {
+  var blocks = document.querySelectorAll('pre');
+
+  blocks.forEach(function(block) {
+    var button = document.createElement('button');
+    button.className = 'copy-code-button';
+    button.title = 'Copy code';
+    button.innerHTML =
+      '<svg class="copy-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+        '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>' +
+        '<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>' +
+      '</svg>' +
+      '<svg class="check-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none">' +
+        '<polyline points="20 6 9 17 4 12"></polyline>' +
+      '</svg>';
+
+    button.addEventListener('click', function() {
+      var code = block.querySelector('code');
+      var text = code ? code.textContent : block.textContent;
+
+      navigator.clipboard.writeText(text).then(function() {
+        button.querySelector('.copy-icon').style.display = 'none';
+        button.querySelector('.check-icon').style.display = 'block';
+        button.classList.add('copied');
+
+        setTimeout(function() {
+          button.querySelector('.copy-icon').style.display = 'block';
+          button.querySelector('.check-icon').style.display = 'none';
+          button.classList.remove('copied');
+        }, 2000);
+      }).catch(function(err) {
+        console.error('Could not copy code: ', err);
+      });
+    });
+
+    block.appendChild(button);
+  });
+});

--- a/book/templates/style.css
+++ b/book/templates/style.css
@@ -578,3 +578,36 @@ thead {
 #search .pagefind-ui__result-excerpt {
     text-align: left;
 }
+
+/* Copy code button */
+pre {
+  position: relative;
+}
+.copy-code-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 4px 6px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: #fff;
+  color: #666;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease-in;
+  line-height: 1;
+  z-index: 1;
+}
+pre:hover .copy-code-button {
+  opacity: 0.7;
+}
+.copy-code-button:hover {
+  opacity: 1 !important;
+  border-color: #bbb;
+  color: #333;
+}
+.copy-code-button.copied {
+  opacity: 1 !important;
+  color: #22863a;
+  border-color: #22863a;
+}


### PR DESCRIPTION
I believe the current code style throughout the book is too large compared to the rest of the text, yet it has almost no delineation from the chapter to indicate that it is a codeblock. 

Updated the styles so that:
- font size is smaller
- line height is smaller
- subtle rounded border
- grayish background for inline and pre code block segments

Some examples, left: before; right: after
<img width="1748" height="776" alt="ppo" src="https://github.com/user-attachments/assets/ca6ba305-cc73-4be6-8c9f-8a0e570de5ed" />
<img width="1800" height="779" alt="chat_template" src="https://github.com/user-attachments/assets/f07a4eb6-546e-4f68-b57c-7e81fd375922" />
