### PR TITLE
Only run Cloudflare deploy for book/teach changes

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -3,8 +3,18 @@ name: Build and Deploy to Cloudflare Pages
 on:
   push:
     branches: ["main"]
+    paths:
+      - "book/**"
+      - "teach/**"
+      - "Makefile"
+      - ".github/workflows/static.yml"
   pull_request:
     branches: ["main"]
+    paths:
+      - "book/**"
+      - "teach/**"
+      - "Makefile"
+      - ".github/workflows/static.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -7,6 +7,8 @@ on:
       - "book/**"
       - "teach/**"
       - "Makefile"
+      - "pyproject.toml"
+      - "uv.lock"
       - ".github/workflows/static.yml"
   pull_request:
     branches: ["main"]
@@ -14,6 +16,8 @@ on:
       - "book/**"
       - "teach/**"
       - "Makefile"
+      - "pyproject.toml"
+      - "uv.lock"
       - ".github/workflows/static.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Adds path filters to the Cloudflare Pages deploy workflow so it only triggers when `book/`, `teach/`, `Makefile`, or the workflow itself changes
- Code-only PRs (e.g. `code/`) skip the ~5min build+deploy entirely
- `workflow_dispatch` still allows manual triggers when needed

## Test plan
- [ ] This PR itself should NOT trigger the deploy (only touches `.github/`)... wait, it does match the workflow path filter. So it will run once to validate.
- [ ] Future code-only PRs should show the workflow as skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)