### PR TITLE
Replace YouTube links with playlist URLs

### DIFF
--- a/book/chapters/01-introduction.md
+++ b/book/chapters/01-introduction.md
@@ -12,7 +12,7 @@ search-title: "Chapter 1: Introduction"
 next-chapter: "Key Related Works"
 next-url: "02-related-works"
 lectures:
-  - video: "https://youtu.be/o6l6tJQgUg4"
+  - video: "https://www.youtube.com/watch?v=o6l6tJQgUg4&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=2"
     label: "Lecture 1: Overview (Chapters 1–3)"
 ---
 

--- a/book/chapters/02-related-works.md
+++ b/book/chapters/02-related-works.md
@@ -12,7 +12,7 @@ search-title: "Chapter 2: Key Related Works"
 next-chapter: "Training Overview"
 next-url: "03-training-overview"
 lectures:
-  - video: "https://youtu.be/o6l6tJQgUg4"
+  - video: "https://www.youtube.com/watch?v=o6l6tJQgUg4&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=2"
     label: "Lecture 1: Overview (Chapters 1–3)"
 ---
 

--- a/book/chapters/03-training-overview.md
+++ b/book/chapters/03-training-overview.md
@@ -12,7 +12,7 @@ search-title: "Chapter 3: Training Overview"
 next-chapter: "Instruction Tuning"
 next-url: "04-instruction-tuning"
 lectures:
-  - video: "https://youtu.be/o6l6tJQgUg4"
+  - video: "https://www.youtube.com/watch?v=o6l6tJQgUg4&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=2"
     label: "Lecture 1: Overview (Chapters 1–3)"
 ---
 

--- a/book/chapters/04-instruction-tuning.md
+++ b/book/chapters/04-instruction-tuning.md
@@ -12,7 +12,7 @@ search-title: "Chapter 4: Instruction Tuning"
 next-chapter: "Reward Models"
 next-url: "05-reward-models"
 lectures:
-  - video: "https://youtu.be/4gIwiSPmQkU"
+  - video: "https://www.youtube.com/watch?v=4gIwiSPmQkU&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=3"
     label: "Lecture 2: IFT, Reward Modeling, Rejection Sampling (Chap. 4, 5, & 9)"
 ---
 

--- a/book/chapters/05-reward-models.md
+++ b/book/chapters/05-reward-models.md
@@ -12,7 +12,7 @@ search-title: "Chapter 5: Reward Models"
 next-chapter: "Reinforcement Learning"
 next-url: "06-policy-gradients"
 lectures:
-  - video: "https://youtu.be/4gIwiSPmQkU"
+  - video: "https://www.youtube.com/watch?v=4gIwiSPmQkU&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=3"
     label: "Lecture 2: IFT, Reward Modeling, Rejection Sampling (Chap. 4, 5, & 9)"
 ---
 

--- a/book/chapters/06-policy-gradients.md
+++ b/book/chapters/06-policy-gradients.md
@@ -12,9 +12,9 @@ search-title: "Chapter 6: Reinforcement Learning"
 next-chapter: "Reasoning"
 next-url: "07-reasoning"
 lectures:
-  - video: "https://youtu.be/K_Sj_-1BUMM"
+  - video: "https://www.youtube.com/watch?v=K_Sj_-1BUMM&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=4"
     label: "Lecture 3: Understanding Policy Gradient Algorithms for RL on LLMs"
-  - video: "https://youtu.be/i-AIMpZHgeg"
+  - video: "https://www.youtube.com/watch?v=i-AIMpZHgeg&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=5"
     label: "Lecture 4: Implementing RL Algorithms for LLMs"
 ---
 

--- a/book/chapters/09-rejection-sampling.md
+++ b/book/chapters/09-rejection-sampling.md
@@ -12,7 +12,7 @@ search-title: "Chapter 9: Rejection Sampling"
 next-chapter: "What are Preferences"
 next-url: "10-preferences"
 lectures:
-  - video: "https://youtu.be/4gIwiSPmQkU"
+  - video: "https://www.youtube.com/watch?v=4gIwiSPmQkU&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=3"
     label: "Lecture 2: IFT, Reward Modeling, Rejection Sampling (Chap. 4, 5, & 9)"
 ---
 

--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -279,7 +279,7 @@
       <p class="meta">Introduction and overview of what you'll learn</p>
     </div>
     <div class="talk-actions">
-      <a href="https://youtu.be/jQPiH-KB4B0" class="btn btn-watch" target="_blank">
+      <a href="https://www.youtube.com/watch?v=jQPiH-KB4B0&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y" class="btn btn-watch" target="_blank">
         <svg width="14" height="14"><use href="#icon-watch"/></svg>
         Watch
       </a>
