### PR TITLE
[book][minor] adding HF TRL to compatible frameworks for TIS

### DIFF
--- a/book/chapters/06-policy-gradients.md
+++ b/book/chapters/06-policy-gradients.md
@@ -991,7 +991,7 @@ per_token_pg_loss = per_token_pg_loss * tis_weight.detach()
 The $[-10, 10]$ clamp is only for numerical stability before exponentiation; the actual truncated-importance-sampling step is the one-sided cap at $C$.
 In practice, the bookkeeping around these logprobs — storing sampler logprobs from generation, recomputing learner logprobs at the old checkpoint, and tracking current logprobs during gradient steps — is a substantial part of the scaffolding in distributed RL frameworks.
 Unlike GSPO, this correction is token-level because it addresses token-level numerical mismatch rather than sequence-level reward granularity.
-TIS for the learner–sampler ratio has been adopted across major open-source RL frameworks (VeRL, OpenRLHF, SkyRL, OAT, and Open Instruct, which uses $C = 2$), and becomes increasingly important for long reasoning traces (Chapter 7), where small per-token differences compound over thousands of generated tokens.
+TIS for the learner–sampler ratio has been adopted across major open-source RL frameworks (VeRL, TRL, OpenRLHF, SkyRL, OAT, and Open Instruct, which uses $C = 2$), and becomes increasingly important for long reasoning traces (Chapter 7), where small per-token differences compound over thousands of generated tokens.
 
 
 ### Example: Proximal Policy Optimization


### PR DESCRIPTION
Hello, this is just a nit. In CH6 under the TIS section, there's a list of RL frameworks that implement TIS.

I just wanted to explicitly add HuggingFace's TRL to the list, since it was also implemented some time ago, readers might be interested to know it's there too.

(Btw, TRL also supports MIS and soon, I hope, complete bidirectional (both sides, not just upper cap) MIS or TIS https://github.com/huggingface/trl/pull/4732 used in ring1T, MimoV2, Kimi K2, GLM5, Nemotron3-super, to name a few OSS SOTAs I’m aware of.)