### PR TITLE
Bump code to v0.2.0

### DIFF
--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,11 +5,16 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
-- 2026-04-12: [PR #349](https://github.com/natolambert/rlhf-book/pull/349) added the SAPO (Soft Adaptive Policy Optimization, Gao et al., 2025) loss to the policy gradient module/folder.
+## v0.2.0
+
 - 2026-04-12: [PR #362](https://github.com/natolambert/rlhf-book/pull/362) added overview figures from the book to the policy_gradients, reward_models, and rejection_sampling module READMEs.
+- 2026-04-12: [PR #354](https://github.com/natolambert/rlhf-book/pull/354) fixed warmup step count in RM training to use ceiling division, so trailing partial accumulation windows are counted correctly.
+- 2026-04-12: [PR #349](https://github.com/natolambert/rlhf-book/pull/349) added SAPO (Soft Adaptive Policy Optimization, Gao et al., 2025) loss to the policy gradient module.
 - 2026-04-12: [PR #350](https://github.com/natolambert/rlhf-book/pull/350) added the Chapter 9 rejection-sampling module, including matched random baselines and canonical DGX Spark reference runs.
+- 2026-04-11: [PR #353](https://github.com/natolambert/rlhf-book/pull/353) added paper links to the policy gradient algorithms table in the README.
 - 2026-04-11: [PR #352](https://github.com/natolambert/rlhf-book/pull/352) fixed RM training logging to report per-optimizer-step metrics instead of per-micro-batch, updated preference RM defaults (lr 1e-6→5e-5, samples 2K→5K, effective batch 8→32, added 10% LR warmup), and added `drop_last=True` to all RM DataLoaders. New reference runs reflect these changes — prior wandb links are no longer comparable.
-- 2026-02-07: [PR #243](https://github.com/natolambert/rlhf-book/pull/243) stabilized ORPO/SimPO by switching to average-logprob behavior and improved direct-alignment logging/sampling instrumentation. It also fixed grad-accum metric logging to report optimizer-step averages (instead of last micro-batch snapshots), aligned SimPO `gamma` semantics, and added small ORPO/SimPO sweep scripts.
+- 2026-04-11: [PR #351](https://github.com/natolambert/rlhf-book/pull/351) made flash-attn optional so the library installs on broader hardware (ARM64, systems without CUDA).
+- 2026-02-07: [PR #243](https://github.com/natolambert/rlhf-book/pull/243) stabilized ORPO/SimPO by switching to average-logprob behavior and improved direct-alignment logging/sampling instrumentation.
 
 ## v0.1.0
 

--- a/code/pyproject.toml
+++ b/code/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rlhf-book-code"
-version = "0.1.0"
+version = "0.2.0"
 description = "Educational code examples for RLHF Book (https://rlhfbook.com)"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
Bumps `code/` to v0.2.0 and restructures the changelog for release.

### What's new since v0.1
- **Rejection sampling module** (Chapter 9) with matched random baselines (#350)
- **SAPO algorithm** in policy gradients (#349)
- **RM training overhaul** — per-step logging, updated defaults, warmup, mixed precision, drop_last (#352, #354)
- **flash-attn now optional** — installs on ARM64/non-CUDA systems (#351)
- **Module README figures** from the book (#362)
- **ORPO/SimPO stabilization** (#243)
- **Paper links** in PG README (#353)

### Changes in this PR
- `code/pyproject.toml`: version 0.1.0 -> 0.2.0
- `code/CHANGELOG.md`: moved entries under v0.2.0 heading, added missing PR entries, fresh Unreleased section

After merge, will tag `code/v0.2` and create the GitHub release.

## Test plan
- [ ] Verify changelog looks correct
- [ ] After merge: create release with `gh release create code/v0.2`

Generated with [Claude Code](https://claude.com/claude-code)