### PR TITLE
Add CI ruff lint/format check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,11 +18,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 
-      - name: Install dependencies
-        run: uv sync --dev
-
       - name: Ruff check
-        run: uv run ruff check .
+        run: uvx ruff@0.14.5 check .
 
       - name: Ruff format check
-        run: uv run ruff format --check .
+        run: uvx ruff@0.14.5 format --check .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "code/**"
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: code
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Ruff check
+        run: uv run ruff check .
+
+      - name: Ruff format check
+        run: uv run ruff format --check .

--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,7 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
-- 2026-04-03: Added CI ruff lint/format check for PRs touching `code/`, applied ruff format to all existing files, fixed lint errors (unused imports, unsorted imports, `zip()` without `strict=`), and documented linting in README.
+- 2026-04-16: [PR #374](https://github.com/natolambert/rlhf-book/pull/374) added CI ruff lint/format check for PRs touching `code/`, applied ruff format to all existing files, fixed lint errors (unused imports, unsorted imports, `zip()` without `strict=`), and documented linting in README.
 - 2026-04-15: [PR #372](https://github.com/natolambert/rlhf-book/pull/372) documented build-essential requirement for Ubuntu/Debian and uv version guidance in README install section.
 - 2026-04-15: [PR #370](https://github.com/natolambert/rlhf-book/pull/370) cleaned up CLAUDE.md for generic use, removed dead LoRA/QLoRA references from RM docstrings and base.py, moved ORPO/SimPO debug notes to direct_alignment/ORPO_SIMPO.md.
 - 2026-04-12: [PR #365](https://github.com/natolambert/rlhf-book/pull/365) updated the canonical PPO reference run to the post-retune validation run from PR #364.

--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,6 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
+- 2026-04-03: Added CI ruff lint/format check for PRs touching `code/`, applied ruff format to all existing files, fixed lint errors (unused imports, unsorted imports, `zip()` without `strict=`), and documented linting in README.
 - 2026-04-15: [PR #372](https://github.com/natolambert/rlhf-book/pull/372) documented build-essential requirement for Ubuntu/Debian and uv version guidance in README install section.
 - 2026-04-15: [PR #370](https://github.com/natolambert/rlhf-book/pull/370) cleaned up CLAUDE.md for generic use, removed dead LoRA/QLoRA references from RM docstrings and base.py, moved ORPO/SimPO debug notes to direct_alignment/ORPO_SIMPO.md.
 - 2026-04-12: [PR #365](https://github.com/natolambert/rlhf-book/pull/365) updated the canonical PPO reference run to the post-retune validation run from PR #364.

--- a/code/CLAUDE.md
+++ b/code/CLAUDE.md
@@ -6,6 +6,7 @@
 - **Always run training commands in background** using `run_in_background: true` to avoid blocking
 - **Be careful with parallel jobs**: Only run one training job at a time unless you verify memory is available. Running too many can OOM the system.
 - **If using a DGX Spark**: ~120GB unified CPU/GPU memory — aim for <80GB usage to be safe. Flash Attention is not available on ARM64/Blackwell; the code automatically falls back to PyTorch SDPA.
+- **Before finalizing changes under `code/`**, run `uvx ruff check .` and `uvx ruff format --check .` — both are enforced by CI on PRs that touch `code/`. Use `uvx ruff check --fix .` and `uvx ruff format .` to auto-fix.
 
 ## Quick Start
 

--- a/code/README.md
+++ b/code/README.md
@@ -270,14 +270,14 @@ This project uses [Ruff](https://docs.astral.sh/ruff/) for linting and formattin
 
 ```bash
 # Check for lint errors
-uv run ruff check .
+uvx ruff check .
 
 # Check formatting
-uv run ruff format --check .
+uvx ruff format --check .
 
 # Auto-fix lint errors and formatting
-uv run ruff check --fix .
-uv run ruff format .
+uvx ruff check --fix .
+uvx ruff format .
 ```
 
 Configuration is in `pyproject.toml` (line length 100, Python 3.12 target).

--- a/code/README.md
+++ b/code/README.md
@@ -264,6 +264,24 @@ export HF_TOKEN="your-token"
 | Reward models | Qwen3-0.6B | ~8-16GB |
 | Reward models | Qwen3-1.7B | ~16-20GB |
 
+## Linting
+
+This project uses [Ruff](https://docs.astral.sh/ruff/) for linting and formatting. A CI check runs on every PR that touches `code/`.
+
+```bash
+# Check for lint errors
+uv run ruff check .
+
+# Check formatting
+uv run ruff format --check .
+
+# Auto-fix lint errors and formatting
+uv run ruff check --fix .
+uv run ruff format .
+```
+
+Configuration is in `pyproject.toml` (line length 100, Python 3.12 target).
+
 ## Book Chapters
 
 These examples correspond to:

--- a/code/direct_alignment/__init__.py
+++ b/code/direct_alignment/__init__.py
@@ -28,6 +28,7 @@ from .loss import (
 )
 from .train import main, main_cli
 
+
 __all__ = [
     # Config
     "Config",

--- a/code/direct_alignment/config.py
+++ b/code/direct_alignment/config.py
@@ -31,8 +31,12 @@ class Config:
     # Sequence length settings (TRL-style controls)
     max_length: int = 512  # Max total sequence length (prompt + completion)
     max_prompt_length: int | None = None  # Max prompt length (truncated from left if exceeded)
-    max_completion_length: int | None = None  # Max completion length (truncated from right if exceeded)
-    truncation_mode: Literal["keep_end", "keep_start"] = "keep_end"  # How to truncate: keep_end preserves response
+    max_completion_length: int | None = (
+        None  # Max completion length (truncated from right if exceeded)
+    )
+    truncation_mode: Literal["keep_end", "keep_start"] = (
+        "keep_end"  # How to truncate: keep_end preserves response
+    )
 
     # Training hyperparameters
     learning_rate: float = 5e-7  # DPO typically uses very low LR
@@ -101,5 +105,6 @@ def load_config(config_path: str | Path) -> Config:
 def save_config(config: Config, config_path: str | Path) -> None:
     """Save configuration to YAML file."""
     import dataclasses
+
     with open(config_path, "w") as f:
         yaml.dump(dataclasses.asdict(config), f, default_flow_style=False)

--- a/code/direct_alignment/data.py
+++ b/code/direct_alignment/data.py
@@ -20,11 +20,15 @@ class PreferenceBatch:
     chosen_input_ids: torch.Tensor  # (batch, seq_len)
     chosen_attention_mask: torch.Tensor  # (batch, seq_len)
     chosen_labels: torch.Tensor  # (batch, seq_len) - for computing loss
-    chosen_response_mask: torch.Tensor  # (batch, seq_len) - 1 for response tokens, 0 for prompt/padding
+    chosen_response_mask: (
+        torch.Tensor
+    )  # (batch, seq_len) - 1 for response tokens, 0 for prompt/padding
     rejected_input_ids: torch.Tensor  # (batch, seq_len)
     rejected_attention_mask: torch.Tensor  # (batch, seq_len)
     rejected_labels: torch.Tensor  # (batch, seq_len)
-    rejected_response_mask: torch.Tensor  # (batch, seq_len) - 1 for response tokens, 0 for prompt/padding
+    rejected_response_mask: (
+        torch.Tensor
+    )  # (batch, seq_len) - 1 for response tokens, 0 for prompt/padding
 
     def to(self, device: str | torch.device) -> "PreferenceBatch":
         """Move batch to device."""
@@ -201,8 +205,7 @@ def load_preference_dataset(
         pass
     else:
         raise ValueError(
-            f"Unknown dataset format. Expected columns: prompt, chosen, rejected. "
-            f"Got: {columns}"
+            f"Unknown dataset format. Expected columns: prompt, chosen, rejected. Got: {columns}"
         )
 
     return dataset
@@ -303,10 +306,12 @@ class PreferenceDataset(torch.utils.data.Dataset):
         prompt_only_text = format_prompt_only(example["prompt"], self.tokenizer)
 
         # Tokenize with response-preserving truncation
-        chosen_input_ids, chosen_attention_mask, chosen_response_mask = \
+        chosen_input_ids, chosen_attention_mask, chosen_response_mask = (
             self._tokenize_with_response_priority(prompt_only_text, chosen_text)
-        rejected_input_ids, rejected_attention_mask, rejected_response_mask = \
+        )
+        rejected_input_ids, rejected_attention_mask, rejected_response_mask = (
             self._tokenize_with_response_priority(prompt_only_text, rejected_text)
+        )
 
         return {
             "chosen_input_ids": chosen_input_ids,

--- a/code/direct_alignment/loss.py
+++ b/code/direct_alignment/loss.py
@@ -35,8 +35,8 @@ def compute_logprobs(
     """
     # Shift for autoregressive: predict token t from tokens 0...t-1
     logits = logits[:, :-1, :]  # (batch, seq_len-1, vocab)
-    labels = labels[:, 1:]      # (batch, seq_len-1)
-    mask = mask[:, 1:]          # (batch, seq_len-1)
+    labels = labels[:, 1:]  # (batch, seq_len-1)
+    mask = mask[:, 1:]  # (batch, seq_len-1)
 
     # Compute per-token log probs
     log_probs = F.log_softmax(logits, dim=-1)
@@ -366,7 +366,9 @@ class KTOLoss(nn.Module):
     See: https://github.com/ContextualAI/HALOs for the official implementation.
     """
 
-    def __init__(self, beta: float = 0.1, desirable_weight: float = 1.0, undesirable_weight: float = 1.0):
+    def __init__(
+        self, beta: float = 0.1, desirable_weight: float = 1.0, undesirable_weight: float = 1.0
+    ):
         """
         Args:
             beta: Temperature parameter.
@@ -441,8 +443,8 @@ class KTOLoss(nn.Module):
 
         # Weighted combination (asymmetric weights reflect loss aversion)
         loss = (
-            self.desirable_weight * chosen_losses.mean() +
-            self.undesirable_weight * rejected_losses.mean()
+            self.desirable_weight * chosen_losses.mean()
+            + self.undesirable_weight * rejected_losses.mean()
         )
 
         metrics = {
@@ -479,7 +481,9 @@ def get_loss_function(loss_type: str, **kwargs) -> nn.Module:
         Loss function module
     """
     if loss_type not in LOSS_FUNCTIONS:
-        raise ValueError(f"Unknown loss type: {loss_type}. Choose from {list(LOSS_FUNCTIONS.keys())}")
+        raise ValueError(
+            f"Unknown loss type: {loss_type}. Choose from {list(LOSS_FUNCTIONS.keys())}"
+        )
 
     # Filter kwargs to only pass what each loss function accepts
     beta = kwargs.get("beta", 0.1)

--- a/code/direct_alignment/profile_memory.py
+++ b/code/direct_alignment/profile_memory.py
@@ -21,9 +21,7 @@ def get_memory_usage() -> tuple[float, float]:
         (used_gb, total_gb)
     """
     # For unified memory systems (DGX Spark), use system memory
-    result = subprocess.run(
-        ["free", "-b"], capture_output=True, text=True
-    )
+    result = subprocess.run(["free", "-b"], capture_output=True, text=True)
     lines = result.stdout.strip().split("\n")
     mem_line = lines[1].split()
     total_bytes = int(mem_line[1])
@@ -41,6 +39,7 @@ def get_attn_implementation() -> str:
         return "sdpa"
     try:
         import flash_attn  # noqa: F401
+
         return "flash_attention_2"
     except ImportError:
         return "sdpa"
@@ -103,9 +102,7 @@ def profile_configuration(
 
     # Create dummy batch (DPO needs chosen + rejected)
     dummy_input_ids = torch.randint(
-        0, tokenizer.vocab_size,
-        (batch_size, max_length),
-        device="cuda"
+        0, tokenizer.vocab_size, (batch_size, max_length), device="cuda"
     )
     dummy_attention_mask = torch.ones_like(dummy_input_ids)
 
@@ -198,7 +195,11 @@ def main():
         print(f"\n--- Context Length: {max_length} ---")
         for batch_size in batch_sizes:
             try:
-                print(f"Testing batch_size={batch_size}, max_length={max_length}...", end=" ", flush=True)
+                print(
+                    f"Testing batch_size={batch_size}, max_length={max_length}...",
+                    end=" ",
+                    flush=True,
+                )
                 result = profile_configuration(
                     model_name=model_name,
                     batch_size=batch_size,
@@ -207,18 +208,22 @@ def main():
                 results.append(result)
 
                 status = "OK" if result["peak_usage_pct"] < 85 else "OVER 85%"
-                print(f"Peak: {result['peak_memory_gb']:.1f} GB ({result['peak_usage_pct']:.1f}%) [{status}]")
+                print(
+                    f"Peak: {result['peak_memory_gb']:.1f} GB ({result['peak_usage_pct']:.1f}%) [{status}]"
+                )
 
             except RuntimeError as e:
                 if "out of memory" in str(e).lower():
-                    print(f"OOM!")
-                    results.append({
-                        "batch_size": batch_size,
-                        "max_length": max_length,
-                        "peak_memory_gb": float("inf"),
-                        "peak_usage_pct": 100,
-                        "error": "OOM",
-                    })
+                    print("OOM!")
+                    results.append(
+                        {
+                            "batch_size": batch_size,
+                            "max_length": max_length,
+                            "peak_memory_gb": float("inf"),
+                            "peak_usage_pct": 100,
+                            "error": "OOM",
+                        }
+                    )
                 else:
                     raise
 
@@ -226,7 +231,9 @@ def main():
     print("\n" + "=" * 80)
     print("SUMMARY: Safe configurations (< 85% memory)")
     print("=" * 80)
-    print(f"{'Batch Size':<12} {'Max Length':<12} {'Peak Memory':<15} {'Usage %':<10} {'Status':<10}")
+    print(
+        f"{'Batch Size':<12} {'Max Length':<12} {'Peak Memory':<15} {'Usage %':<10} {'Status':<10}"
+    )
     print("-" * 60)
 
     for r in results:

--- a/code/direct_alignment/train.py
+++ b/code/direct_alignment/train.py
@@ -21,16 +21,15 @@ from pathlib import Path
 
 import numpy as np
 import torch
-import torch.nn.functional as F
 import wandb
 from rich.console import Console
-from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TimeElapsedColumn
+from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 from torch.nn.utils import clip_grad_norm_
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from .config import Config, load_config
 from .data import PreferenceBatch, create_dataloader
-from .loss import compute_logprobs, get_loss_function, ORPOLoss
+from .loss import ORPOLoss, compute_logprobs, get_loss_function
 
 
 def get_attn_implementation() -> str:
@@ -39,6 +38,7 @@ def get_attn_implementation() -> str:
         return "sdpa"  # aarch64 / DGX Spark - use SDPA with cuDNN
     try:
         import flash_attn  # noqa: F401
+
         return "flash_attention_2"
     except ImportError:
         return "sdpa"
@@ -79,9 +79,7 @@ def load_model(
     model = model.to(device)
 
     if gradient_checkpointing:
-        model.gradient_checkpointing_enable(
-            gradient_checkpointing_kwargs={"use_reentrant": False}
-        )
+        model.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
 
     return model, tokenizer
 
@@ -276,7 +274,9 @@ def print_training_info(console: Console, cfg: Config, num_samples: int):
     console.print(f"  Beta: {cfg.beta}")
     console.print(f"  Dataset: {cfg.dataset_name}")
     console.print(f"  Samples: {num_samples}")
-    console.print(f"  Batch size: {cfg.batch_size} x {cfg.gradient_accumulation_steps} = {cfg.batch_size * cfg.gradient_accumulation_steps}")
+    console.print(
+        f"  Batch size: {cfg.batch_size} x {cfg.gradient_accumulation_steps} = {cfg.batch_size * cfg.gradient_accumulation_steps}"
+    )
     console.print(f"  Learning rate: {cfg.learning_rate}")
     console.print(f"  Epochs: {cfg.num_epochs}")
     console.print(
@@ -428,7 +428,7 @@ def generate_samples(
 
         # Decode response only (not the prompt)
         response = tokenizer.decode(
-            outputs[0][inputs["input_ids"].shape[1]:],
+            outputs[0][inputs["input_ids"].shape[1] :],
             skip_special_tokens=True,
         )
 
@@ -448,7 +448,9 @@ def generate_samples(
         # Print to console if provided
         if console:
             console.print(f"\n[bold cyan]Prompt {prompt_id}:[/bold cyan] {prompt}")
-            console.print(f"[bold green]Response:[/bold green] {response[:500]}{'...' if len(response) > 500 else ''}")
+            console.print(
+                f"[bold green]Response:[/bold green] {response[:500]}{'...' if len(response) > 500 else ''}"
+            )
 
     model.train()
     return samples
@@ -559,7 +561,10 @@ def main(cfg: Config):
         if step < num_warmup_steps:
             # Start warmup at 1/num_warmup_steps, not 0 (avoids first step doing nothing)
             return float(step + 1) / float(max(1, num_warmup_steps + 1))
-        return max(0.0, float(num_training_steps - step) / float(max(1, num_training_steps - num_warmup_steps)))
+        return max(
+            0.0,
+            float(num_training_steps - step) / float(max(1, num_training_steps - num_warmup_steps)),
+        )
 
     scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
 
@@ -632,7 +637,9 @@ def main(cfg: Config):
 
                 # Update scheduler after optimizer step
                 if (batch_idx + 1) % cfg.gradient_accumulation_steps == 0:
-                    step_metrics = {key: value / metrics_count for key, value in metrics_sum.items()}
+                    step_metrics = {
+                        key: value / metrics_count for key, value in metrics_sum.items()
+                    }
                     scheduler.step()
                     global_step += 1
 
@@ -651,7 +658,9 @@ def main(cfg: Config):
 
                     # Generate and log samples periodically
                     if cfg.sample_every > 0 and global_step % cfg.sample_every == 0:
-                        console.print(f"\n[bold yellow]Generating samples at step {global_step}...[/bold yellow]")
+                        console.print(
+                            f"\n[bold yellow]Generating samples at step {global_step}...[/bold yellow]"
+                        )
                         prompt_entries = select_sample_prompts(
                             prompt_pool=sample_prompt_pool,
                             sample_num_prompts=cfg.sample_num_prompts,
@@ -690,7 +699,11 @@ def main(cfg: Config):
                 scheduler.step()
                 global_step += 1
 
-                step_metrics = {key: value / metrics_count for key, value in metrics_sum.items()} if metrics_count > 0 else {}
+                step_metrics = (
+                    {key: value / metrics_count for key, value in metrics_sum.items()}
+                    if metrics_count > 0
+                    else {}
+                )
                 # Log final partial batch
                 step_metrics["learning_rate"] = scheduler.get_last_lr()[0]
                 step_metrics["epoch"] = epoch + 1.0
@@ -766,15 +779,33 @@ def main_cli():
     parser.add_argument("--batch_size", type=int, help="Batch size")
     parser.add_argument("--gradient_accumulation_steps", type=int)
     parser.add_argument("--wandb_project", type=str, help="Wandb project name")
-    parser.add_argument("--sample_every", type=int, help="Generate samples every N steps (0 to disable)")
+    parser.add_argument(
+        "--sample_every", type=int, help="Generate samples every N steps (0 to disable)"
+    )
     parser.add_argument("--sample_num_prompts", type=int, help="Prompts per sample event")
-    parser.add_argument("--sample_prompt_strategy", type=str, choices=["fixed", "round_robin", "random"])
-    parser.add_argument("--sample_prompts_file", type=str, help="Optional .txt/.json prompt list for in-loop samples")
+    parser.add_argument(
+        "--sample_prompt_strategy", type=str, choices=["fixed", "round_robin", "random"]
+    )
+    parser.add_argument(
+        "--sample_prompts_file",
+        type=str,
+        help="Optional .txt/.json prompt list for in-loop samples",
+    )
     parser.add_argument("--sample_max_tokens", type=int, help="Max new tokens per in-loop sample")
-    parser.add_argument("--sample_max_input_tokens", type=int, help="Max prompt tokens for in-loop sample generation")
-    parser.add_argument("--sample_temperature", type=float, help="Temperature for in-loop sample generation")
+    parser.add_argument(
+        "--sample_max_input_tokens",
+        type=int,
+        help="Max prompt tokens for in-loop sample generation",
+    )
+    parser.add_argument(
+        "--sample_temperature", type=float, help="Temperature for in-loop sample generation"
+    )
     parser.add_argument("--sample_top_p", type=float, help="Top-p for in-loop sample generation")
-    parser.add_argument("--sample_do_sample", action=argparse.BooleanOptionalAction, help="Enable/disable stochastic in-loop sampling")
+    parser.add_argument(
+        "--sample_do_sample",
+        action=argparse.BooleanOptionalAction,
+        help="Enable/disable stochastic in-loop sampling",
+    )
     parser.add_argument("--seed", type=int, help="Random seed")
 
     args = parser.parse_args()

--- a/code/policy_gradients/buffer.py
+++ b/code/policy_gradients/buffer.py
@@ -37,7 +37,9 @@ class Experience:
         """Move all tensors to the specified device."""
         field_names = [f.name for f in fields(self)]
         moved_tensors = {
-            name: getattr(self, name).to(device) for name in field_names if getattr(self, name) is not None
+            name: getattr(self, name).to(device)
+            for name in field_names
+            if getattr(self, name) is not None
         }
         return Experience(**moved_tensors)
 

--- a/code/policy_gradients/config.py
+++ b/code/policy_gradients/config.py
@@ -121,7 +121,9 @@ class Config(BaseModel):
         if self.num_rollouts > 1 and self.rollout_batch_size != self.num_rollouts:
             raise ValueError("When num_rollouts > 1, rollout_batch_size must equal num_rollouts.")
         if (self.prompts_per_step * self.num_rollouts) % self.rollout_batch_size != 0:
-            raise ValueError("prompts_per_step * num_rollouts must be divisible by rollout_batch_size.")
+            raise ValueError(
+                "prompts_per_step * num_rollouts must be divisible by rollout_batch_size."
+            )
         return self
 
 

--- a/code/policy_gradients/loss.py
+++ b/code/policy_gradients/loss.py
@@ -18,7 +18,9 @@ import torch.nn as nn
 from .buffer import Experience
 
 
-def approx_kl(log_probs: torch.Tensor, log_probs_ref: torch.Tensor, action_mask: torch.Tensor) -> torch.Tensor:
+def approx_kl(
+    log_probs: torch.Tensor, log_probs_ref: torch.Tensor, action_mask: torch.Tensor
+) -> torch.Tensor:
     """Monte-Carlo approximation of KL divergence (k3 estimator).
 
     See: http://joschu.net/blog/kl-approx.html
@@ -39,7 +41,9 @@ def masked_mean(
     """Compute mean over masked positions."""
     if mask is None:
         return tensor.mean(dim=dim, keepdim=keepdim)
-    return (tensor * mask).sum(dim=dim, keepdim=keepdim) / mask.sum(dim=dim, keepdim=keepdim).clamp_min(eps)
+    return (tensor * mask).sum(dim=dim, keepdim=keepdim) / mask.sum(
+        dim=dim, keepdim=keepdim
+    ).clamp_min(eps)
 
 
 class GRPOLoss(nn.Module):
@@ -59,7 +63,9 @@ class GRPOLoss(nn.Module):
         # Policy loss with clipping
         ratio = (log_probs - experience.log_probs_old).exp()
         unclipped_term = ratio * experience.advantages
-        clipped_term = ratio.clamp(1 - self.clip_eps_lo, 1 + self.clip_eps_hi) * experience.advantages
+        clipped_term = (
+            ratio.clamp(1 - self.clip_eps_lo, 1 + self.clip_eps_hi) * experience.advantages
+        )
         policy_loss = -torch.min(unclipped_term, clipped_term)
 
         # Optional KL penalty
@@ -91,7 +97,9 @@ class GSPOLoss(nn.Module):
             log_probs - experience.log_probs_old, mask=experience.action_mask, dim=-1, keepdim=True
         ).exp()
         unclipped_term = seq_logprobs * experience.advantages
-        clipped_term = seq_logprobs.clamp(1 - self.clip_eps_lo, 1 + self.clip_eps_hi) * experience.advantages
+        clipped_term = (
+            seq_logprobs.clamp(1 - self.clip_eps_lo, 1 + self.clip_eps_hi) * experience.advantages
+        )
         policy_loss = -torch.min(unclipped_term, clipped_term)
 
         # Optional KL penalty
@@ -214,9 +222,13 @@ class PPOLoss(nn.Module):
     ) -> torch.Tensor:
         # Value loss with clipping
         values = values.to(log_probs.device)
-        returns = experience.advantages + experience.values_old  # A_t = G_t - V(s_t) => G_t = A_t + V(s_t)
+        returns = (
+            experience.advantages + experience.values_old
+        )  # A_t = G_t - V(s_t) => G_t = A_t + V(s_t)
         values_clipped = torch.clamp(
-            values, experience.values_old - self.clip_eps_val, experience.values_old + self.clip_eps_val
+            values,
+            experience.values_old - self.clip_eps_val,
+            experience.values_old + self.clip_eps_val,
         )
         val_unclipped_term = 0.5 * (returns - values) ** 2
         val_clipped_term = 0.5 * (returns - values_clipped) ** 2

--- a/code/policy_gradients/train.py
+++ b/code/policy_gradients/train.py
@@ -33,7 +33,16 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, GenerationConfig
 
 from .buffer import Experience, ReplayBuffer, join_experiences_batch
 from .config import Config, load_config
-from .loss import CISPOLoss, GRPOLoss, GSPOLoss, PPOLoss, ReinforceLoss, SAPOLoss, approx_kl, masked_mean
+from .loss import (
+    CISPOLoss,
+    GRPOLoss,
+    GSPOLoss,
+    PPOLoss,
+    ReinforceLoss,
+    SAPOLoss,
+    approx_kl,
+    masked_mean,
+)
 from .utils import print_model_info, print_rollout_sample, print_step_header, progress_bar
 
 
@@ -152,12 +161,17 @@ def _format_reward(completions: list[str], **kwargs) -> list[float]:
 
 
 def compute_rewards(
-    dataset: ProceduralDataset, completions: list[str], entries: list[dict], format_weight: float = 0.5
+    dataset: ProceduralDataset,
+    completions: list[str],
+    entries: list[dict],
+    format_weight: float = 0.5,
 ) -> list[float]:
     """Compute combined accuracy + format rewards."""
     accuracy_rewards = _accuracy_reward(dataset, completions, entries)
     format_rewards = _format_reward(completions)
-    combined_rewards = [acc + format_weight * fmt for acc, fmt in zip(accuracy_rewards, format_rewards, strict=True)]
+    combined_rewards = [
+        acc + format_weight * fmt for acc, fmt in zip(accuracy_rewards, format_rewards, strict=True)
+    ]
     return combined_rewards
 
 
@@ -245,7 +259,9 @@ def compute_advantages(
         return rewards
 
 
-def compute_log_probs(model, sequence_ids: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
+def compute_log_probs(
+    model, sequence_ids: torch.Tensor, attention_mask: torch.Tensor
+) -> torch.Tensor:
     """Compute log probabilities for each token in the sequence."""
     if not model:
         return None
@@ -302,7 +318,9 @@ def rollout(
     ).to(model.device)
 
     # 2. Generate responses
-    pad_token_id = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else tokenizer.eos_token_id
+    pad_token_id = (
+        tokenizer.pad_token_id if tokenizer.pad_token_id is not None else tokenizer.eos_token_id
+    )
     generation_config = GenerationConfig(
         temperature=temperature,
         top_p=top_p,
@@ -366,7 +384,9 @@ def main(cfg: Config):
     )
     model, tokenizer = load_model(cfg.model_name, model_device, gradient_checkpointing=True)
     ref_model = get_ref_model(cfg.model_name, ref_model_device, cfg.beta)
-    val_model = get_val_model(cfg.model_name, val_model_device, cfg.loss, gradient_checkpointing=True)
+    val_model = get_val_model(
+        cfg.model_name, val_model_device, cfg.loss, gradient_checkpointing=True
+    )
     objective = get_loss_objective(
         loss=cfg.loss,
         clip_eps_lo=cfg.clip_eps_lo,
@@ -402,7 +422,9 @@ def main(cfg: Config):
 
         with progress_bar(console) as progress:
             entries = [entry for entry in batch for _ in range(cfg.num_rollouts)]
-            task = progress.add_task("Generating rollouts", total=len(entries) // cfg.rollout_batch_size)
+            task = progress.add_task(
+                "Generating rollouts", total=len(entries) // cfg.rollout_batch_size
+            )
 
             for batch in batched(entries, cfg.rollout_batch_size):
                 with torch.no_grad():
@@ -428,8 +450,12 @@ def main(cfg: Config):
                     log_probs_old = compute_log_probs(model, sequence_ids, attention_mask)
                     log_probs_ref = compute_log_probs(ref_model, sequence_ids, attention_mask)
                     values_old = compute_values(val_model, sequence_ids, attention_mask)
-                    rewards = apply_reward_kl(rewards, log_probs_old, log_probs_ref, action_mask, cfg.beta, cfg.loss)
-                    advantages = compute_advantages(rewards, cfg.loss, action_mask, values_old, cfg.gamma, cfg.lam)
+                    rewards = apply_reward_kl(
+                        rewards, log_probs_old, log_probs_ref, action_mask, cfg.beta, cfg.loss
+                    )
+                    advantages = compute_advantages(
+                        rewards, cfg.loss, action_mask, values_old, cfg.gamma, cfg.lam
+                    )
 
                     experience = Experience(
                         sequence_ids=sequence_ids,
@@ -475,8 +501,12 @@ def main(cfg: Config):
                 experience = experience.to(model.device)
 
                 # Compute loss
-                log_probs = compute_log_probs(model, experience.sequence_ids, experience.attention_mask)
-                values = compute_values(val_model, experience.sequence_ids, experience.attention_mask)
+                log_probs = compute_log_probs(
+                    model, experience.sequence_ids, experience.attention_mask
+                )
+                values = compute_values(
+                    val_model, experience.sequence_ids, experience.attention_mask
+                )
                 loss = objective(log_probs=log_probs, experience=experience, values=values)
                 if not loss.isfinite():
                     continue
@@ -485,7 +515,9 @@ def main(cfg: Config):
                 accumulated_loss += loss.item()
 
                 # Update weights every batch_acc steps
-                if (batch_idx + 1) % cfg.batch_acc == 0 or (batch_idx + 1) == len(experience_sampler):
+                if (batch_idx + 1) % cfg.batch_acc == 0 or (batch_idx + 1) == len(
+                    experience_sampler
+                ):
                     grad_norm = clip_grad_norm_(params, max_norm=cfg.max_norm)
                     optimizer.step()
                     optimizer.zero_grad(set_to_none=True)
@@ -494,7 +526,9 @@ def main(cfg: Config):
                     num_accumulated = min(cfg.batch_acc, (batch_idx % cfg.batch_acc) + 1)
                     avg_loss = accumulated_loss / num_accumulated
                     hours_elapsed = (time.time() - start_time) / 3600
-                    wandb.log({"loss": avg_loss, "grad_norm": grad_norm, "hours_elapsed": hours_elapsed})
+                    wandb.log(
+                        {"loss": avg_loss, "grad_norm": grad_norm, "hours_elapsed": hours_elapsed}
+                    )
                     progress.update(task, advance=1, description=f"[dim]Loss: {avg_loss:.4f}[/dim]")
                     accumulated_loss = 0.0
                 else:

--- a/code/rejection_sampling/preprocess.py
+++ b/code/rejection_sampling/preprocess.py
@@ -35,10 +35,7 @@ def load_gsm8k_prompts(cfg: Config) -> list[Prompt]:
     ds = load_dataset(cfg.data.name, cfg.data.subset, split=cfg.data.train_split)
     if cfg.data.max_train_samples is not None:
         ds = ds.select(range(min(cfg.data.max_train_samples, len(ds))))
-    return [
-        {"question": row["question"], "gold": format_gsm8k_gold(row["answer"])}
-        for row in ds
-    ]
+    return [{"question": row["question"], "gold": format_gsm8k_gold(row["answer"])} for row in ds]
 
 
 def _build_generation_chat(question: str, tokenizer) -> str:
@@ -61,9 +58,7 @@ def generate_completions(
     """Generate N completions per prompt, returning an (M, N) list-of-lists."""
     model.eval()
     pad_token_id = (
-        tokenizer.pad_token_id
-        if tokenizer.pad_token_id is not None
-        else tokenizer.eos_token_id
+        tokenizer.pad_token_id if tokenizer.pad_token_id is not None else tokenizer.eos_token_id
     )
     generation_config = GenerationConfig(
         temperature=cfg.temperature,
@@ -170,9 +165,7 @@ def score_rollouts(
         if rm_tokenizer.pad_token_id is not None
         else rm_tokenizer.eos_token_id
     )
-    rewards: list[list[float]] = [
-        [0.0] * cfg.num_completions_per_prompt for _ in prompts
-    ]
+    rewards: list[list[float]] = [[0.0] * cfg.num_completions_per_prompt for _ in prompts]
 
     with progress_bar(console) as progress:
         total_batches = (len(flat) + cfg.score_batch_size - 1) // cfg.score_batch_size
@@ -187,9 +180,7 @@ def score_rollouts(
             input_ids = torch.full(
                 (len(batch), max_len), pad_id, dtype=torch.long, device=rm.device
             )
-            attention_mask = torch.zeros(
-                (len(batch), max_len), dtype=torch.long, device=rm.device
-            )
+            attention_mask = torch.zeros((len(batch), max_len), dtype=torch.long, device=rm.device)
             for row, (_, _, ids) in enumerate(batch):
                 pad_len = max_len - len(ids)
                 input_ids[row, pad_len:] = torch.tensor(ids, dtype=torch.long, device=rm.device)
@@ -322,13 +313,17 @@ def run(cfg: Config) -> Path:
 def load_cached_records(cfg: Config) -> list[dict]:
     path = rollouts_path(cfg)
     if not path.exists():
-        raise FileNotFoundError(f"Rollout cache not found at {path}; run preprocess.run(cfg) first.")
+        raise FileNotFoundError(
+            f"Rollout cache not found at {path}; run preprocess.run(cfg) first."
+        )
     with open(path) as f:
         return [json.loads(line) for line in f if line.strip()]
 
 
 def main_cli() -> None:
-    parser = argparse.ArgumentParser(description="Generate + score rollouts for rejection sampling.")
+    parser = argparse.ArgumentParser(
+        description="Generate + score rollouts for rejection sampling."
+    )
     parser.add_argument("--config", type=str, required=True, help="Path to YAML config file")
     args = parser.parse_args()
     run(load_config(args.config))

--- a/code/rejection_sampling/train.py
+++ b/code/rejection_sampling/train.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import torch
 import torch.nn.functional as F
 import torch.optim as optim
+import wandb
 from datasets import load_dataset
 from rich.console import Console
 from rich.panel import Panel
@@ -17,7 +18,6 @@ from rich.table import Table
 from torch.nn.utils import clip_grad_norm_
 from torch.utils.data import DataLoader, Dataset
 
-import wandb
 from policy_gradients.train import get_attn_implementation, load_model, seed_everything
 from policy_gradients.utils import print_model_info, print_step_header, progress_bar
 
@@ -104,9 +104,7 @@ def sft(
     """Full-parameter causal-LM SFT on the selected rejection-sampling pairs."""
     dataset = SFTDataset(selected_pairs, tokenizer, cfg.max_seq_length)
     pad_id = (
-        tokenizer.pad_token_id
-        if tokenizer.pad_token_id is not None
-        else tokenizer.eos_token_id
+        tokenizer.pad_token_id if tokenizer.pad_token_id is not None else tokenizer.eos_token_id
     )
     dataloader = DataLoader(
         dataset=dataset,
@@ -170,9 +168,7 @@ def sft(
                             "hours_elapsed": hours_elapsed,
                         }
                     )
-                    progress.update(
-                        task, advance=1, description=f"[dim]Loss: {avg_loss:.4f}[/dim]"
-                    )
+                    progress.update(task, advance=1, description=f"[dim]Loss: {avg_loss:.4f}[/dim]")
                     accumulated_loss = 0.0
                     global_step += 1
                 else:
@@ -204,15 +200,12 @@ def evaluate(cfg: Config, model, tokenizer, console: Console) -> float:
         ds = ds.select(range(min(cfg.data.max_test_samples, len(ds))))
 
     eval_rows = [
-        {"question": row["question"], "gold": format_gsm8k_gold(row["answer"])}
-        for row in ds
+        {"question": row["question"], "gold": format_gsm8k_gold(row["answer"])} for row in ds
     ]
 
     model.eval()
     pad_id = (
-        tokenizer.pad_token_id
-        if tokenizer.pad_token_id is not None
-        else tokenizer.eos_token_id
+        tokenizer.pad_token_id if tokenizer.pad_token_id is not None else tokenizer.eos_token_id
     )
 
     correct = 0
@@ -306,7 +299,8 @@ def main(cfg: Config) -> None:
     else:
         wandb.init(
             project=wandb_project,
-            name=os.environ.get("WANDB_RUN_NAME", cfg.wandb_run_name) or f"rs-{cfg.selection.strategy}",
+            name=os.environ.get("WANDB_RUN_NAME", cfg.wandb_run_name)
+            or f"rs-{cfg.selection.strategy}",
             config=cfg.model_dump(),
         )
     wandb.log(
@@ -344,7 +338,9 @@ def main(cfg: Config) -> None:
 
 
 def main_cli() -> None:
-    parser = argparse.ArgumentParser(description="Rejection sampling: selection + SFT + GSM8k eval.")
+    parser = argparse.ArgumentParser(
+        description="Rejection sampling: selection + SFT + GSM8k eval."
+    )
     parser.add_argument("--config", type=str, required=True, help="Path to YAML config file")
     args = parser.parse_args()
     main(load_config(args.config))

--- a/code/rejection_sampling/utils.py
+++ b/code/rejection_sampling/utils.py
@@ -12,9 +12,7 @@ from .config import Config
 
 # AceMath-7B-RM is trained on solutions in this format, so we must use the
 # same system prompt at generation time for the scores to be meaningful.
-ACEMATH_SYSTEM_PROMPT = (
-    "Please reason step by step, and check your final answer within \\boxed{}."
-)
+ACEMATH_SYSTEM_PROMPT = "Please reason step by step, and check your final answer within \\boxed{}."
 
 
 def free_memory(*objs) -> None:
@@ -59,7 +57,9 @@ def cache_key(cfg: Config) -> str:
 
 def format_gsm8k_gold(answer_field: str) -> str:
     """GSM8k gold answers live after `####` at the end of the CoT."""
-    gold = answer_field.split("####", 1)[1].strip() if "####" in answer_field else answer_field.strip()
+    gold = (
+        answer_field.split("####", 1)[1].strip() if "####" in answer_field else answer_field.strip()
+    )
     return gold.replace(",", "")
 
 

--- a/code/reward_models/base.py
+++ b/code/reward_models/base.py
@@ -9,7 +9,7 @@ Note: We use full fine-tuning for simplicity with small models (0.6B-1.7B).
 """
 
 import os
-from typing import Callable, Iterator
+from typing import Callable
 
 import torch
 import torch.nn as nn
@@ -222,7 +222,13 @@ def training_loop(
         avg_loss = epoch_loss / len(loader)
         avg_metrics = {k: v / len(loader) for k, v in epoch_metrics.items()}
         print(f"Epoch {epoch} | Loss: {avg_loss:.4f} | {avg_metrics}")
-        log_metrics({"epoch_loss": avg_loss, "epoch": epoch, **{f"epoch_{k}": v for k, v in avg_metrics.items()}})
+        log_metrics(
+            {
+                "epoch_loss": avg_loss,
+                "epoch": epoch,
+                **{f"epoch_{k}": v for k, v in avg_metrics.items()},
+            }
+        )
 
 
 # =============================================================================
@@ -254,6 +260,7 @@ def create_collate_fn(tokenizer: AutoTokenizer, fields: list[str]):
         fields: List of field names to collate. Fields ending in '_ids' use
                 pad_token_id, fields ending in '_mask' use 0, others use -100.
     """
+
     def collate_fn(batch: list[dict]) -> dict[str, torch.Tensor]:
         result = {}
         for field in fields:

--- a/code/reward_models/train_orm.py
+++ b/code/reward_models/train_orm.py
@@ -25,7 +25,6 @@ import random
 from typing import Dict, List
 
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
 from datasets import Dataset, load_dataset
 from torch.utils.data import DataLoader
@@ -92,7 +91,9 @@ def pack_example(
     The label is applied to all completion tokens, with prompt tokens masked (-100).
     """
     prompt_ids = tokenizer(prompt, add_special_tokens=False)["input_ids"]
-    completion_ids = tokenizer(completion + tokenizer.eos_token, add_special_tokens=False)["input_ids"]
+    completion_ids = tokenizer(completion + tokenizer.eos_token, add_special_tokens=False)[
+        "input_ids"
+    ]
     input_ids = prompt_ids + completion_ids
     attention = [1] * len(input_ids)
     labels = [-100] * len(prompt_ids) + [label] * len(completion_ids)
@@ -277,9 +278,11 @@ def train_orm(
     optimizer = create_optimizer(model, lr)
     total_optimizer_steps = -(-len(loader) // grad_accum_steps) * epochs
     warmup_steps = int(total_optimizer_steps * warmup_ratio)
-    scheduler = torch.optim.lr_scheduler.LinearLR(
-        optimizer, start_factor=0.1, total_iters=warmup_steps
-    ) if warmup_steps > 0 else None
+    scheduler = (
+        torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, total_iters=warmup_steps)
+        if warmup_steps > 0
+        else None
+    )
 
     # Mixed precision
     autocast_enabled = torch.cuda.is_available()
@@ -429,12 +432,21 @@ def main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument("--model-id", type=str, default=DEFAULT_MODEL_ID, help="Base model ID")
-    parser.add_argument("--samples", type=int, default=DEFAULT_SAMPLES, help="Number of training samples")
+    parser.add_argument(
+        "--samples", type=int, default=DEFAULT_SAMPLES, help="Number of training samples"
+    )
     parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE, help="Batch size")
-    parser.add_argument("--grad-accum", type=int, default=DEFAULT_GRAD_ACCUM, help="Gradient accumulation steps")
+    parser.add_argument(
+        "--grad-accum", type=int, default=DEFAULT_GRAD_ACCUM, help="Gradient accumulation steps"
+    )
     parser.add_argument("--epochs", type=int, default=DEFAULT_EPOCHS, help="Training epochs")
     parser.add_argument("--lr", type=float, default=DEFAULT_LR, help="Learning rate")
-    parser.add_argument("--warmup-ratio", type=float, default=DEFAULT_WARMUP_RATIO, help="Fraction of steps for LR warmup")
+    parser.add_argument(
+        "--warmup-ratio",
+        type=float,
+        default=DEFAULT_WARMUP_RATIO,
+        help="Fraction of steps for LR warmup",
+    )
     parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="Random seed")
     parser.add_argument("--skip-demo", action="store_true", help="Skip scoring demo after training")
     parser.add_argument("--no-wandb", action="store_true", help="Disable wandb logging")

--- a/code/reward_models/train_preference_rm.py
+++ b/code/reward_models/train_preference_rm.py
@@ -122,12 +122,14 @@ def build_preference_dataset(
             add_special_tokens=True,
         )
 
-        records.append({
-            "chosen_ids": chosen_tokens["input_ids"],
-            "chosen_mask": chosen_tokens["attention_mask"],
-            "rejected_ids": rejected_tokens["input_ids"],
-            "rejected_mask": rejected_tokens["attention_mask"],
-        })
+        records.append(
+            {
+                "chosen_ids": chosen_tokens["input_ids"],
+                "chosen_mask": chosen_tokens["attention_mask"],
+                "rejected_ids": rejected_tokens["input_ids"],
+                "rejected_mask": rejected_tokens["attention_mask"],
+            }
+        )
 
     return Dataset.from_list(records)
 
@@ -277,9 +279,11 @@ def train_preference_rm(
     optimizer = create_optimizer(model, lr)
     total_optimizer_steps = -(-len(loader) // grad_accum_steps) * epochs
     warmup_steps = int(total_optimizer_steps * warmup_ratio)
-    scheduler = torch.optim.lr_scheduler.LinearLR(
-        optimizer, start_factor=0.1, total_iters=warmup_steps
-    ) if warmup_steps > 0 else None
+    scheduler = (
+        torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, total_iters=warmup_steps)
+        if warmup_steps > 0
+        else None
+    )
 
     # Mixed precision
     autocast_enabled = torch.cuda.is_available()
@@ -335,13 +339,16 @@ def train_preference_rm(
                 avg_loss = accum_loss / mb
                 acc = accum_correct / n
                 print(f"Epoch {epoch} step {global_step} | loss {avg_loss:.4f} | acc {acc:.3f}")
-                log_metrics({
-                    "loss": avg_loss,
-                    "accuracy": acc,
-                    "r_chosen_mean": accum_r_chosen / mb,
-                    "r_rejected_mean": accum_r_rejected / mb,
-                    "reward_margin": (accum_r_chosen - accum_r_rejected) / mb,
-                }, step=global_step)
+                log_metrics(
+                    {
+                        "loss": avg_loss,
+                        "accuracy": acc,
+                        "r_chosen_mean": accum_r_chosen / mb,
+                        "r_rejected_mean": accum_r_rejected / mb,
+                        "reward_margin": (accum_r_chosen - accum_r_rejected) / mb,
+                    },
+                    step=global_step,
+                )
 
                 # Reset accumulators
                 accum_loss = 0.0
@@ -416,13 +423,24 @@ def main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument("--model-id", type=str, default=DEFAULT_MODEL_ID, help="Base model ID")
-    parser.add_argument("--samples", type=int, default=DEFAULT_SAMPLES, help="Number of preference pairs")
+    parser.add_argument(
+        "--samples", type=int, default=DEFAULT_SAMPLES, help="Number of preference pairs"
+    )
     parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE, help="Batch size")
-    parser.add_argument("--grad-accum", type=int, default=DEFAULT_GRAD_ACCUM, help="Gradient accumulation steps")
-    parser.add_argument("--max-length", type=int, default=DEFAULT_MAX_LENGTH, help="Max sequence length")
+    parser.add_argument(
+        "--grad-accum", type=int, default=DEFAULT_GRAD_ACCUM, help="Gradient accumulation steps"
+    )
+    parser.add_argument(
+        "--max-length", type=int, default=DEFAULT_MAX_LENGTH, help="Max sequence length"
+    )
     parser.add_argument("--epochs", type=int, default=DEFAULT_EPOCHS, help="Training epochs")
     parser.add_argument("--lr", type=float, default=DEFAULT_LR, help="Learning rate")
-    parser.add_argument("--warmup-ratio", type=float, default=DEFAULT_WARMUP_RATIO, help="Fraction of steps for LR warmup")
+    parser.add_argument(
+        "--warmup-ratio",
+        type=float,
+        default=DEFAULT_WARMUP_RATIO,
+        help="Fraction of steps for LR warmup",
+    )
     parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="Random seed")
     parser.add_argument("--skip-demo", action="store_true", help="Skip scoring demo after training")
     parser.add_argument("--no-wandb", action="store_true", help="Disable wandb logging")

--- a/code/reward_models/train_prm.py
+++ b/code/reward_models/train_prm.py
@@ -195,7 +195,7 @@ def build_prm_dataset(
             attention_mask = [1] * len(input_ids)
             label_ids = [-100] * len(input_ids)
 
-            for step_text, lbl in zip(chunk_steps, chunk_labels):
+            for step_text, lbl in zip(chunk_steps, chunk_labels, strict=True):
                 step_payload = step_text.strip() + STEP_SEPARATOR
                 encoded = tokenizer(step_payload, add_special_tokens=False)["input_ids"]
                 input_ids.extend(encoded)
@@ -211,11 +211,13 @@ def build_prm_dataset(
             if len(input_ids) > max_tokens_per_sample:
                 continue
 
-            records.append({
-                "input_ids": input_ids,
-                "attention_mask": attention_mask,
-                "labels": label_ids,
-            })
+            records.append(
+                {
+                    "input_ids": input_ids,
+                    "attention_mask": attention_mask,
+                    "labels": label_ids,
+                }
+            )
 
     if not records:
         raise ValueError("No PRM examples loaded. Check dataset path/permissions.")
@@ -366,9 +368,11 @@ def train_prm(
     optimizer = create_optimizer(model, lr)
     total_optimizer_steps = -(-len(loader) // grad_accum_steps) * epochs
     warmup_steps = int(total_optimizer_steps * warmup_ratio)
-    scheduler = torch.optim.lr_scheduler.LinearLR(
-        optimizer, start_factor=0.1, total_iters=warmup_steps
-    ) if warmup_steps > 0 else None
+    scheduler = (
+        torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, total_iters=warmup_steps)
+        if warmup_steps > 0
+        else None
+    )
 
     # Mixed precision for memory efficiency
     autocast_enabled = torch.cuda.is_available()
@@ -518,7 +522,9 @@ def demo_scoring(model: ProcessRewardModel, tokenizer: AutoTokenizer, seed: int 
 
     scores = score_trace(model, tokenizer, problem, steps, device)
 
-    for idx, (step_text, true_label, step_scores) in enumerate(zip(steps, labels, scores)):
+    for idx, (step_text, true_label, step_scores) in enumerate(
+        zip(steps, labels, scores, strict=True)
+    ):
         label_name = true_label
         pred_class = max(step_scores, key=step_scores.get)
         print(f"\nStep {idx} (true label: {label_name}, predicted: {pred_class}):")
@@ -537,12 +543,21 @@ def main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument("--model-id", type=str, default=DEFAULT_MODEL_ID, help="Base model ID")
-    parser.add_argument("--samples", type=int, default=DEFAULT_SAMPLES, help="Number of training samples")
+    parser.add_argument(
+        "--samples", type=int, default=DEFAULT_SAMPLES, help="Number of training samples"
+    )
     parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE, help="Batch size")
-    parser.add_argument("--grad-accum", type=int, default=DEFAULT_GRAD_ACCUM, help="Gradient accumulation steps")
+    parser.add_argument(
+        "--grad-accum", type=int, default=DEFAULT_GRAD_ACCUM, help="Gradient accumulation steps"
+    )
     parser.add_argument("--epochs", type=int, default=DEFAULT_EPOCHS, help="Training epochs")
     parser.add_argument("--lr", type=float, default=DEFAULT_LR, help="Learning rate")
-    parser.add_argument("--warmup-ratio", type=float, default=DEFAULT_WARMUP_RATIO, help="Fraction of steps for LR warmup")
+    parser.add_argument(
+        "--warmup-ratio",
+        type=float,
+        default=DEFAULT_WARMUP_RATIO,
+        help="Fraction of steps for LR warmup",
+    )
     parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="Random seed")
     parser.add_argument("--skip-demo", action="store_true", help="Skip scoring demo after training")
     parser.add_argument("--no-wandb", action="store_true", help="Disable wandb logging")


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow (`.github/workflows/lint.yml`) that runs `ruff check` and `ruff format --check` on PRs touching `code/`
- Applies `ruff format` to all 16 files that needed it and fixes 10 lint errors (unused imports, unsorted imports, f-string without placeholders, `zip()` without `strict=`)
- Documents the linting setup in `code/README.md`

## Test plan
- [ ] Verify CI workflow runs on this PR (it touches `code/`)
- [ ] Confirm `ruff check` and `ruff format --check` pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)