### PR TITLE
Update PPO regularization explanation in policy gradients

### DIFF
--- a/book/chapters/06-policy-gradients.md
+++ b/book/chapters/06-policy-gradients.md
@@ -1194,7 +1194,7 @@ In this view, a large part of the difference between algorithms like PPO (which 
 In PPO, the objective that handles capping the step-size of the update is known as the [surrogate objective](https://huggingface.co/blog/deep-rl-ppo#introducing-the-clipped-surrogate-objective). 
 To monitor how much the PPO regularization is impacting updates in RLHF, one can look at the clip fraction variable in many popular implementations, which is the percentage of samples in the batch whose probability ratio falls outside the trust region. For these samples, the surrogate objective becomes flat with respect to the ratio, meaning their gradient contribution drops to zero.
 
-In practice with language models, algorithms like PPO and GRPO are often run with only one gradient step per batch, which means that the PPO-native regularization is never applied (as clipping can only occur within a batch when the policy changes substantially) and the KL distances penalties predominate.
+In practice with language models, algorithms like PPO and GRPO are often run with only one gradient step per batch, which means that the PPO-native regularization is never applied (as clipping can only occur within a batch when the policy changes substantially) and the KL distances penalties predominate. However, this is not universal -- for example, DAPO [@yu2025dapo] uses 16 gradient steps per generation, and Tulu 3 [@lambert2024t] uses 4 PPO update iterations per batch for 8B and 70B models but reduces to 1 for 405B to maintain training stability.
 
 ### Further Reading
 


### PR DESCRIPTION
Hi Nathan,

first of all thank you sooo much for this amazing book! Love the content, but also that you made it available as epub so I can read it on a kindle while commuting.

Today I found two small errors at the very end of the policy gradient chapter, which I think you want to be fixed:

1) Just like you explain on the prior pages, the surrogate objective in PPO does not clip the gradients, but the ratio, which results in zero gradients
2) "In practice with language models, algorithms like PPO and GRPO are run with only one gradient step per batch...". This did not align with my experience e.g. DAPO and CISPO explicitly mention to use 16 gradient steps per generation. I checked, and the original GRPO does in fact only use one update step, but I dont think that is common (please correct me if you disagree). And it contradicts the prior explanations, e.g., line 289 in this chapter (https://github.com/natolambert/rlhf-book/blob/d5f403cec70d325b6f31a6eb714d337eb2e01b73/book/chapters/06-policy-gradients.md?plain=1#L289).

Thanks again for this amazing resource and for welcoming community feedback so openly :)