### PR TITLE
code: add overview figures to module READMEs

### DIFF
--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,6 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
+- 2026-04-12: [PR #362](https://github.com/natolambert/rlhf-book/pull/362) added overview figures from the book to the policy_gradients, reward_models, and rejection_sampling module READMEs.
 - 2026-04-12: [PR #350](https://github.com/natolambert/rlhf-book/pull/350) added the Chapter 9 rejection-sampling module, including matched random baselines and canonical DGX Spark reference runs.
 - 2026-04-11: [PR #352](https://github.com/natolambert/rlhf-book/pull/352) fixed RM training logging to report per-optimizer-step metrics instead of per-micro-batch, updated preference RM defaults (lr 1e-6→5e-5, samples 2K→5K, effective batch 8→32, added 10% LR warmup), and added `drop_last=True` to all RM DataLoaders. New reference runs reflect these changes — prior wandb links are no longer comparable.
 - 2026-02-07: [PR #243](https://github.com/natolambert/rlhf-book/pull/243) stabilized ORPO/SimPO by switching to average-logprob behavior and improved direct-alignment logging/sampling instrumentation. It also fixed grad-accum metric logging to report optimizer-step averages (instead of last micro-batch snapshots), aligned SimPO `gamma` semantics, and added small ORPO/SimPO sweep scripts.

--- a/code/policy_gradients/README.md
+++ b/code/policy_gradients/README.md
@@ -1,5 +1,7 @@
 # Policy Gradient Methods
 
+![Overview of the RLHF training loop.](../../book/images/rlhf-overview.png)
+
 Educational implementations of policy gradient algorithms for [RLHF Book](https://rlhfbook.com).
 See **Chapter 6: Policy Gradient Methods** for mathematical derivations and intuitions.
 See the parent [`code/README.md`](../README.md) for installation, configuration, and memory requirements.

--- a/code/rejection_sampling/README.md
+++ b/code/rejection_sampling/README.md
@@ -1,5 +1,7 @@
 # Rejection Sampling
 
+![Rejection sampling overview.](../../book/images/rejection-sampling.png)
+
 Educational implementation of rejection sampling (RS) for RLHF, accompanying
 Chapter 9 of [the RLHF Book](https://rlhfbook.com). See the parent
 [`code/README.md`](../README.md) for installation, configuration, and memory

--- a/code/reward_models/README.md
+++ b/code/reward_models/README.md
@@ -1,5 +1,7 @@
 # Reward Model Training
 
+![Overview of the RLHF training loop.](../../book/images/rlhf-overview.png)
+
 Educational implementations of reward model training for [RLHF Book](https://rlhfbook.com).
 See **Chapter 5: Reward Models** for mathematical derivations and intuitions.
 


### PR DESCRIPTION
## Summary

- Add book diagrams as visual overviews at the top of the `policy_gradients`, `reward_models`, and `rejection_sampling` module READMEs
- The RLHF training loop diagram (`book/images/rlhf-overview.png`) is added to policy gradients and reward models, and the rejection sampling overview (`book/images/rejection-sampling.png`) to rejection sampling
- Images are referenced via relative paths from the existing book assets — no files are copied or duplicated

## Test plan

- [ ] Verify images render correctly on the GitHub PR diff preview
- [x] Confirm relative paths resolve when viewing each module README on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)