### PR TITLE
Add [code] links to nav for chapters with examples

### DIFF
--- a/book/templates/nav.js
+++ b/book/templates/nav.js
@@ -40,10 +40,10 @@ class NavigationDropdown extends HTMLElement {
         <h3>Core Training Pipeline</h3>
         <ol start="4">
           <li><a href="https://rlhfbook.com/c/04-instruction-tuning">Instruction Tuning</a></li>
-          <li><a href="https://rlhfbook.com/c/05-reward-models">Reward Models</a></li>
-          <li><a href="https://rlhfbook.com/c/06-policy-gradients">Reinforcement Learning</a></li>
+          <li><a href="https://rlhfbook.com/c/05-reward-models">Reward Models</a> [<a href="https://github.com/natolambert/rlhf-book/tree/main/code/reward_models">code</a>]</li>
+          <li><a href="https://rlhfbook.com/c/06-policy-gradients">Reinforcement Learning</a> [<a href="https://github.com/natolambert/rlhf-book/tree/main/code/policy_gradients">code</a>]</li>
           <li><a href="https://rlhfbook.com/c/07-reasoning">Reasoning</a></li>
-          <li><a href="https://rlhfbook.com/c/08-direct-alignment">Direct Alignment</a></li>
+          <li><a href="https://rlhfbook.com/c/08-direct-alignment">Direct Alignment</a> [<a href="https://github.com/natolambert/rlhf-book/tree/main/code/direct_alignment">code</a>]</li>
           <li><a href="https://rlhfbook.com/c/09-rejection-sampling">Rejection Sampling</a></li>
         </ol>
       </div>


### PR DESCRIPTION
## Summary
- Adds `[code]` links in the navigation sidebar next to Reward Models, Reinforcement Learning, and Direct Alignment chapters
- Each link points to the corresponding `code/` subdirectory on GitHub (`reward_models/`, `policy_gradients/`, `direct_alignment/`)

Closes #279

## Test plan
- [ ] Preview the site and verify the nav renders `[code]` links correctly next to ch5, ch6, ch8
- [ ] Verify the links resolve to the correct GitHub directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)