### PR TITLE
Add rlhfbook.com footer to PDF and EPUB templates

### DIFF
--- a/book/templates/epub.html
+++ b/book/templates/epub.html
@@ -34,6 +34,7 @@ $endif$
 $for(author)$
   <p class="author">$author$</p>
 $endfor$
+  <p class="publisher"><a href="https://rlhfbook.com">rlhfbook.com</a></p>
 $for(creator)$
   <p class="$creator.role$">$creator.text$</p>
 $endfor$

--- a/book/templates/pdf.tex
+++ b/book/templates/pdf.tex
@@ -339,9 +339,19 @@ $if(block-headings)$
 \fi
 $endif$
 $endif$
-$if(pagestyle)$
-\pagestyle{$pagestyle$}
-$endif$
+% Custom footer: rlhfbook.com on left, page number on right
+\usepackage{fancyhdr}
+\pagestyle{fancy}
+\fancyhf{}
+\renewcommand{\headrulewidth}{0pt}
+\fancyfoot[L]{\small\textcolor{gray}{rlhfbook.com}}
+\fancyfoot[R]{\small\textcolor{gray}{\thepage}}
+% Title page gets no footer
+\fancypagestyle{plain}{%
+  \fancyhf{}%
+  \renewcommand{\headrulewidth}{0pt}%
+  \renewcommand{\footrulewidth}{0pt}%
+}
 $for(header-includes)$
 $header-includes$
 $endfor$


### PR DESCRIPTION
## Summary
- **PDF**: Adds fancyhdr footer with rlhfbook.com (left) and page number (right) in gray on every page except the title page
- **EPUB**: Adds rlhfbook.com link on the title page below the author name (e-readers control pagination, so per-page footers are not possible)

## Test plan
- [x] make pdf builds successfully (211 pages)
- [x] make epub builds successfully
- [x] Verified footer renders on PDF pages
- [x] Verified title page (page 1) has no footer
- [x] Verified EPUB title page shows rlhfbook.com link