### PR TITLE
Document build-essential and uv version requirements

### DIFF
--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,6 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
+- 2026-04-15: [PR #372](https://github.com/natolambert/rlhf-book/pull/372) documented build-essential requirement for Ubuntu/Debian and uv version guidance in README install section.
 - 2026-04-15: [PR #370](https://github.com/natolambert/rlhf-book/pull/370) cleaned up CLAUDE.md for generic use, removed dead LoRA/QLoRA references from RM docstrings and base.py, moved ORPO/SimPO debug notes to direct_alignment/ORPO_SIMPO.md.
 - 2026-04-12: [PR #365](https://github.com/natolambert/rlhf-book/pull/365) updated the canonical PPO reference run to the post-retune validation run from PR #364.
 - 2026-04-12: [PR #364](https://github.com/natolambert/rlhf-book/pull/364) retuned PPO

--- a/code/README.md
+++ b/code/README.md
@@ -35,12 +35,22 @@ demonstrating the concepts from Chapter 5 (Reward Models).
 
 ## Installation
 
-**Requires Python 3.12+** and [uv](https://docs.astral.sh/uv/getting-started/installation/).
+**Requires Python 3.12+** and [uv](https://docs.astral.sh/uv/getting-started/installation/) **v0.6+**.
+
+**Ubuntu/Debian users**: install build tools first (needed to compile native dependencies like `pycosat`):
+
+```bash
+sudo apt install -y build-essential python3-dev
+```
+
+Then install:
 
 ```bash
 cd code/
 uv sync
 ```
+
+> If you see a warning about `extra-build-dependencies`, run `uv self update` to upgrade uv.
 
 By default, [Flash Attention](https://github.com/Dao-AILab/flash-attention) is turned off
 to support a broad range of hardware, but for speedups you should consider installing it:

--- a/code/README.md
+++ b/code/README.md
@@ -35,7 +35,7 @@ demonstrating the concepts from Chapter 5 (Reward Models).
 
 ## Installation
 
-**Requires Python 3.12+** and [uv](https://docs.astral.sh/uv/getting-started/installation/) **v0.6+** (`uv self update` if needed). See [#366](https://github.com/natolambert/rlhf-book/issues/366) for troubleshooting.
+**Requires Python 3.12+** and an up-to-date [uv](https://docs.astral.sh/uv/getting-started/installation/) (`uv self update`). See [#366](https://github.com/natolambert/rlhf-book/issues/366) for troubleshooting uv compatibility.
 
 **Ubuntu/Debian users**: install build tools first (needed to compile native dependencies):
 

--- a/code/README.md
+++ b/code/README.md
@@ -35,7 +35,7 @@ demonstrating the concepts from Chapter 5 (Reward Models).
 
 ## Installation
 
-**Requires Python 3.12+** and [uv](https://docs.astral.sh/uv/getting-started/installation/) **v0.6+**.
+**Requires Python 3.12+** and a recent version of [uv](https://docs.astral.sh/uv/getting-started/installation/) (run `uv self update` if in doubt).
 
 **Ubuntu/Debian users**: install build tools first (needed to compile native dependencies like `pycosat`):
 
@@ -50,7 +50,7 @@ cd code/
 uv sync
 ```
 
-> If you see a warning about `extra-build-dependencies`, run `uv self update` to upgrade uv.
+> If you see a warning about `extra-build-dependencies`, your uv is too old — run `uv self update`.
 
 By default, [Flash Attention](https://github.com/Dao-AILab/flash-attention) is turned off
 to support a broad range of hardware, but for speedups you should consider installing it:

--- a/code/README.md
+++ b/code/README.md
@@ -35,9 +35,9 @@ demonstrating the concepts from Chapter 5 (Reward Models).
 
 ## Installation
 
-**Requires Python 3.12+** and a recent version of [uv](https://docs.astral.sh/uv/getting-started/installation/) (run `uv self update` if in doubt).
+**Requires Python 3.12+** and [uv](https://docs.astral.sh/uv/getting-started/installation/) **v0.6+** (`uv self update` if needed). See [#366](https://github.com/natolambert/rlhf-book/issues/366) for troubleshooting.
 
-**Ubuntu/Debian users**: install build tools first (needed to compile native dependencies like `pycosat`):
+**Ubuntu/Debian users**: install build tools first (needed to compile native dependencies):
 
 ```bash
 sudo apt install -y build-essential python3-dev
@@ -49,8 +49,6 @@ Then install:
 cd code/
 uv sync
 ```
-
-> If you see a warning about `extra-build-dependencies`, your uv is too old — run `uv self update`.
 
 By default, [Flash Attention](https://github.com/Dao-AILab/flash-attention) is turned off
 to support a broad range of hardware, but for speedups you should consider installing it:


### PR DESCRIPTION
## Summary
Addresses #366

- Add `build-essential` / `python3-dev` install step for Ubuntu/Debian users (needed to compile `pycosat` from `reasoning-gym`)
- Note uv v0.6+ requirement (for `extra-build-dependencies` support)
- Add hint about `uv self update` if users see the warning

## Test plan
- [ ] Fresh Ubuntu machine: follow the install steps and verify `uv sync` succeeds

Generated with [Claude Code](https://claude.com/claude-code)