@@ -310,7 +310,7 @@
           <p class="meta">Chapters 1-3 &middot; Foundations of RLHF and post-training</p>
         </div>
         <div class="talk-actions">
-          <a href="https://youtu.be/o6l6tJQgUg4" class="btn btn-watch" target="_blank"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
+          <a href="https://www.youtube.com/watch?v=o6l6tJQgUg4&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=2" class="btn btn-watch" target="_blank"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
           <a href="/teach/course/lec1-chap1-3/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
           <a href="/teach/course/lec1-chap1-3/" class="btn" target="_blank"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
           <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec1-chap1-3.md?plain=1" class="btn btn-source" target="_blank"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
@@ -322,7 +322,7 @@
           <p class="meta">Chapters 4, 5, 9 &middot; Beginning the core optimization methods section</p>
         </div>
         <div class="talk-actions">
-          <a href="https://youtu.be/4gIwiSPmQkU" class="btn btn-watch" target="_blank"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
+          <a href="https://www.youtube.com/watch?v=4gIwiSPmQkU&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=3" class="btn btn-watch" target="_blank"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
           <a href="/teach/course/lec2-chap4-5-9/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
           <a href="/teach/course/lec2-chap4-5-9/" class="btn" target="_blank"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
           <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec2-chap4-5-9.md?plain=1" class="btn btn-source" target="_blank"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
@@ -334,7 +334,7 @@
           <p class="meta">Chapter 6, Part 1 &middot; Policy gradients math, intuitions, and theory</p>
         </div>
         <div class="talk-actions">
-          <a href="https://youtu.be/K_Sj_-1BUMM" class="btn btn-watch" target="_blank"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
+          <a href="https://www.youtube.com/watch?v=K_Sj_-1BUMM&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=4" class="btn btn-watch" target="_blank"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
           <a href="/teach/course/lec3-chap6-p1/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
           <a href="/teach/course/lec3-chap6-p1/" class="btn" target="_blank"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
           <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec3-chap6-p1.md?plain=1" class="btn btn-source" target="_blank"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
@@ -346,7 +346,7 @@
           <p class="meta">Chapter 6, Part 2 &middot; Code, loss aggregation, async training, and practical engineering</p>
         </div>
         <div class="talk-actions">
-          <a href="https://youtu.be/i-AIMpZHgeg" class="btn btn-watch" target="_blank"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
+          <a href="https://www.youtube.com/watch?v=i-AIMpZHgeg&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=5" class="btn btn-watch" target="_blank"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
           <a href="/teach/course/lec4-chap6-p2/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
           <a href="/teach/course/lec4-chap6-p2/" class="btn" target="_blank"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
           <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec4-chap6-p2.md?plain=1" class="btn btn-source" target="_blank"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>

--- a/book/templates/html.html
+++ b/book/templates/html.html
@@ -121,7 +121,7 @@ $endif$
       <h3 style="margin: 0 0 0.15em 0; font-size: 1.05em;">Welcome to the Course</h3>
       <p style="font-size: 0.88em; color: #666; margin: 0;">Video introduction and overview of the RLHF Book</p>
     </div>
-    <a href="https://youtu.be/jQPiH-KB4B0" target="_blank" style="display: inline-flex; align-items: center; gap: 0.4em; font-size: 0.85em; padding: 0.35em 0.7em; border-radius: 0.3em; border: 1px solid #c0392b; background: rgba(192,57,43,0.1); color: #c0392b; text-decoration: none; white-space: nowrap;">
+    <a href="https://www.youtube.com/watch?v=jQPiH-KB4B0&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y" target="_blank" style="display: inline-flex; align-items: center; gap: 0.4em; font-size: 0.85em; padding: 0.35em 0.7em; border-radius: 0.3em; border: 1px solid #c0392b; background: rgba(192,57,43,0.1); color: #c0392b; text-decoration: none; white-space: nowrap;">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3"/></svg>
       Watch
     </a>


### PR DESCRIPTION
## Summary
- All course lecture video links now use playlist URLs with index parameters
- Viewers land on the correct video and see the full course series in the sidebar
- Updated across: index page, course page, and 7 chapter frontmatter files

### Links updated
| Video | Files |
|-------|-------|
| Welcome intro | html.html, course.html |
| Lecture 1 (Ch 1-3) | course.html, ch01, ch02, ch03 |
| Lecture 2 (Ch 4,5,9) | course.html, ch04, ch05, ch09 |
| Lecture 3 (Ch 6 pt1) | course.html, ch06 |
| Lecture 4 (Ch 6 pt2) | course.html, ch06 |

Unrelated video links (DPO talk in appendix-b, GRPO codebases in lec4 slides) left as-is.

## Test plan
- [ ] Click a video link from the course page — should open in playlist context
- [ ] Click a lecture link from a chapter page — same behavior

Generated with [Claude Code](https://claude.com/claude-code)