### PR TITLE
Tune preference RM defaults

### DIFF
--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -1,3 +1,5 @@
 # Changelog
 
+- 2026-04-06: [PR #337](https://github.com/natolambert/rlhf-book/pull/337) tuned preference RM default hyperparameters (lr 1e-6 → 5e-5, effective batch 8 → 32) via Bayesian sweep on 5K samples. Full 60K run trains to epoch_loss=0.4 (random chance ~0.693). [Sweep 1](https://wandb.ai/singh-adityak1-independent/rlhf-book/sweeps/ml8d95f2), [Sweep 2](https://wandb.ai/singh-adityak1-independent/rlhf-book/sweeps/cfmnk2xg), [Full run](https://wandb.ai/singh-adityak1-independent/rlhf-book/runs/rsmqd9lr).
+
 - 2026-02-07: [PR #243](https://github.com/natolambert/rlhf-book/pull/243) stabilized ORPO/SimPO by switching to average-logprob behavior and improved direct-alignment logging/sampling instrumentation. It also fixed grad-accum metric logging to report optimizer-step averages (instead of last micro-batch snapshots), aligned SimPO `gamma` semantics, and added small ORPO/SimPO sweep scripts.

--- a/code/reward_models/train_preference_rm.py
+++ b/code/reward_models/train_preference_rm.py
@@ -46,10 +46,10 @@ DEFAULT_MODEL_ID = "Qwen/Qwen3-0.6B-Base"
 DEFAULT_DATASET = "argilla/ultrafeedback-binarized-preferences-cleaned"
 DEFAULT_SAMPLES = 2000
 DEFAULT_BATCH_SIZE = 2
-DEFAULT_GRAD_ACCUM = 4
+DEFAULT_GRAD_ACCUM = 16
 DEFAULT_MAX_LENGTH = 512
 DEFAULT_EPOCHS = 1
-DEFAULT_LR = 1e-6  # Lower LR for full fine-tuning (vs 1e-5 for LoRA)
+DEFAULT_LR = 5e-5
 DEFAULT_SEED = 42
 
 


### PR DESCRIPTION
## Summary
Tune preference RM default hyperparameters: `lr` 1e-6 → 5e-5, `grad_accum` 4 → 16 (effective batch 32)

## Motivation
Default hyperparameters were untuned. Ran two Bayesian sweeps on 5K samples, ranked by epoch loss:
1. Wide sweep (LR 5e-7 to 5e-5, batch [4, 8, 16, 32]). Best sweep: LR=5e-5, batch size=16. Motivates exploring higher LR and batch size
2. Follow-up sweep (LR 5e-5 to 1e-4, batch [16, 32]). Best sweep: LR=5e-5, batch size=32

## Results
- Sweep 1: https://wandb.ai/singh-adityak1-independent/rlhf-book/sweeps/ml8d95f2
- Sweep 2: https://wandb.ai/singh-adityak1-independent/rlhf-book/sweeps/cfmnk2xg
- Full 60K run with tuned hyperparams: https://wandb.ai/singh-adityak1-independent/rlhf-book/runs/rsmqd9lr?nw=nwusersinghadityak1
- Full 60K run trains to epoch_loss=0.4 (random chance is -ln(0.5) ≈ 0.693)