### PR TITLE
Make flash-attn optional to fix install on broader hardware

### DIFF
--- a/code/README.md
+++ b/code/README.md
@@ -54,9 +54,11 @@ uv sync --extra flash
 
 ### Platform notes
 
-- **Standard x86_64 systems**: Flash Attention provides significant speedups during training.
-  Pre-built wheels are available for CUDA 12.x ([full list](https://github.com/Dao-AILab/flash-attention/releases/tag/v2.8.3));
-  CUDA 13 requires a source build.
+- **Standard x86_64 systems**: Flash Attention provides a ~10-20% training speedup on
+  Ampere/Ada GPUs (e.g. 3090, 4090). Pre-built wheels are available for CUDA 12.x
+  ([releases](https://github.com/Dao-AILab/flash-attention/releases/latest));
+  as of 11 Apr. 2026 CUDA 13 requires a source build (which tends to be a pain),
+  so nothing is gated on it.
 - **DGX Spark / aarch64**: Flash Attention is not available on ARM64/Blackwell. The code
   automatically falls back to PyTorch SDPA, which is actually faster on these systems due
   to native cuDNN optimizations.

--- a/code/README.md
+++ b/code/README.md
@@ -52,6 +52,15 @@ uv sync --extra flash
 > non-standard setups), just use the base install — the code automatically falls back
 > to PyTorch SDPA, and all examples will work correctly without it.
 
+### Platform notes
+
+- **Standard x86_64 systems**: Flash Attention provides significant speedups during training.
+  Pre-built wheels are available for CUDA 12.x ([full list](https://github.com/Dao-AILab/flash-attention/releases/tag/v2.8.3));
+  CUDA 13 requires a source build.
+- **DGX Spark / aarch64**: Flash Attention is not available on ARM64/Blackwell. The code
+  automatically falls back to PyTorch SDPA, which is actually faster on these systems due
+  to native cuDNN optimizations.
+
 ## Policy Gradient Training
 
 Train various policy gradient algorithms on procedural reasoning tasks:

--- a/code/README.md
+++ b/code/README.md
@@ -47,10 +47,10 @@ to support a broad range of hardware, but for speedups you should consider insta
 uv sync --extra flash
 ```
 
-> **Note:** Flash Attention requires a source build, which needs a working CUDA toolkit
-> and can take several minutes. If the build fails (common with newer CUDA versions or
-> non-standard setups), just use the base install — the code automatically falls back
-> to PyTorch SDPA, and all examples will work correctly without it.
+> **Note:** If a pre-built wheel matches your CUDA version this installs in seconds.
+> If not (e.g. CUDA 13), it falls back to a source build which needs a CUDA toolkit
+> and can take several minutes. If the build fails, just use the base install — the
+> code automatically falls back to PyTorch SDPA and all examples will work without it.
 
 ### Platform notes
 

--- a/code/README.md
+++ b/code/README.md
@@ -33,27 +33,24 @@ demonstrating the concepts from Chapter 5 (Reward Models).
 
 ## Installation
 
-**Requires Python 3.12+**
+**Requires Python 3.12+** and [uv](https://docs.astral.sh/uv/getting-started/installation/).
 
 ```bash
 cd code/
 uv sync
 ```
 
-### Platform-specific notes
-
-**Standard x86_64 systems** (recommended): Flash Attention is installed by default for
-significant speedups during training.
-
-**DGX Spark / aarch64**: Flash Attention is not available on ARM64/Blackwell. The code
-automatically falls back to PyTorch SDPA, which is actually faster on these systems due
-to native cuDNN optimizations.
+By default, [Flash Attention](https://github.com/Dao-AILab/flash-attention) is turned off
+to support a broad range of hardware, but for speedups you should consider installing it:
 
 ```bash
-# On DGX Spark, just run:
-uv sync
-# Flash-attn will be skipped automatically on aarch64
+uv sync --extra flash
 ```
+
+> **Note:** Flash Attention requires a source build, which needs a working CUDA toolkit
+> and can take several minutes. If the build fails (common with newer CUDA versions or
+> non-standard setups), just use the base install — the code automatically falls back
+> to PyTorch SDPA, and all examples will work correctly without it.
 
 ## Policy Gradient Training
 

--- a/code/pyproject.toml
+++ b/code/pyproject.toml
@@ -21,15 +21,14 @@ dependencies = [
 
     # Policy gradients (procedural datasets)
     "reasoning-gym>=0.1.24",
-
-    # Flash attention - default for x86_64, provides major speedup
-    # Excluded on aarch64 (DGX Spark) where SDPA is used instead
-    "flash-attn>=2.5.0; platform_machine == 'x86_64'",
 ]
 
 [project.optional-dependencies]
-# For DGX Spark (aarch64 / Blackwell) - no flash-attn, uses PyTorch SDPA
-dgx-spark = []
+# Flash attention - optional speedup for x86_64 NVIDIA GPUs
+# The code automatically falls back to PyTorch SDPA if not installed
+flash = [
+    "flash-attn>=2.5.0; platform_machine == 'x86_64'",
+]
 
 # Development dependencies
 dev = [
@@ -53,6 +52,11 @@ include = ["policy_gradients*", "reward_models*", "direct_alignment*"]
 
 [tool.uv]
 package = true
+
+# flash-attn needs torch at build time but doesn't declare it
+# This injects the project's torch into flash-attn's build environment
+[tool.uv.extra-build-dependencies]
+flash-attn = [{ requirement = "torch", match-runtime = true }]
 
 # PyTorch CUDA wheels - only use cu121 on x86_64 Linux
 # aarch64 (DGX Spark) uses system PyTorch or cu130 wheels


### PR DESCRIPTION
## Summary

- Move `flash-attn` from a hard dependency to an optional extra (`uv sync --extra flash`), fixing install failures on systems where flash-attn can't be built (e.g. CUDA 13, missing nvcc)
- Add `[tool.uv.extra-build-dependencies]` config so `uv sync --extra flash` correctly injects torch into the build environment when users do opt in
- Update README install section with clearer instructions

Reported by technical editor Vahid M — `uv sync` was failing with `ModuleNotFoundError: No module named 'torch'` during the flash-attn build on an x86_64 system with CUDA 13.

All training code already has `try: import flash_attn` / `except ImportError: return "sdpa"` fallbacks, so this is a packaging-only change with no code behavior difference.

## Test plan

- [x] Clean `uv sync` on DGX Spark (aarch64, CUDA 13) — installs without flash-attn, all imports work
- [x] Verified `get_attn_implementation()` returns `"sdpa"` in both `policy_gradients` and `direct_alignment`
- [ ] Verify `uv sync --extra flash` works on x86_64 with CUDA 12.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)