### PR TITLE
Add note about speedrun PR in code README

### DIFF
--- a/code/README.md
+++ b/code/README.md
@@ -4,6 +4,8 @@ Educational code examples accompanying [RLHF Book](https://rlhfbook.com) by Nath
 
 I primarily run experiments on a [DGX Spark](https://www.nvidia.com/en-us/products/workstations/dgx-spark/). For setup advice, see my [dgx-spark-setup](https://github.com/natolambert/dgx-spark-setup) guide.
 
+*Note: There's an open PR [here](https://github.com/natolambert/rlhf-book/pull/328) exploring the idea of adding speedrun functionality to this repository — comment if you're interested in pushing this further or seeing it merged into main.*
+
 ## Attribution
 
 This code is built on the excellent work of community contributors:


### PR DESCRIPTION
## Summary
- Adds a note under the DGX Spark line in `code/README.md` pointing to #328 (speedrun functionality) and inviting community interest

## Test plan
- [ ] Verify the note renders correctly and the link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)