### PR TITLE
Fix warmup step count in RM training

### DIFF
--- a/code/reward_models/train_orm.py
+++ b/code/reward_models/train_orm.py
@@ -276,7 +276,7 @@ def train_orm(
 
     # Optimizer and LR scheduler with linear warmup
     optimizer = create_optimizer(model, lr)
-    total_optimizer_steps = (len(loader) // grad_accum_steps) * epochs
+    total_optimizer_steps = -(-len(loader) // grad_accum_steps) * epochs
     warmup_steps = int(total_optimizer_steps * warmup_ratio)
     scheduler = torch.optim.lr_scheduler.LinearLR(
         optimizer, start_factor=0.1, total_iters=warmup_steps

--- a/code/reward_models/train_preference_rm.py
+++ b/code/reward_models/train_preference_rm.py
@@ -276,7 +276,7 @@ def train_preference_rm(
 
     # Optimizer and LR scheduler with linear warmup + linear decay
     optimizer = create_optimizer(model, lr)
-    total_optimizer_steps = (len(loader) // grad_accum_steps) * epochs
+    total_optimizer_steps = -(-len(loader) // grad_accum_steps) * epochs
     warmup_steps = int(total_optimizer_steps * warmup_ratio)
     scheduler = torch.optim.lr_scheduler.LinearLR(
         optimizer, start_factor=0.1, total_iters=warmup_steps

--- a/code/reward_models/train_prm.py
+++ b/code/reward_models/train_prm.py
@@ -364,7 +364,7 @@ def train_prm(
 
     # Optimizer and LR scheduler with linear warmup
     optimizer = create_optimizer(model, lr)
-    total_optimizer_steps = (len(loader) // grad_accum_steps) * epochs
+    total_optimizer_steps = -(-len(loader) // grad_accum_steps) * epochs
     warmup_steps = int(total_optimizer_steps * warmup_ratio)
     scheduler = torch.optim.lr_scheduler.LinearLR(
         optimizer, start_factor=0.1, total_iters=warmup_steps


### PR DESCRIPTION
## Summary
- Use ceiling division (`-(-x // y)`) instead of floor division for `total_optimizer_steps` in all 3 RM training scripts
- The training loop performs an optimizer step on the trailing partial accumulation window, but the warmup scheduler was computed with floor division — undercounting by up to 1 step per epoch

Follow-up to #352 based on Codex review feedback.

## Test plan
- [ ] Re-run preference RM, ORM, PRM training and verify warmup behaves correctly
- [ ] Confirm no regression in training curves

🤖 Generated with [Claude Code](https://claude.com/claude-code)