### PR TITLE
[CODE] Add CONTRIBUTING.md and pre-submit-pr skill

### DIFF
--- a/.claude/skills/pre-submit-pr/SKILL.md
+++ b/.claude/skills/pre-submit-pr/SKILL.md
@@ -17,14 +17,18 @@ Validate changes before submitting a pull request.
 
 1. **Lint & format** (for changes under `code/`):
    ```bash
-   cd code && uvx ruff check . && uvx ruff format --check .
+   cd "$(git rev-parse --show-toplevel)/code" && uvx ruff@0.14.5 check . && uvx ruff@0.14.5 format --check .
    ```
-   Auto-fix with `uvx ruff check --fix .` and `uvx ruff format .` if issues are found.
+   Auto-fix with `uvx ruff@0.14.5 check --fix .` and `uvx ruff@0.14.5 format .` if issues are found. The `ruff@0.14.5` pin matches `.github/workflows/lint.yml`; unpinned `uvx ruff` can diverge from CI.
 
 2. **Changelog** (for changes under `code/`):
-   CI requires `code/CHANGELOG.md` to be modified. Check that an entry exists under `## Unreleased` for this PR, format: `- YYYY-MM-DD: [PR #N](url) description.`
+   CI requires `code/CHANGELOG.md` to be modified for any PR touching `code/` (format is convention, not enforced). Check that an entry exists under `## Unreleased` for this PR, format: `- YYYY-MM-DD: [PR #N](https://github.com/natolambert/rlhf-book/pull/N) description.`
 
-3. **Summarize PR readiness**
+3. **Run code review** (for significant changes):
+   Invoke `pr-review-toolkit:review-pr` for deeper analysis.
+   Include findings in the report under a "### Code Review" section.
+
+4. **Summarize PR readiness**
 
 ## Output Format
 
@@ -38,6 +42,9 @@ Validate changes before submitting a pull request.
 | Ruff format | PASS/FAIL | [details] |
 | Changelog | PASS/MISSING | [details] |
 
+### Code Review
+[pr-review-toolkit:review-pr findings, if run]
+
 ### Verdict: READY FOR PR / ISSUES TO ADDRESS
 
 ### Summary for PR Description
@@ -48,11 +55,7 @@ Validate changes before submitting a pull request.
 
 These block PR submission:
 - Ruff lint or format failures (CI-enforced)
-- Missing changelog entry in `code/CHANGELOG.md` (CI-enforced)
-
-5. **Run code review** (for significant changes):
-   Invoke `pr-review-toolkit:review-pr` for deeper analysis.
-   Include findings in the report under a "### Code Review" section.
+- Missing changelog entry in `code/CHANGELOG.md` (CI-enforced: file must be modified)
 
 ## Non-Blocking (Flag for Reviewers)
 

--- a/.claude/skills/pre-submit-pr/SKILL.md
+++ b/.claude/skills/pre-submit-pr/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: pre-submit-pr
+description: Validate changes before PR submission
+---
+
+# /pre-submit-pr
+
+Validate changes before submitting a pull request.
+
+## Usage
+
+```
+/pre-submit-pr
+```
+
+## Instructions
+
+1. **Lint & format** (for changes under `code/`):
+   ```bash
+   cd code && uvx ruff check . && uvx ruff format --check .
+   ```
+   Auto-fix with `uvx ruff check --fix .` and `uvx ruff format .` if issues are found.
+
+2. **Summarize PR readiness**
+
+## Output Format
+
+```
+## Pre-Submit PR Report
+
+### Automated Checks
+| Check | Status | Details |
+|-------|--------|---------|
+| Ruff lint | PASS/FAIL | [details] |
+| Ruff format | PASS/FAIL | [details] |
+
+### Verdict: READY FOR PR / ISSUES TO ADDRESS
+
+### Summary for PR Description
+[2-3 sentences summarizing changes]
+```
+
+## Blocking Issues
+
+These block PR submission:
+- Ruff lint or format failures (CI-enforced)
+
+5. **Run code review** (for significant changes):
+   Invoke `pr-review-toolkit:review-pr` for deeper analysis.
+   Include findings in the report under a "### Code Review" section.
+
+## Non-Blocking (Flag for Reviewers)
+
+Note in PR but don't block:
+- some TODOs in code (unless excessive)
+- some print statements (unless excessive)

