### PR TITLE
Require CHANGELOG update for code/ PRs

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,26 @@
+name: Changelog Check
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "code/**"
+
+jobs:
+  check-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for CHANGELOG.md update
+        run: |
+          CHANGED=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files --paginate --jq '.[].filename')
+          if echo "$CHANGED" | grep -q '^code/CHANGELOG.md$'; then
+            echo "CHANGELOG.md updated"
+          else
+            echo "::error::PRs that modify code/ must also update code/CHANGELOG.md"
+            echo ""
+            echo "Please add a one-line entry to code/CHANGELOG.md under the Unreleased section."
+            echo "Format: - YYYY-MM-DD: [PR #N](url) description of changes."
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+PRs that modify `code/` must add a one-line entry here under the current development section.
+On release, entries get moved under a version heading.
+
+## Unreleased
+
 - 2026-04-12: [PR #350](https://github.com/natolambert/rlhf-book/pull/350) added the Chapter 9 rejection-sampling module, including matched random baselines and canonical DGX Spark reference runs.
 - 2026-04-11: [PR #352](https://github.com/natolambert/rlhf-book/pull/352) fixed RM training logging to report per-optimizer-step metrics instead of per-micro-batch, updated preference RM defaults (lr 1e-6→5e-5, samples 2K→5K, effective batch 8→32, added 10% LR warmup), and added `drop_last=True` to all RM DataLoaders. New reference runs reflect these changes — prior wandb links are no longer comparable.
 - 2026-02-07: [PR #243](https://github.com/natolambert/rlhf-book/pull/243) stabilized ORPO/SimPO by switching to average-logprob behavior and improved direct-alignment logging/sampling instrumentation. It also fixed grad-accum metric logging to report optimizer-step averages (instead of last micro-batch snapshots), aligned SimPO `gamma` semantics, and added small ORPO/SimPO sweep scripts.
+
+## v0.1.0
+
+Initial release: policy gradient methods (REINFORCE, PPO, GRPO, RLOO, Dr. GRPO, GSPO, CISPO), reward models (preference RM, ORM, PRM), and direct alignment (DPO, IPO, SimPO, ORPO, KTO).

--- a/code/CLAUDE.md
+++ b/code/CLAUDE.md
@@ -10,10 +10,12 @@
 
 ## Changelog Process
 
-- Keep `CHANGELOG.md` minimal and release-oriented.
-- Use exactly **one bullet per PR**.
+- **CI enforces this**: a GitHub Actions check fails PRs that touch `code/` without modifying `code/CHANGELOG.md`.
+- Add entries under the `## Unreleased` section at the top of `CHANGELOG.md`.
+- Use exactly **one bullet per PR**, format: `- YYYY-MM-DD: [PR #N](url) description`.
 - Each bullet must include a PR link and can contain multiple sentences summarizing meaningful changes.
 - When changes affect comparability (metrics, logging semantics, evaluation logic), mention that directly in the same bullet.
+- **On release**: rename `## Unreleased` to `## vX.Y.Z` and add a fresh `## Unreleased` section above it.
 
 ## Experiment Organization
 


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that fails PRs touching `code/` unless `code/CHANGELOG.md` is also modified
- Restructures CHANGELOG.md with **Unreleased** section (where new entries go) and versioned sections below (bumped on release)

## How it works
- The workflow only triggers on PRs that modify files under `code/`
- It checks the PR's changed files via the GitHub API
- If `code/CHANGELOG.md` isn't in the diff, the check fails with a message explaining the format

## Test plan
- [ ] Verify the check passes on this PR (it modifies `code/CHANGELOG.md`)
- [ ] Verify future code-only PRs without changelog entries get a failing check

🤖 Generated with [Claude Code](https://claude.com/claude-code)