### PR TITLE
Add Resources section to nav with RL Cheatsheet and Library

### DIFF
--- a/book/templates/nav.js
+++ b/book/templates/nav.js
@@ -19,11 +19,13 @@ class NavigationDropdown extends HTMLElement {
       <div class="section">
         <h3>Links</h3>
         <ul>
-          <li><a href="https://rlhfbook.com">Home</a></li>
-          <li><a href="https://github.com/natolambert/rlhf-book">GitHub Repository</a></li>
+          <li><a href="https://rlhfbook.com">Home</a> / <a href="https://github.com/natolambert/rlhf-book">GitHub</a></li>
           <li><a href="https://rlhfbook.com/book.pdf">PDF</a> / <a href="https://arxiv.org/abs/2504.12501">Arxiv</a> / <a href="https://rlhfbook.com/book.epub">EPUB</a> / <a href="https://rlhfbook.com/book.kindle.epub">Kindle</a></li>
           <li><a href="https://hubs.la/Q03TsMBq0">Pre-order now!</a></li>
-          <li><a href="https://rlhfbook.com/library">Library</a></li>
+        </ul>
+        <h3>Resources</h3>
+        <ul>
+          <li><a href="https://rlhfbook.com/rl-cheatsheet">RL Cheatsheet</a> / <a href="https://rlhfbook.com/library">Library</a></li>
         </ul>
       </div>
 


### PR DESCRIPTION
## Summary
- Adds **Resources** sub-header in the Links nav cell with RL Cheatsheet and Library
- Consolidates Home / GitHub onto one line
- Removes Library from its old buried spot in Links

Closes #276

## Test plan
- [x] make html builds successfully
- [x] Verified nav renders correctly in browser