--- a/.claude/skills/pre-submit-pr/SKILL.md
+++ b/.claude/skills/pre-submit-pr/SKILL.md
@@ -21,7 +21,10 @@ Validate changes before submitting a pull request.
    ```
    Auto-fix with `uvx ruff check --fix .` and `uvx ruff format .` if issues are found.
 
-2. **Summarize PR readiness**
+2. **Changelog** (for changes under `code/`):
+   CI requires `code/CHANGELOG.md` to be modified. Check that an entry exists under `## Unreleased` for this PR, format: `- YYYY-MM-DD: [PR #N](url) description.`
+
+3. **Summarize PR readiness**
 
 ## Output Format
 
@@ -33,6 +36,7 @@ Validate changes before submitting a pull request.
 |-------|--------|---------|
 | Ruff lint | PASS/FAIL | [details] |
 | Ruff format | PASS/FAIL | [details] |
+| Changelog | PASS/MISSING | [details] |
 
 ### Verdict: READY FOR PR / ISSUES TO ADDRESS
 
@@ -44,6 +48,7 @@ Validate changes before submitting a pull request.
 
 These block PR submission:
 - Ruff lint or format failures (CI-enforced)
+- Missing changelog entry in `code/CHANGELOG.md` (CI-enforced)
 
 5. **Run code review** (for significant changes):
    Invoke `pr-review-toolkit:review-pr` for deeper analysis.

