### PR TITLE
Clean up docs, remove dead LoRA code, fix hardcoded paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ book/         # Book source and build files
   templates/  # Pandoc templates for each output format
   scripts/    # Build utilities
   data/       # Library data
-  preorder/   # Pre-order redirect page
+  preorder/   # Order redirect page
   metadata.yml # Book metadata for Pandoc
 code/         # Code examples and tutorials
 diagrams/     # Diagram sources (Python scripts, specs)

--- a/book/README.md
+++ b/book/README.md
@@ -92,7 +92,7 @@ book/
 ├── templates/    # Pandoc templates for each output format
 ├── scripts/      # Build utilities
 ├── data/         # Library data (JSON)
-└── preorder/     # Pre-order redirect page
+└── preorder/     # Order redirect page
 ```
 
 ## Setup

--- a/book/preorder/index.html
+++ b/book/preorder/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>Redirecting to RLHF Book Order Page</title>
-    <meta http-equiv="refresh" content="0; url=https://hubs.la/Q03TsMBq0" />
-    <link rel="canonical" href="https://hubs.la/Q03TsMBq0" />
+    <meta http-equiv="refresh" content="0; url=https://hubs.la/Q03Tc3cf0" />
+    <link rel="canonical" href="https://hubs.la/Q03Tc3cf0" />
     <style>
       body {
         margin: 0;

--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,6 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
+- 2026-04-15: [PR #370](https://github.com/natolambert/rlhf-book/pull/370) cleaned up CLAUDE.md for generic use, removed dead LoRA/QLoRA references from RM docstrings and base.py, moved ORPO/SimPO debug notes to direct_alignment/ORPO_SIMPO.md.
 - 2026-04-12: [PR #365](https://github.com/natolambert/rlhf-book/pull/365) updated the canonical PPO reference run to the post-retune validation run from PR #364.
 - 2026-04-12: [PR #364](https://github.com/natolambert/rlhf-book/pull/364) retuned PPO
   hyperparameters for smoother training.

--- a/code/CLAUDE.md
+++ b/code/CLAUDE.md
@@ -67,4 +67,4 @@ With gradient checkpointing can reduce by ~30-40%.
 
 - [ ] Validate and generate reference wandb runs for direct alignment (DPO, IPO, SimPO, ORPO, KTO) — see [#358](https://github.com/natolambert/rlhf-book/issues/358). For ORPO/SimPO debugging context, see [direct_alignment/ORPO_SIMPO.md](direct_alignment/ORPO_SIMPO.md)
 - [ ] Add evaluation scripts for reward models
-- [ ] Remove QLoRA from reward models (small models don't need it)
+- [x] ~~Remove QLoRA from reward models~~ (done — full fine-tune is the default, dead LoRA references cleaned up)

--- a/code/CLAUDE.md
+++ b/code/CLAUDE.md
@@ -4,9 +4,25 @@
 
 - **Always run Python commands with `uv run python`** (not bare `python`/`python3`) so the project environment is used consistently
 - **Always run training commands in background** using `run_in_background: true` to avoid blocking
-- Check task progress with `tail -f /tmp/claude/.../tasks/<id>.output`
-- **Be careful with parallel jobs**: Only run one training job at a time unless you verify memory is available (`free -h`). Running too many can OOM the system.
-- DGX Spark memory: ~120GB total (unified CPU/GPU), aim for <80GB usage to be safe
+- **Be careful with parallel jobs**: Only run one training job at a time unless you verify memory is available. Running too many can OOM the system.
+
+## Quick Start
+
+```bash
+cd code/
+uv sync
+
+# Optional: log to wandb (public project for book examples)
+export WANDB_PROJECT=rlhf-book
+
+# Run training scripts
+uv run python -m policy_gradients.train --config policy_gradients/configs/grpo.yaml
+uv run python -m reward_models.train_preference_rm --samples 2000 --epochs 1
+uv run python -m reward_models.train_orm --samples 400 --epochs 2
+uv run python -m reward_models.train_prm --samples 500 --epochs 2
+uv run python -m direct_alignment.train --config direct_alignment/configs/dpo.yaml
+uv run python -m rejection_sampling.train --config rejection_sampling/configs/top_per_prompt.yaml
+```
 
 ## Changelog Process
 
@@ -26,116 +42,6 @@
 - Put helper scripts directly inside the campaign folder at `direct_alignment/experiments/YYYY-MM-DD-<slug>/`.
 - Keep root-level generic scripts separate; experiment-specific scripts should live with their experiment logs.
 
-## Quick Start
-
-```bash
-cd /home/natolambert/dev/rlhf-book/code
-uv sync
-
-# Set wandb project (public project for book examples)
-export WANDB_PROJECT=rlhf-book
-
-# Run training scripts
-uv run python -m reward_models.train_orm --samples 400 --epochs 2
-uv run python -m reward_models.train_preference_rm --samples 2000 --epochs 1
-uv run python -m reward_models.train_prm --samples 500 --epochs 2
-uv run python -m policy_gradients.train --config configs/reinforce.yaml
-uv run python -m direct_alignment.train --config direct_alignment/configs/dpo.yaml
-```
-
-## TODOs
-
-### Immediate
-- [x] Add .python-version to .gitignore
-- [x] Refactor reward models to use base.py shared utilities
-- [ ] **Remove QLoRA from reward models** - use full fine-tuning for simplicity
-  - Small models (0.6B-1.7B) don't need LoRA for memory savings
-  - Simplifies code and removes bitsandbytes/PEFT dependencies
-  - May need to adjust learning rate (try 1e-5 or 5e-6)
-- [x] Generate wandb runs for all algorithms:
-  - [x] ORM (full fine-tune): https://wandb.ai/natolambert/rlhf-book/runs/3gkoqb7f
-  - [x] Preference RM (Bradley-Terry): https://wandb.ai/natolambert/rlhf-book/runs/1g3y9bcc
-  - [x] PRM (Process RM): https://wandb.ai/natolambert/rlhf-book/runs/iv4d966d
-  - [x] REINFORCE: https://wandb.ai/natolambert/rlhf-book/runs/0uqbq4oz
-  - [x] GRPO: https://wandb.ai/natolambert/rlhf-book/runs/vjp7lgdi
-  - [x] RLOO: https://wandb.ai/natolambert/rlhf-book/runs/07xeasn8
-  - [x] PPO: https://wandb.ai/natolambert/rlhf-book/runs/yv21y1qm
-  - [x] Dr. GRPO: https://wandb.ai/natolambert/rlhf-book/runs/a1swuynq
-  - [x] GSPO: https://wandb.ai/natolambert/rlhf-book/runs/10sxytli
-  - [x] CISPO: https://wandb.ai/natolambert/rlhf-book/runs/6dg0m06n
-
-- [x] Add README table with algorithm → wandb run links
-
-### Direct Alignment (DPO and variants)
-
-**Status: Implemented, needs testing**
-
-- [ ] Test DPO training end-to-end on UltraFeedback
-- [ ] Test IPO, SimPO, ORPO, KTO training
-- [ ] Generate wandb runs for all algorithms:
-  - [ ] DPO
-  - [ ] IPO
-  - [ ] SimPO
-  - [ ] ORPO
-  - [ ] KTO
-- [ ] Add wandb run links to README table
-- [ ] Verify OLMo-2-0425-1B-SFT works as default model
-- [ ] Consider adding evaluation (e.g., AlpacaEval, MT-Bench style)
-- [ ] Test data loading with Anthropic HH dataset
-
-## Current Debug Plan (ORPO/SimPO, Feb 2026)
-
-Context:
-- ORPO/SimPO instability from extreme ORPO scales was addressed by switching to average log-probs.
-- New issue is "stable but flat" learning, especially for ORPO.
-- SimPO formula now uses gamma as a gamma/beta ratio: `-logsigmoid(beta * (logit_margin - gamma))`.
-- Experiment log with full run ledger and W&B links: `direct_alignment/experiments/2026-02-08-orpo-simpo.md`.
-
-Plan:
-1. Run quick low-sample sanity jobs first (1 epoch, 640 samples) before long sweeps.
-2. Confirm SimPO margins/accuracy move with the gamma-ratio formulation.
-3. Sweep ORPO beta/LR to rebalance SFT vs preference term.
-4. Only then launch 12.8K-sample full runs.
-
-Small-run scripts:
-- `direct_alignment/experiments/2026-02-08-orpo-simpo/run_simpo_small.sh`
-- `direct_alignment/experiments/2026-02-08-orpo-simpo/run_orpo_small.sh`
-
-Examples:
-```bash
-cd /home/natolambert/dev/rlhf-book/code
-
-# SimPO sanity run (background)
-WANDB_PROJECT=rlhf-book ./direct_alignment/experiments/2026-02-08-orpo-simpo/run_simpo_small.sh
-
-# ORPO sanity run (background)
-WANDB_PROJECT=rlhf-book ./direct_alignment/experiments/2026-02-08-orpo-simpo/run_orpo_small.sh
-```
-
-Useful overrides:
-```bash
-# SimPO: stronger margin push
-GAMMA=1.0 LEARNING_RATE=1e-6 MAX_SAMPLES=640 NUM_EPOCHS=1 ./direct_alignment/experiments/2026-02-08-orpo-simpo/run_simpo_small.sh
-
-# ORPO: stronger preference term
-BETA=1.0 LEARNING_RATE=5e-6 MAX_SAMPLES=640 NUM_EPOCHS=1 ./direct_alignment/experiments/2026-02-08-orpo-simpo/run_orpo_small.sh
-```
-
-Acceptance criteria for small runs:
-- SimPO: `accuracy` and `margins` trend upward in first ~10-20 optimizer steps.
-- ORPO: `margins` move off near-zero and `or_loss` contributes non-trivially vs `sft_loss`.
-- Samples remain coherent (no repetitive collapse).
-
-### Reward Model Training
-
-**Status: Experimental** - Needs tuning of hyperparameters, datasets, and models for cleaner training curves.
-
-### Later
-- [x] Refactor train_prm.py to use base.py utilities (done)
-- [ ] Consider adding configs/ for reward model hyperparams
-- [ ] Add evaluation scripts for reward models
-- [ ] Delete commented LoRA code once full fine-tune metrics confirmed
-
 ## Model Recommendations
 
 For educational examples on consumer GPUs:
@@ -143,11 +49,9 @@ For educational examples on consumer GPUs:
 - **Qwen3-1.7B-Base**: ~8-10GB VRAM, better quality
 - **Qwen2.5-3B**: ~15-20GB VRAM, best quality
 
-## Wandb Project
+## Wandb
 
-Public project: https://wandb.ai/natolambert/rlhf-book
-
-All example runs should log here for documentation.
+Reference runs are published at https://wandb.ai/natolambert/rlhf-book (public, no login needed). When contributing new algorithms or configs, log runs to your own wandb project and include the link in your PR.
 
 ## Memory Notes
 
@@ -158,7 +62,8 @@ Without LoRA (full fine-tune):
 
 With gradient checkpointing can reduce by ~30-40%.
 
-## Learning Rate Notes
+## TODOs
 
-- With LoRA: 1e-4 to 5e-5 typical
-- Without LoRA (full fine-tune): 1e-5 to 5e-6 typical (10x smaller)
+- [ ] Validate and generate reference wandb runs for direct alignment (DPO, IPO, SimPO, ORPO, KTO) — see [#358](https://github.com/natolambert/rlhf-book/issues/358)
+- [ ] Add evaluation scripts for reward models
+- [ ] Remove QLoRA from reward models (small models don't need it)

--- a/code/CLAUDE.md
+++ b/code/CLAUDE.md
@@ -5,6 +5,7 @@
 - **Always run Python commands with `uv run python`** (not bare `python`/`python3`) so the project environment is used consistently
 - **Always run training commands in background** using `run_in_background: true` to avoid blocking
 - **Be careful with parallel jobs**: Only run one training job at a time unless you verify memory is available. Running too many can OOM the system.
+- **If using a DGX Spark**: ~120GB unified CPU/GPU memory — aim for <80GB usage to be safe. Flash Attention is not available on ARM64/Blackwell; the code automatically falls back to PyTorch SDPA.
 
 ## Quick Start
 
@@ -64,6 +65,6 @@ With gradient checkpointing can reduce by ~30-40%.
 
 ## TODOs
 
-- [ ] Validate and generate reference wandb runs for direct alignment (DPO, IPO, SimPO, ORPO, KTO) — see [#358](https://github.com/natolambert/rlhf-book/issues/358)
+- [ ] Validate and generate reference wandb runs for direct alignment (DPO, IPO, SimPO, ORPO, KTO) — see [#358](https://github.com/natolambert/rlhf-book/issues/358). For ORPO/SimPO debugging context, see [direct_alignment/ORPO_SIMPO.md](direct_alignment/ORPO_SIMPO.md)
 - [ ] Add evaluation scripts for reward models
 - [ ] Remove QLoRA from reward models (small models don't need it)

--- a/code/direct_alignment/ORPO_SIMPO.md
+++ b/code/direct_alignment/ORPO_SIMPO.md
@@ -1,0 +1,45 @@
+# ORPO/SimPO Debugging Notes
+
+Status: **Needs validation** — see [#358](https://github.com/natolambert/rlhf-book/issues/358)
+
+## Context
+
+- ORPO/SimPO instability from extreme ORPO scales was addressed in [PR #243](https://github.com/natolambert/rlhf-book/pull/243) by switching to average log-probs.
+- Remaining issue is "stable but flat" learning, especially for ORPO where the preference term (`or_loss`) contributes negligibly vs the SFT loss.
+- SimPO formula now uses gamma as a gamma/beta ratio: `-logsigmoid(beta * (logit_margin - gamma))`.
+- Experiment log with full run ledger and W&B links: `experiments/2026-02-08-orpo-simpo.md`.
+
+## Debugging approach
+
+1. Run quick low-sample sanity jobs first (1 epoch, 640 samples) before long sweeps.
+2. Confirm SimPO margins/accuracy move with the gamma-ratio formulation.
+3. Sweep ORPO beta/LR to rebalance SFT vs preference term.
+4. Only then launch 12.8K-sample full runs.
+
+## Small-run scripts
+
+```bash
+cd code/
+
+# SimPO sanity run
+WANDB_PROJECT=rlhf-book ./direct_alignment/experiments/2026-02-08-orpo-simpo/run_simpo_small.sh
+
+# ORPO sanity run
+WANDB_PROJECT=rlhf-book ./direct_alignment/experiments/2026-02-08-orpo-simpo/run_orpo_small.sh
+```
+
+### Useful overrides
+
+```bash
+# SimPO: stronger margin push
+GAMMA=1.0 LEARNING_RATE=1e-6 MAX_SAMPLES=640 NUM_EPOCHS=1 ./direct_alignment/experiments/2026-02-08-orpo-simpo/run_simpo_small.sh
+
+# ORPO: stronger preference term
+BETA=1.0 LEARNING_RATE=5e-6 MAX_SAMPLES=640 NUM_EPOCHS=1 ./direct_alignment/experiments/2026-02-08-orpo-simpo/run_orpo_small.sh
+```
+
+## Acceptance criteria
+
+- SimPO: `accuracy` and `margins` trend upward in first ~10-20 optimizer steps.
+- ORPO: `margins` move off near-zero and `or_loss` contributes non-trivially vs `sft_loss`.
+- Samples remain coherent (no repetitive collapse).

--- a/code/direct_alignment/README.md
+++ b/code/direct_alignment/README.md
@@ -33,7 +33,7 @@ As of 2026-02-08, ORPO/SimPO are still under investigation. See `direct_alignmen
 ## Quick Start
 
 ```bash
-cd /home/natolambert/dev/rlhf-book/code
+cd code/
 uv sync
 
 # Train DPO on 1k samples (quick test)

--- a/code/reward_models/README.md
+++ b/code/reward_models/README.md
@@ -26,7 +26,7 @@ See **Chapter 5: Reward Models** for mathematical derivations and intuitions.
 ## Quick Start
 
 ```bash
