### PR TITLE
[code] improvement to PPO hyperparameters

### DIFF
--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,7 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
-- 2026-04-12: [PR #TODO @casinca after PR](https://github.com/natolambert/rlhf-book/pull/TODO) retuned PPO
+- 2026-04-12: [PR #364](https://github.com/natolambert/rlhf-book/pull/364) retuned PPO
   hyperparameters for smoother training.
 - 2026-04-12: [PR #350](https://github.com/natolambert/rlhf-book/pull/350) added the Chapter 9 rejection-sampling module, including matched random baselines and canonical DGX Spark reference runs.
 - 2026-04-11: [PR #352](https://github.com/natolambert/rlhf-book/pull/352) fixed RM training logging to report per-optimizer-step metrics instead of per-micro-batch, updated preference RM defaults (lr 1e-6→5e-5, samples 2K→5K, effective batch 8→32, added 10% LR warmup), and added `drop_last=True` to all RM DataLoaders. New reference runs reflect these changes — prior wandb links are no longer comparable.

--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,6 +5,8 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
+- 2026-04-12: [PR #TODO @casinca after PR](https://github.com/natolambert/rlhf-book/pull/TODO) retuned PPO
+  hyperparameters for smoother training.
 - 2026-04-12: [PR #350](https://github.com/natolambert/rlhf-book/pull/350) added the Chapter 9 rejection-sampling module, including matched random baselines and canonical DGX Spark reference runs.
 - 2026-04-11: [PR #352](https://github.com/natolambert/rlhf-book/pull/352) fixed RM training logging to report per-optimizer-step metrics instead of per-micro-batch, updated preference RM defaults (lr 1e-6→5e-5, samples 2K→5K, effective batch 8→32, added 10% LR warmup), and added `drop_last=True` to all RM DataLoaders. New reference runs reflect these changes — prior wandb links are no longer comparable.
 - 2026-02-07: [PR #243](https://github.com/natolambert/rlhf-book/pull/243) stabilized ORPO/SimPO by switching to average-logprob behavior and improved direct-alignment logging/sampling instrumentation. It also fixed grad-accum metric logging to report optimizer-step averages (instead of last micro-batch snapshots), aligned SimPO `gamma` semantics, and added small ORPO/SimPO sweep scripts.

--- a/code/policy_gradients/configs/ppo.yaml
+++ b/code/policy_gradients/configs/ppo.yaml
@@ -11,10 +11,10 @@ loss: ppo
 model_name: Qwen/Qwen3-1.7B
 clip_eps_lo: 0.2
 clip_eps_hi: 0.2
-clip_eps_val: 0.2  # PPO-specific: value function clipping
-gamma: 0.99        # PPO-specific: discount factor
-lam: 0.95          # PPO-specific: GAE lambda
-vf_coef: 0.1       # PPO-specific: value loss coefficient
+clip_eps_val: 0.4  # PPO-specific: value function clipping
+gamma: 1.0         # PPO-specific: discount factor
+lam: 0.98          # PPO-specific: GAE lambda
+vf_coef: 0.5       # PPO-specific: value loss coefficient
 lr: 5e-6
 temperature: 0.6
 top_p: 0.95


### PR DESCRIPTION
Updated PPO hparams for the `TODO: Tune PPO hyperparameters for cleaner training curves (currently experimental)`

Only the discount factor was my own call. It felt off, imho, discounting the rewards (*except if we'd want to pressure
for shorter trajectories. It was probably inherited from classic RL envs, where it makes more sense.*)

I asked Opus to check some major frameworks as a sanity check to confirm, no discounting by default for LLM envs.

| Framework | gamma | Source |
|-----------|-------|--------|
| **TRL** | `1.0` | [ppo_config.py:222-228](https://github.com/huggingface/trl/blob/5abe9cd6571d737e700d8660fb800ee91c03a3ce/trl/experimental/ppo/ppo_config.py#L265-L268) |
| **Verl** | `1.0` | [algorithm.py:350-351](https://github.com/verl-project/verl/blob/516657fa39595dd557ba34b98ae58d25d0f44e66/verl/trainer/config/algorithm.py#L651) |
| **OpenRLHF** | `1` | [train_ppo_ray.py:379-380](https://github.com/OpenRLHF/OpenRLHF/blob/48406a0b8a6da6199c8ad00c11a74685f0b7e6ad/openrlhf/cli/train_ppo_ray.py#L387) |
| **DeepSpeed-Chat** | `1.0` | [ppo_trainer.py:48-49](https://github.com/deepspeedai/DeepSpeedExamples/blob/45b4b7156c8794a3452a5a7d03dbd8d797068569/applications/DeepSpeed-Chat/dschat/rlhf/ppo_trainer.py#L70) |

&nbsp;

The rest of the hparams (`clip_eps_val`, `lam`, `vf_coef`) were not chosen by me. I asked to take
the ~average of the default values, from the above RL frameworks, that it thought could be improved.

While there's always room for improvement, I believe this should be better (new, bottom) than the current PPO hparams (your run, top). Although it still need to be validated/run on your side to confirm. Hope this'll be decent.

960 steps (3hrs on an A100)
<img width="1827" height="956" alt="image" src="https://github.com/user-attachments/assets/d0d3fde2-d4a9-4e1a-adbe-79e8723c23c9" />