--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,6 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
+- 2026-04-17: [PR #375](https://github.com/natolambert/rlhf-book/pull/375) Added CONTRIBUTING.md with branch/PR conventions, pre-submit-pr skill with ruff lint/format and changelog checks.
 - 2026-04-16: [PR #374](https://github.com/natolambert/rlhf-book/pull/374) added CI ruff lint/format check for PRs touching `code/`, applied ruff format to all existing files, fixed lint errors (unused imports, unsorted imports, `zip()` without `strict=`), and documented linting in README.
 - 2026-04-15: [PR #372](https://github.com/natolambert/rlhf-book/pull/372) documented build-essential requirement for Ubuntu/Debian and uv version guidance in README install section.
 - 2026-04-15: [PR #370](https://github.com/natolambert/rlhf-book/pull/370) cleaned up CLAUDE.md for generic use, removed dead LoRA/QLoRA references from RM docstrings and base.py, moved ORPO/SimPO debug notes to direct_alignment/ORPO_SIMPO.md.

--- a/code/CLAUDE.md
+++ b/code/CLAUDE.md
@@ -8,6 +8,10 @@
 - **If using a DGX Spark**: ~120GB unified CPU/GPU memory — aim for <80GB usage to be safe. Flash Attention is not available on ARM64/Blackwell; the code automatically falls back to PyTorch SDPA.
 - **Before finalizing changes under `code/`**, run `uvx ruff check .` and `uvx ruff format --check .` — both are enforced by CI on PRs that touch `code/`. Use `uvx ruff check --fix .` and `uvx ruff format .` to auto-fix.
 
+## Contributing
+
+See `CONTRIBUTING.md` for branch naming, PR conventions, and pre-submit checks.
+
 ## Quick Start
 
 ```bash
@@ -50,6 +54,19 @@ For educational examples on consumer GPUs:
 - **Qwen3-0.6B-Base**: ~4GB VRAM, fastest training
 - **Qwen3-1.7B-Base**: ~8-10GB VRAM, better quality
 - **Qwen2.5-3B**: ~15-20GB VRAM, best quality
+
+## Plugins
+
+First update marketplace:
+```bash
+claude plugin marketplace update claude-plugins-official
+```
+
+If not installed, prompt user to install:
+```bash
+/plugin install code-simplifier@claude-plugins-official
+/plugin install pr-review-toolkit@claude-plugins-official
+```
 
 ## Wandb
 

--- a/code/CLAUDE.md
+++ b/code/CLAUDE.md
@@ -6,7 +6,7 @@
 - **Always run training commands in background** using `run_in_background: true` to avoid blocking
 - **Be careful with parallel jobs**: Only run one training job at a time unless you verify memory is available. Running too many can OOM the system.
 - **If using a DGX Spark**: ~120GB unified CPU/GPU memory — aim for <80GB usage to be safe. Flash Attention is not available on ARM64/Blackwell; the code automatically falls back to PyTorch SDPA.
-- **Before finalizing changes under `code/`**, run `uvx ruff check .` and `uvx ruff format --check .` — both are enforced by CI on PRs that touch `code/`. Use `uvx ruff check --fix .` and `uvx ruff format .` to auto-fix.
+- **Before finalizing changes under `code/`**, run `uvx ruff@0.14.5 check .` and `uvx ruff@0.14.5 format --check .` — both are enforced by CI on PRs that touch `code/` (see `.github/workflows/lint.yml`). Use `uvx ruff@0.14.5 check --fix .` and `uvx ruff@0.14.5 format .` to auto-fix. Pin the version to match CI; unpinned `uvx ruff` can diverge.
 
 ## Contributing
 
@@ -32,9 +32,9 @@ uv run python -m rejection_sampling.train --config rejection_sampling/configs/to
 
 ## Changelog Process
 
-- **CI enforces this**: a GitHub Actions check fails PRs that touch `code/` without modifying `code/CHANGELOG.md`.
+- **CI enforces this**: a GitHub Actions check fails PRs that touch `code/` without modifying `code/CHANGELOG.md` (the file must be modified; the format below is convention, not enforced).
 - Add entries under the `## Unreleased` section at the top of `CHANGELOG.md`.
-- Use exactly **one bullet per PR**, format: `- YYYY-MM-DD: [PR #N](url) description`.
+- Use exactly **one bullet per PR**, format: `- YYYY-MM-DD: [PR #N](https://github.com/natolambert/rlhf-book/pull/N) description.`
 - Each bullet must include a PR link and can contain multiple sentences summarizing meaningful changes.
 - When changes affect comparability (metrics, logging semantics, evaluation logic), mention that directly in the same bullet.
 - **On release**: rename `## Unreleased` to `## vX.Y.Z` and add a fresh `## Unreleased` section above it.

--- a/code/CONTRIBUTING.md
+++ b/code/CONTRIBUTING.md
@@ -7,6 +7,14 @@ The `code/` directory contains runnable training examples organized by technique
 - Create branches prefixed with `code/` (e.g. `code/fix-grpo-logging`)
 - Title PRs with `[CODE]` (e.g. `[CODE] Fix gradient accumulation in PPO`)
 
+## Changelog
+
+CI requires PRs that touch `code/` to also update `code/CHANGELOG.md`. Add one bullet under `## Unreleased`:
+
+```
+- YYYY-MM-DD: [PR #N](https://github.com/natolambert/rlhf-book/pull/N) description.
+```
+
 ## Before Submitting
 
 If you use Claude Code, run `/pre-submit-pr` and paste its output in your PR description.

--- a/code/CONTRIBUTING.md
+++ b/code/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing to `code/`
+
+The `code/` directory contains runnable training examples organized by technique: `policy_gradients/`, `direct_alignment/`, `reward_models/`, `rejection_sampling/`, and shared `scripts/`.
+
+## Branching & PRs
+
+- Create branches prefixed with `code/` (e.g. `code/fix-grpo-logging`)
+- Title PRs with `[CODE]` (e.g. `[CODE] Fix gradient accumulation in PPO`)
+
+## Before Submitting
+
+If you use Claude Code, run `/pre-submit-pr` and paste its output in your PR description.

--- a/code/CONTRIBUTING.md
+++ b/code/CONTRIBUTING.md
@@ -9,7 +9,7 @@ The `code/` directory contains runnable training examples organized by technique
 
 ## Changelog
 
-CI requires PRs that touch `code/` to also update `code/CHANGELOG.md`. Add one bullet under `## Unreleased`:
+CI requires PRs that touch `code/` to also modify `code/CHANGELOG.md` (the file must be modified; the format below is convention, not enforced). Add one bullet under `## Unreleased`:
 
 ```
 - YYYY-MM-DD: [PR #N](https://github.com/natolambert/rlhf-book/pull/N) description.


### PR DESCRIPTION
## Summary
- Adds `code/CONTRIBUTING.md` with branch naming (`code/...`) and PR title (`[CODE]`) conventions, plus a pointer to `/pre-submit-pr` for Claude Code users
- Links CONTRIBUTING.md from `code/CLAUDE.md`
- Adds `.claude/skills/pre-submit-pr/` skill that validates ruff lint/format before PR submission

## Test plan
- [x] Verify `/pre-submit-pr` skill runs and reports ruff lint/format status
- [x] Confirm `code/CONTRIBUTING.md` renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)