-cd /home/natolambert/dev/rlhf-book/code
+cd code/
 uv sync
 
 # Train ORM

--- a/code/reward_models/base.py
+++ b/code/reward_models/base.py
@@ -6,7 +6,6 @@ This module provides common functionality shared across ORM, PRM, and Preference
 - Data utilities: collate functions
 
 Note: We use full fine-tuning for simplicity with small models (0.6B-1.7B).
-For larger models, consider using LoRA/QLoRA (see commented code below).
 """
 
 import os
@@ -17,10 +16,6 @@ import torch.nn as nn
 import wandb
 from torch.utils.data import DataLoader
 from transformers import AutoModelForCausalLM, AutoTokenizer
-
-# Commented out LoRA imports - kept for reference if needed for larger models
-# from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
-# from transformers import BitsAndBytesConfig
 
 
 # =============================================================================
@@ -44,10 +39,6 @@ class BaseRewardModel(nn.Module):
         model_id: str,
         head_dim: int = 1,
         freeze_backbone: bool = False,
-        # LoRA params kept for potential future use
-        # lora_r: int = 16,
-        # lora_alpha: int = 32,
-        # lora_dropout: float = 0.05,
     ):
         super().__init__()
 
@@ -69,29 +60,6 @@ class BaseRewardModel(nn.Module):
         # Build head with same dtype as model
         self.head = self._build_head(self.model.config.hidden_size, head_dim)
         self.head = self.head.to(torch.bfloat16)
-
-        # --- Commented out LoRA setup for reference ---
-        # bnb_config = BitsAndBytesConfig(
-        #     load_in_4bit=True,
-        #     bnb_4bit_compute_dtype=torch.bfloat16,
-        # )
-        # lora_config = LoraConfig(
-        #     r=lora_r,
-        #     lora_alpha=lora_alpha,
-        #     lora_dropout=lora_dropout,
-        #     bias="none",
-        #     task_type="CAUSAL_LM",
-        #     target_modules=["q_proj", "k_proj", "v_proj", "o_proj",
-        #                     "gate_proj", "up_proj", "down_proj"],
-        # )
-        # base = AutoModelForCausalLM.from_pretrained(
-        #     model_id,
-        #     quantization_config=bnb_config,
-        #     device_map=device_map,
-        #     trust_remote_code=True,
-        # )
-        # base = prepare_model_for_kbit_training(base)
-        # self.model = get_peft_model(base, lora_config)
 
     def _build_head(self, hidden_size: int, output_dim: int) -> nn.Module:
         """Build the reward head. Override for custom architectures."""

--- a/code/reward_models/train_orm.py
+++ b/code/reward_models/train_orm.py
@@ -8,7 +8,7 @@ License: MIT
 Adapted for RLHF Book (https://rlhfbook.com) by Nathan Lambert
 
 This script trains a minimal outcome reward model by fine-tuning a base LLM
-with LoRA on GSM8K-derived correct/incorrect math answers. For each question,
+on GSM8K-derived correct/incorrect math answers. For each question,
 we parse the gold numeric answer and synthesize wrong completions by adding
 random offsets. The model learns to classify solution correctness via per-token
 BCE loss on completion tokens.
@@ -157,11 +157,10 @@ def collate_fn(batch: List[Dict], tokenizer: AutoTokenizer) -> Dict[str, torch.T
 
 
 class OutcomeRewardModel(BaseRewardModel):
-    """Outcome Reward Model with LoRA fine-tuning.
+    """Outcome Reward Model with full fine-tuning.
 
     Architecture:
-    - Base LLM (e.g., Qwen3) with 4-bit quantization
-    - LoRA adapters on attention projections
+    - Base LLM (e.g., Qwen3) loaded in bfloat16
     - Linear head mapping hidden states to scalar reward
 
     The model outputs per-token logits which are trained with BCE loss

--- a/code/reward_models/train_preference_rm.py
+++ b/code/reward_models/train_preference_rm.py
@@ -148,11 +148,10 @@ def collate_fn(batch: List[Dict], tokenizer: AutoTokenizer) -> Dict[str, torch.T
 
 
 class PreferenceRewardModel(BaseRewardModel):
-    """Preference-based Reward Model with LoRA fine-tuning.
+    """Preference-based Reward Model with full fine-tuning.
 
     Architecture:
-    - Base LLM (e.g., Qwen3) with 4-bit quantization
-    - LoRA adapters on attention projections
+    - Base LLM (e.g., Qwen3) loaded in bfloat16
     - Linear head mapping last hidden state to scalar reward
 
     The model outputs a single scalar reward for each sequence.

--- a/code/reward_models/train_prm.py
+++ b/code/reward_models/train_prm.py
@@ -7,7 +7,7 @@ License: MIT
 
 Adapted for RLHF Book (https://rlhfbook.com) by Nathan Lambert
 
-This script trains a process reward model by fine-tuning a base LLM with LoRA
+This script trains a process reward model by fine-tuning a base LLM
 on PRM800K-style chain-of-thought traces. Each reasoning step has a label in
 {-1, 0, 1} (bad, neutral, good). The model learns to classify step quality
 via cross-entropy loss on step terminator tokens.


### PR DESCRIPTION
## Summary
Closes #367

### CLAUDE.md cleanup
- Replace hardcoded `/home/natolambert/` paths with relative `cd code/`
- Remove DGX Spark as assumed setup — add conditional "If using a DGX Spark" note instead
- Remove stale ORPO/SimPO debug plan (moved to `direct_alignment/ORPO_SIMPO.md`, tracked in #358)
- Remove completed TODOs and old wandb run links (already in README)
- Remove Learning Rate Notes section (LoRA no longer used)
- Add `rejection_sampling` to quick start examples
- Make wandb section contributor-friendly

### Dead LoRA/QLoRA removal
- Remove all commented-out LoRA code from `reward_models/base.py` (imports, params, setup block)
- Update docstrings in `train_orm.py`, `train_preference_rm.py`, `train_prm.py` from "LoRA fine-tuning" / "4-bit quantization" to "full fine-tuning" / "bfloat16"
- Mark QLoRA TODO as done

### Hardcoded paths in module READMEs
- `code/reward_models/README.md` and `code/direct_alignment/README.md` — replace `/home/natolambert/dev/rlhf-book/code` with `cd code/`

### Preorder page fixes
- Standardize inconsistent Manning redirect URLs in `book/preorder/index.html`
- Update "Pre-order redirect page" descriptions in top-level `CLAUDE.md` and `book/README.md`

## Test plan
- [ ] Verify CLAUDE.md reads well for someone new to the repo
- [ ] Verify no remaining hardcoded paths or stale LoRA references

Generated with [Claude Code](https://claude.com/claude-code)