### PR TITLE
Add code link for rejection sampling in nav

### DIFF
--- a/book/templates/nav.js
+++ b/book/templates/nav.js
@@ -48,7 +48,7 @@ class NavigationDropdown extends HTMLElement {
           <li><a href="https://rlhfbook.com/c/06-policy-gradients">Reinforcement Learning</a> [<a href="https://github.com/natolambert/rlhf-book/tree/main/code/policy_gradients">code</a>]</li>
           <li><a href="https://rlhfbook.com/c/07-reasoning">Reasoning</a></li>
           <li><a href="https://rlhfbook.com/c/08-direct-alignment">Direct Alignment</a> [<a href="https://github.com/natolambert/rlhf-book/tree/main/code/direct_alignment">code</a>]</li>
-          <li><a href="https://rlhfbook.com/c/09-rejection-sampling">Rejection Sampling</a></li>
+          <li><a href="https://rlhfbook.com/c/09-rejection-sampling">Rejection Sampling</a> [<a href="https://github.com/natolambert/rlhf-book/tree/main/code/rejection_sampling">code</a>]</li>
         </ol>
       </div>
 


### PR DESCRIPTION
## Summary
- Add `[code]` link for Chapter 9 (Rejection Sampling) in the navigation dropdown, pointing to `code/rejection_sampling`

## Test plan
- [x] Verify the nav dropdown shows the code link next to Rejection Sampling
- [x] Verify the link resolves to the correct GitHub directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<img width="800" height="505" alt="image" src="https://github.com/user-attachments/assets/b42c3dcd-9cf3-477d-a899-6c1ecbeefae6" />
