### PR TITLE
Port substantive editor fixes from Manning PR #52

### DIFF
--- a/book/chapters/03-training-overview.md
+++ b/book/chapters/03-training-overview.md
@@ -27,12 +27,13 @@ Together, the policy and dynamics induce a trajectory distribution:
 
 $$p_{\pi}(\tau)=\rho_0(s_0)\prod_{t=0}^{T-1}\pi(a_t\mid s_t)\,p(s_{t+1}\mid s_t,a_t).$$ {#eq:rl_dynam}
 
-Across a finite episode with horizon $T$, the goal of an RL agent is to solve the following optimization:
+Across a finite episode with horizon $T$, the goal of an RL agent is to solve the following optimization, where $\gamma$ is a discount factor from 0 to 1 that balances the desirability of near-term versus future rewards:
 
-$$J(\pi) = \mathbb{E}_{\tau \sim p_{\pi}} \left[ \sum_{t=0}^{T-1} \gamma^t r(s_t, a_t) \right],$$ {#eq:rl_opt}
+$$\max_\pi \; \mathbb{E}_{\tau \sim p_{\pi}} \left[ \sum_{t=0}^{T-1} \gamma^t r(s_t, a_t) \right],$$ {#eq:rl_opt}
+
+The expected return for a given policy is often denoted $J(\pi)$, with the optimal value written $J^* = \max_\pi J(\pi)$.
 
 For continuing tasks, one often takes $T\to\infty$ and relies on discounting ($\gamma<1$) to keep the objective well-defined.
-$\gamma$ is a discount factor from 0 to 1 that balances the desirability of near-term versus future rewards.
 Multiple methods for optimizing this expression are discussed in Chapter 6.
 
 ![Standard RL loop](images/rl.png){#fig:rl width=320px .center}
@@ -52,7 +53,7 @@ The thermostat example has the following components (see @fig:thermostat-equatio
 
 $$\pi(a_t = \text{on} \mid s_t) = \begin{cases} 1 & \text{if } s_t < 70^{\circ}\text{F} \\ 0 & \text{otherwise} \end{cases}$$ {#eq:thermostat_policy}
 
-- **Transition**: the room warms when the heater is on and cools when it is off -- this is the environment dynamics that the agent cannot control directly.
+- **Transition**: the room warms when the heater is on and cools when it is off. The agent influences these dynamics through its actions, but the underlying physics -- how fast the room heats or cools -- are outside its control.
 
 ![Each term in the trajectory distribution (@eq:rl_dynam) mapped to the thermostat RL example.](images/thermostat_equation.png){#fig:thermostat-equation .center}
 
@@ -110,7 +111,7 @@ Table: Key differences between standard RL and RLHF for language models. {#tbl:r
 :::
 
 Given the single-turn nature of the problem, the optimization can be re-written without the time horizon and discount factor (and with an explicit reward model):
-$$J(\pi) = \mathbb{E}_{\tau \sim \pi} \left[r_\theta(s_t, a_t) \right].$$ {#eq:rl_opt_int}
+$$\max_\pi \; \mathbb{E}_{\tau \sim \pi} \left[r_\theta(s_t, a_t) \right].$$ {#eq:rl_opt_int}
 
 In many ways, the result is that while RLHF is heavily inspired by RL optimizers and problem formulations, the actual implementation is very distinct from traditional RL.
 
@@ -124,7 +125,7 @@ In order to succeed in a fine-tuning regime, RLHF techniques employ multiple typ
 The goal is to allow the reward maximization to still occur without the model succumbing to over-optimization, as discussed in Chapter 14.
 The most common change to the optimization function is to add a distance penalty on the difference between the current RLHF policy and the starting point of the optimization:
 
-$$J(\pi) = \mathbb{E}_{\tau \sim \pi} \left[r_\theta(s_t, a_t)\right] - \beta  \mathcal{D}_{\text{KL}}(\pi(\cdot|s_t) \| \pi_{\text{ref}}(\cdot|s_t)).$$ {#eq:rlhf_opt_eq}
+$$\max_\pi \; \mathbb{E}_{\tau \sim \pi} \left[r_\theta(s_t, a_t)\right] - \beta  \mathcal{D}_{\text{KL}}(\pi(\cdot|s_t) \| \pi_{\text{ref}}(\cdot|s_t)).$$ {#eq:rlhf_opt_eq}
 
 Within this formulation, a lot of study into RLHF training goes into understanding how to spend a certain "KL budget" as measured by a distance from the initial model.
 For more details, see Chapter 15 on Regularization.

--- a/book/chapters/04-instruction-tuning.md
+++ b/book/chapters/04-instruction-tuning.md
@@ -27,7 +27,7 @@ Without a basic level of instruction-following abilities, most of the pipelines 
 
 ## Chat templates and the structure of instructions
 
-The beginning of the post-training process is defining a pattern to format user queries so that they are easily readable by a language model that processes information through a tokenizer.
+The post-training process begins with defining a pattern to format user queries so that they are easily readable by a language model that processes information through a tokenizer.
 When using a pretrained language model, the prompting is quite simple. The model only knows a few tokens: a beginning-of-sequence token (e.g., `<bos_token>`), an end-of-sequence token (e.g., `<eos_token>`), and a padding token (to manage training on batches with empty components).
 This means, to prompt a base model, the user inputs a sequence of tokens for the model to continue from, such as:
 
@@ -103,7 +103,7 @@ How many helicopters can a human eat in one sitting?<|im_end|>
 
 Notice how the final tokens in the sequence are `<|im_start|>assistant`. This is how the model knows to continue generating tokens until it finally generates its end-of-sequence token, which in this case is `<|im_end|>`.
 
-By packing all question-answer pair data (and downstream preference tuning data) into this format, modern language models follow it with perfect consistency. This is the language that instruction tuned models use to exchange information with users and the models stored on GPUs or other computing devices.
+By packing all question-answer pair data (and downstream preference tuning data) into this format, modern language models follow it with perfect consistency. This is the language that instruction tuned models use to exchange information with users and the models running on GPUs or other computing devices.
 
 The behavior can be extended naively to multiple turns, such as shown below:
 
@@ -119,7 +119,7 @@ Are you sure about that?<|im_end|>
 <|im_start|>assistant
 ```
 
-In the open ecosystem, the standard method for applying the chat template to a list of messages is a piece of Jinja code saved in the tokenizer, as `apply_chat_template`.
+In the open ecosystem, the standard method for applying the chat template to a list of messages uses a Jinja snippet -- a lightweight Python templating language -- stored in the tokenizer configuration, as `apply_chat_template`.
 
 The above chat template is a derivative of OpenAI's Chat Markup Language (ChatML), which was an early attempt to standardize message formatting.
 Now, OpenAI and other model providers use a hierarchical system where the user can configure a system message, yet there are higher-level instructions that may or may not be revealed to the user [@wallace2024instruction].
@@ -172,3 +172,4 @@ Many practices, such as deciding on the types of parallelism used to shard model
 - **Prompt masking**: When pretraining, every token in the batch is predicted autoregressively and the loss is then applied to them. For instruction tuning, the prompt tokens are masked out so the model isn't learning to accurately predict user queries -- just responses. The same applies for other post-training algorithms.
 - **Multi-turn masking**: For multi-turn conversations, there are two common masking choices. (1) *Final-turn only*: only the tokens in the final assistant turn are included in the loss, while all earlier context (including earlier assistant turns) is masked. Long conversations can still be "unrolled" into multiple training samples: for a conversation of $N$ turns, each example predicts one assistant response while masking all prior context and excluding any future turns. (2) *Mask user turns only*: all user turns are masked, but *every* assistant turn is included in the loss. You can still unroll in this setting if you want more (shorter) training examples, but the key difference is that intermediate assistant replies are trained on directly.
 - **Same loss function as pretraining:** Instruction tuning uses the same autoregressive loss function used in pretraining language models, but with substantially different data and masking (training only on full sequences, whereas pretraining documents can be split across batches), etc.
+- **Learning rate:** SFT typically uses a learning rate one to two orders of magnitude smaller than pretraining to best manage the different optimization dynamics (smaller datasets, smaller batches, and a strong pretrained initialization all favor more conservative updates). For example, OLMo 2 uses a peak learning rate of $3 \times 10^{-4}$ for pretraining but $1 \times 10^{-5}$ for SFT [@olmo20242]. OLMo 3 uses a higher SFT learning rate of $5\text{--}8 \times 10^{-5}$ [@teamolmo2025olmo3], in part because its training infrastructure uses sequence packing, which fits multiple examples into each training sequence and increases the effective batch size measured in useful tokens. Larger batches produce lower-variance gradient estimates, which in turn supports a higher learning rate without destabilizing training -- a relationship known as the linear scaling rule. The learning rate is commonly warmed up over a small fraction of training steps before decaying linearly. In practice, teams often sweep over multiple learning rates and select the best checkpoint on a held-out evaluation suite [@teamolmo2025olmo3].


### PR DESCRIPTION
## Summary
Ports the substantive edits (not below/above wording tweaks) from [rlhf-book-manning#52](https://github.com/natolambert/rlhf-book-manning/pull/52) into the web book.

**Ch03 (Training Overview):**
- Add max_pi operator to all three optimization equations -- these were missing the explicit optimization and read as definitions rather than objectives
- Introduce J(pi) / J* notation after the first equation
- Move gamma definition before its first use in the equation
- Clarify thermostat transition bullet (physics are outside agent control)

**Ch04 (Instruction Tuning):**
- Grammar: "The beginning of the post-training process is defining" to "The post-training process begins with defining"
- "stored on GPUs" to "running on GPUs"
- "a piece of Jinja code saved in the tokenizer" to "a Jinja snippet -- a lightweight Python templating language -- stored in the tokenizer configuration"
- New **Learning rate** bullet in Implementation section covering SFT vs pretraining LR differences with OLMo 2/3 examples

## Test plan
- [ ] Verify equations render correctly with max_pi prefix
- [ ] Check new learning rate bullet renders with citations

🤖 Generated with [Claude Code](https://claude.com/claude-code)