### PR TITLE
Update equation explanation for clarity

### DIFF
--- a/book/chapters/08-direct-alignment.md
+++ b/book/chapters/08-direct-alignment.md
@@ -108,7 +108,7 @@ Next, pull the negative sign out of the difference in brackets. To do this, spli
 
 $$ = \max_{\pi}\left(\mathbb{E}_{x \sim \mathcal{D}}\mathbb{E}_{y \sim \pi(y|x)}[r(x,y)] - \beta\,\mathbb{E}_{x \sim \mathcal{D}}\mathbb{E}_{y \sim \pi(y|x)}\left[\log\frac{\pi(y|x)}{\pi_{\text{ref}}(y|x)}\right]\right) $$ {#eq:dpo_deriv_2}
 
-Then, remove the factor of $-1$ and $\beta$,
+Then, remove the factor of $-1$ (convert the maximization into a minimization),
 
 $$ = \min_{\pi}\left(-\mathbb{E}_{x \sim \mathcal{D}}\mathbb{E}_{y \sim \pi(y|x)}[r(x,y)] + \beta\,\mathbb{E}_{x \sim \mathcal{D}}\mathbb{E}_{y \sim \pi(y|x)}\left[\log\frac{\pi(y|x)}{\pi_{\mathrm{ref}}(y|x)}\right]\right) $$ {#eq:dpo_deriv_3}
 


### PR DESCRIPTION
In the derivation of the DPO objective, there is a small mismatch between the description and the following equation.

The description says that we "remove -1 and \beta", but in that step only the -1 is removed. We divide by beta in the next step.

I also added a short note that we get rid of the -1 by turning the max into a min, which probably is clear to most readers but might be helpful to some.