### PR TITLE
Fix code block overflow with scrollable wrapper

### DIFF
--- a/book/templates/copy-code.js
+++ b/book/templates/copy-code.js
@@ -6,6 +6,11 @@ document.addEventListener('DOMContentLoaded', function() {
   var blocks = document.querySelectorAll('pre');
 
   blocks.forEach(function(block) {
+    var wrapper = document.createElement('div');
+    wrapper.className = 'code-wrapper';
+    block.parentNode.insertBefore(wrapper, block);
+    wrapper.appendChild(block);
+
     var button = document.createElement('button');
     button.className = 'copy-code-button';
     button.title = 'Copy code';
@@ -37,6 +42,6 @@ document.addEventListener('DOMContentLoaded', function() {
       });
     });
 
-    block.appendChild(button);
+    wrapper.appendChild(button);
   });
 });

--- a/book/templates/style.css
+++ b/book/templates/style.css
@@ -176,14 +176,17 @@ samp {
 
 pre {
     white-space: pre;
-    white-space: pre-wrap;
-    word-wrap: break-word;
     line-height: 1.4;
     padding: 1em 1.2em;
     background-color: #f6f6f6;
     border: 1px solid #e8e8e8;
     border-radius: 4px;
     overflow-x: auto;
+}
+
+/* Override pandoc's .sourceCode { overflow: visible } which kills scrollbars */
+pre.sourceCode {
+    overflow-x: auto !important;
 }
 
 p code, li code {
@@ -580,7 +583,7 @@ thead {
 }
 
 /* Copy code button */
-pre {
+.code-wrapper {
   position: relative;
 }
 .copy-code-button {
@@ -598,7 +601,7 @@ pre {
   line-height: 1;
   z-index: 1;
 }
-pre:hover .copy-code-button {
+.code-wrapper:hover .copy-code-button {
   opacity: 0.7;
 }
 .copy-code-button:hover {


### PR DESCRIPTION
## Summary

- Fix code blocks overflowing their container instead of scrolling horizontally
- Wrap each `<pre>` element in a `.code-wrapper` div so the copy button stays positioned outside the scrollable area
- Override pandoc's default `overflow: visible` on `.sourceCode` blocks that was preventing horizontal scrollbars
- Remove `pre-wrap` / `word-wrap` so long lines scroll instead of breaking mid-token

## Test plan

- [x] Verify long code blocks show horizontal scrollbar instead of overflowing
- [x] Verify copy-code button still appears on hover and copies correctly
- [x] Check on mobile viewport widths


---

I should have tested more edge cases for the previous implementation, but essentially found a bug where the border doesnt align with the "overflow":

<img width="905" height="757" alt="Screenshot 2026-02-25 at 20 19 45" src="https://github.com/user-attachments/assets/943c44ab-eeed-40d9-985e-1b676908fe10" />

Fixed it as shown below:
<img width="762" height="761" alt="Screenshot 2026-02-25 at 20 19 37" src="https://github.com/user-attachments/assets/de224b46-7847-4708-844d-345c2dbeff2e" />


Also tested on iPhone layout for responsiveness:
<img width="801" height="787" alt="Screenshot 2026-02-25 at 20 19 14" src="https://github.com/user-attachments/assets/2548b9e6-a8b4-4e18-9ba7-0211bcd56324" />


Sorry for the inconvenience! 

🤖 Generated with [Claude Code](https://claude.com/claude-code)