### PR TITLE
Extract site footer into a single partial

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,12 +97,15 @@ response = model.generate_content([
 
 ## Footer Convention
 
-The site footer (citation block + logos + copyright) appears in three templates:
-- `book/templates/html.html` — **source of truth** (index page)
-- `book/templates/chapter.html` — chapter pages (uses h4 instead of h3 for Citation heading)
-- `book/templates/library.html` — library standalone page (uses h4 instead of h3)
+The site footer (logos + copyright line) lives in `book/templates/footer.html` and is included by all three page templates:
 
-When updating the footer, edit `html.html` first, then copy the changes to `chapter.html` and `library.html`. The only difference is the Citation heading level (h3 on index, h4 on chapters/library).
+- `book/templates/html.html` (index) includes it via the Pandoc partial `$footer.html()$`
+- `book/templates/chapter.html` (chapter pages) includes it via `$footer.html()$`
+- `book/templates/library.html` (standalone page, copied as-is to build/) includes it via the HTML sentinel `<!-- include: footer.html -->`, which the Makefile's `library.html` rule expands with `awk` on build
+
+To update the footer, edit `book/templates/footer.html`. That's it.
+
+The Citation block (which has a different heading level across pages — h3 on index, h4 on chapters/library) is **not** part of the footer partial and remains inline in each template.
 
 ## Style Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,15 +97,20 @@ response = model.generate_content([
 
 ## Footer Convention
 
-The site footer (logos + copyright line) lives in `book/templates/footer.html` and is included by all three page templates:
+The site footer (logos + copyright line) lives in `book/templates/footer.html` and is included by every page template on rlhfbook.com:
 
-- `book/templates/html.html` (index) includes it via the Pandoc partial `$footer.html()$`
-- `book/templates/chapter.html` (chapter pages) includes it via `$footer.html()$`
-- `book/templates/library.html` (standalone page, copied as-is to build/) includes it via the HTML sentinel `<!-- include: footer.html -->`, which the Makefile's `library.html` rule expands with `awk` on build
+- `book/templates/html.html` (index) — included via the Pandoc partial `$footer.html()$`
+- `book/templates/chapter.html` (chapter pages) — included via `$footer.html()$`
+- `book/templates/library.html` (standalone page, copied to build/) — included via the HTML sentinel `<!-- include: footer.html -->`
+- `book/templates/course.html` (copied to build/) — sentinel
+- `book/templates/404.html` (copied to build/ by the `files` target) — sentinel
+- `book/rl-cheatsheet/index.html` (copied to build/) — sentinel
+
+The sentinels are expanded at build time by the `$(INLINE_FOOTER)` awk command defined in the Makefile. Pandoc-templated pages use its native partial syntax.
 
 To update the footer, edit `book/templates/footer.html`. That's it.
 
-The Citation block (which has a different heading level across pages — h3 on index, h4 on chapters/library) is **not** part of the footer partial and remains inline in each template.
+The Citation block (which has a different heading level across pages — h3 on index, h4 on chapters/library) is **not** part of the footer partial and remains inline in each template. Footer asset paths are absolute (`/assets/...`) so they resolve correctly even when 404.html is served as a fallback on an arbitrary URL.
 
 ## Style Notes
 

--- a/Makefile
+++ b/Makefile
@@ -158,9 +158,9 @@ $(BUILD)/html/$(OUTPUT_FILENAME_HTML).html:	$(HTML_DEPENDENCIES)
 	@test -f book/data/library.json && cp book/data/library.json $(BUILD)/html/data/library.json || echo "No library data to copy"
 	$(ECHO_BUILT)
 
-$(BUILD)/html/library.html: book/templates/library.html
+$(BUILD)/html/library.html: book/templates/library.html book/templates/footer.html
 	$(MKDIR_CMD) $(BUILD)/html
-	cp book/templates/library.html $@
+	awk '/<!-- include: footer\.html -->/{while((getline line < "book/templates/footer.html")>0) print line; next}{print}' book/templates/library.html > $@
 
 $(BUILD)/html/course.html: book/templates/course.html
 	$(MKDIR_CMD) $(BUILD)/html

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ DATE_ARG = --metadata date="$(shell date +'%d %B %Y')"
 CONTENT = awk 'FNR==1 && NR!=1 {print "\n\n"}{print}' $(CHAPTERS)
 CONTENT_FILTERS = tee # Use this to add sed filters or other piped commands
 
+# Expands `<!-- include: footer.html -->` sentinels in static HTML pages that
+# are copied (rather than run through pandoc) to build/. Keeps all site
+# footers in sync with book/templates/footer.html.
+INLINE_FOOTER = awk '/<!-- include: footer\.html -->/{while((getline line < "book/templates/footer.html")>0) print line; next}{print}'
+FOOTER_PARTIAL = book/templates/footer.html
+
 # Debugging
 
 DEBUG_ARGS = --verbose
@@ -158,19 +164,19 @@ $(BUILD)/html/$(OUTPUT_FILENAME_HTML).html:	$(HTML_DEPENDENCIES)
 	@test -f book/data/library.json && cp book/data/library.json $(BUILD)/html/data/library.json || echo "No library data to copy"
 	$(ECHO_BUILT)
 
-$(BUILD)/html/library.html: book/templates/library.html book/templates/footer.html
+$(BUILD)/html/library.html: book/templates/library.html $(FOOTER_PARTIAL)
 	$(MKDIR_CMD) $(BUILD)/html
-	awk '/<!-- include: footer\.html -->/{while((getline line < "book/templates/footer.html")>0) print line; next}{print}' book/templates/library.html > $@
+	$(INLINE_FOOTER) book/templates/library.html > $@
 
-$(BUILD)/html/course.html: book/templates/course.html
+$(BUILD)/html/course.html: book/templates/course.html $(FOOTER_PARTIAL)
 	$(MKDIR_CMD) $(BUILD)/html
-	cp book/templates/course.html $@
+	$(INLINE_FOOTER) book/templates/course.html > $@
 
 rl-cheatsheet: $(BUILD)/html/rl-cheatsheet/inside_cover_back.pdf
 
-$(BUILD)/html/rl-cheatsheet/inside_cover_back.pdf: book/rl-cheatsheet/inside_cover_back.tex book/rl-cheatsheet/index.html
+$(BUILD)/html/rl-cheatsheet/inside_cover_back.pdf: book/rl-cheatsheet/inside_cover_back.tex book/rl-cheatsheet/index.html $(FOOTER_PARTIAL)
 	mkdir -p $(BUILD)/html/rl-cheatsheet
-	cp book/rl-cheatsheet/index.html $(BUILD)/html/rl-cheatsheet/
+	$(INLINE_FOOTER) book/rl-cheatsheet/index.html > $(BUILD)/html/rl-cheatsheet/index.html
 	cp book/rl-cheatsheet/inside_cover_back.tex $(BUILD)/html/rl-cheatsheet/
 	cd $(BUILD)/html/rl-cheatsheet && pdflatex inside_cover_back.tex
 	rm -f $(BUILD)/html/rl-cheatsheet/*.aux $(BUILD)/html/rl-cheatsheet/*.log
@@ -244,7 +250,7 @@ files:
 	cp book/favicon.ico $(BUILD)/html/ || echo "Failed to copy to $(BUILD)/html/"
 	cp book/favicon.ico $(BUILD)/html/c/ || echo "Failed to copy to $(BUILD)/html/c/"
 	cp book/_redirects $(BUILD)/html/ || echo "Failed to copy _redirects to $(BUILD)/html/"
-	cp ./book/templates/404.html $(BUILD)/html/ || echo "Failed to copy 404.html to $(BUILD)/html/"
+	$(INLINE_FOOTER) book/templates/404.html > $(BUILD)/html/404.html || echo "Failed to copy 404.html to $(BUILD)/html/"
 	cp -R book/preorder $(BUILD)/html/ || echo "Failed to copy preorder static pages"
 	cp -R book/code $(BUILD)/html/ || echo "Failed to copy code redirect page"
 	cp $(BUILD)/pdf/book.pdf $(BUILD)/html/ || echo "Failed to copy to $(BUILD)/html/"

--- a/book/rl-cheatsheet/index.html
+++ b/book/rl-cheatsheet/index.html
@@ -328,19 +328,6 @@
     </table>
   </div>
 
-  <footer style="padding: 40px 20px 20px; text-align: center;">
-    <div style="display: flex; justify-content: center; gap: 20px; align-items: center;">
-      <a href="https://github.com/natolambert/rlhf-book" target="_blank">
-        <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" style="width: 40px; height: 40px;">
-      </a>
-      <a href="https://arxiv.org/abs/2504.12501" target="_blank">
-        <img src="assets/arxiv.svg" alt="arXiv" style="width: 40px; height: 40px;">
-      </a>
-      <a href="https://www.manning.com/books/the-rlhf-book" target="_blank">
-        <img src="assets/manning.svg" alt="Manning" style="width: 40px; height: 40px;">
-      </a>
-    </div>
-    <p>&copy; 2024-2026 Nathan Lambert &middot; <a href="https://rlhfbook.com" style="color: #888; text-decoration: none;">rlhfbook.com</a></p>
-  </footer>
+  <!-- include: footer.html -->
 </body>
 </html>

--- a/book/templates/404.html
+++ b/book/templates/404.html
@@ -106,20 +106,6 @@
   <p><a href="https://rlhfbook.com/">Return to the homepage</a></p>
 </div>
 
-<footer style="padding: 20px; margin-top: 6em; text-align: center;">
-  <hr>
-  <div style="display: flex; justify-content: center; gap: 20px; align-items: center;">
-    <a href="https://github.com/natolambert/rlhf-book" target="_blank">
-      <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" style="width: 40px; height: 40px;">
-    </a>
-    <a href="https://arxiv.org/abs/2504.12501" target="_blank">
-      <img src="/assets/arxiv.svg" alt="arXiv" style="width: 40px; height: 40px;">
-    </a>
-    <a href="https://www.manning.com/books/the-rlhf-book" target="_blank">
-      <img src="/assets/manning.svg" alt="Manning" style="width: 40px; height: 40px;">
-    </a>
-  </div>
-  <p>&copy; 2024-2026 Nathan Lambert &middot; <a href="https://rlhfbook.com" style="color: #888; text-decoration: none;">rlhfbook.com</a></p>
-</footer>
+<!-- include: footer.html -->
 </body>
 </html>

--- a/book/templates/chapter.html
+++ b/book/templates/chapter.html
@@ -204,22 +204,6 @@ $endfor$
   url = {https://rlhfbook.com}
 }</pre>
 </section>
-<footer style="padding: 20px; text-align: center; margin-top: 2em;">
-  <div style="display: flex; justify-content: center; gap: 20px; align-items: center;">
-    <a href="https://github.com/natolambert/rlhf-book" target="_blank">
-      <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" style="width: 40px; height: 40px;">
-    </a>
-    <a href="https://arxiv.org/abs/2504.12501" target="_blank">
-      <img src="assets/arxiv.svg" alt="arXiv" style="width: 40px; height: 40px;">
-    </a>
-    <a href="https://www.manning.com/books/the-rlhf-book" target="_blank">
-      <img src="assets/manning.svg" alt="Manning" style="width: 40px; height: 40px;">
-    </a>
-    <a href="https://amzn.to/4cwCDJQ" target="_blank">
-      <img src="assets/amazon.svg" alt="Amazon" style="width: 40px; height: 40px;">
-    </a>
-  </div>
-  <p>&copy; 2024-2026 Nathan Lambert &middot; <a href="https://rlhfbook.com" style="color: #888; text-decoration: none;">rlhfbook.com</a></p>
-</footer>
+$footer.html()$
 </body>
 </html>

--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -390,20 +390,7 @@
   url = {https://rlhfbook.com}
 }</pre>
   </section>
-  <footer style="padding: 20px; text-align: center; margin-top: 2em;">
-    <div style="display: flex; justify-content: center; gap: 20px; align-items: center;">
-      <a href="https://github.com/natolambert/rlhf-book" target="_blank">
-        <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" style="width: 40px; height: 40px;">
-      </a>
-      <a href="https://arxiv.org/abs/2504.12501" target="_blank">
-        <img src="assets/arxiv.svg" alt="arXiv" style="width: 40px; height: 40px;">
-      </a>
-      <a href="https://www.manning.com/books/the-rlhf-book" target="_blank">
-        <img src="assets/manning.svg" alt="Manning" style="width: 40px; height: 40px;">
-      </a>
-    </div>
-    <p>&copy; 2024-2026 Nathan Lambert &middot; <a href="https://rlhfbook.com" style="color: #888; text-decoration: none;">rlhfbook.com</a></p>
-  </footer>
+  <!-- include: footer.html -->
 
   <script>
     // Scale iframes to fit their containers

--- a/book/templates/footer.html
+++ b/book/templates/footer.html
@@ -4,13 +4,13 @@
       <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" style="width: 40px; height: 40px;">
     </a>
     <a href="https://arxiv.org/abs/2504.12501" target="_blank">
-      <img src="assets/arxiv.svg" alt="arXiv" style="width: 40px; height: 40px;">
+      <img src="/assets/arxiv.svg" alt="arXiv" style="width: 40px; height: 40px;">
     </a>
     <a href="https://www.manning.com/books/the-rlhf-book" target="_blank">
-      <img src="assets/manning.svg" alt="Manning" style="width: 40px; height: 40px;">
+      <img src="/assets/manning.svg" alt="Manning" style="width: 40px; height: 40px;">
     </a>
     <a href="https://amzn.to/4cwCDJQ" target="_blank">
-      <img src="assets/amazon.svg" alt="Amazon" style="width: 40px; height: 40px;">
+      <img src="/assets/amazon.svg" alt="Amazon" style="width: 40px; height: 40px;">
     </a>
   </div>
   <p>&copy; 2024-2026 Nathan Lambert &middot; <a href="https://rlhfbook.com" style="color: #888; text-decoration: none;">rlhfbook.com</a></p>

--- a/book/templates/footer.html
+++ b/book/templates/footer.html
@@ -1,0 +1,17 @@
+<footer style="padding: 20px; text-align: center; margin-top: 2em;">
+  <div style="display: flex; justify-content: center; gap: 20px; align-items: center;">
+    <a href="https://github.com/natolambert/rlhf-book" target="_blank">
+      <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" style="width: 40px; height: 40px;">
+    </a>
+    <a href="https://arxiv.org/abs/2504.12501" target="_blank">
+      <img src="assets/arxiv.svg" alt="arXiv" style="width: 40px; height: 40px;">
+    </a>
+    <a href="https://www.manning.com/books/the-rlhf-book" target="_blank">
+      <img src="assets/manning.svg" alt="Manning" style="width: 40px; height: 40px;">
+    </a>
+    <a href="https://amzn.to/4cwCDJQ" target="_blank">
+      <img src="assets/amazon.svg" alt="Amazon" style="width: 40px; height: 40px;">
+    </a>
+  </div>
+  <p>&copy; 2024-2026 Nathan Lambert &middot; <a href="https://rlhfbook.com" style="color: #888; text-decoration: none;">rlhfbook.com</a></p>
+</footer>

--- a/book/templates/html.html
+++ b/book/templates/html.html
@@ -157,22 +157,6 @@ $endif$
   url = {https://rlhfbook.com}
 }</pre>
   </section>
-  <footer style="padding: 20px; text-align: center; margin-top: 2em;">
-    <div style="display: flex; justify-content: center; gap: 20px; align-items: center;">
-      <a href="https://github.com/natolambert/rlhf-book" target="_blank">
-        <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" style="width: 40px; height: 40px;">
-      </a>
-      <a href="https://arxiv.org/abs/2504.12501" target="_blank">
-        <img src="assets/arxiv.svg" alt="arXiv" style="width: 40px; height: 40px;">
-      </a>
-      <a href="https://www.manning.com/books/the-rlhf-book" target="_blank">
-        <img src="assets/manning.svg" alt="Manning" style="width: 40px; height: 40px;">
-      </a>
-      <a href="https://amzn.to/4cwCDJQ" target="_blank">
-        <img src="assets/amazon.svg" alt="Amazon" style="width: 40px; height: 40px;">
-      </a>
-    </div>
-    <p>&copy; 2024-2026 Nathan Lambert &middot; <a href="https://rlhfbook.com" style="color: #888; text-decoration: none;">rlhfbook.com</a></p>
-  </footer>  
+  $footer.html()$
 </body>
 </html>

--- a/book/templates/library.html
+++ b/book/templates/library.html
@@ -395,23 +395,8 @@
   url = {https://rlhfbook.com}
 }</pre>
   </section>
-  <footer style="padding: 20px; text-align: center; margin-top: 2em;">
-    <div style="display: flex; justify-content: center; gap: 20px; align-items: center;">
-      <a href="https://github.com/natolambert/rlhf-book" target="_blank">
-        <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" style="width: 40px; height: 40px;">
-      </a>
-      <a href="https://arxiv.org/abs/2504.12501" target="_blank">
-        <img src="assets/arxiv.svg" alt="arXiv" style="width: 40px; height: 40px;">
-      </a>
-      <a href="https://www.manning.com/books/the-rlhf-book" target="_blank">
-        <img src="assets/manning.svg" alt="Manning" style="width: 40px; height: 40px;">
-      </a>
-      <a href="https://amzn.to/4cwCDJQ" target="_blank">
-        <img src="assets/amazon.svg" alt="Amazon" style="width: 40px; height: 40px;">
-      </a>
-    </div>
-    <p>&copy; 2024-2026 Nathan Lambert &middot; <a href="https://rlhfbook.com" style="color: #888; text-decoration: none;">rlhfbook.com</a></p>
-  </footer>
+  <!-- include: footer.html -->
+
 
   <script>
     const state = {


### PR DESCRIPTION
## Summary

Extract the duplicated site footer (logos + copyright) into `book/templates/footer.html` so edits to the footer live in one place instead of three.

## Background

`CLAUDE.md` previously documented the convention:

> When updating the footer, edit `html.html` first, then copy the changes to `chapter.html` and `library.html`.

That's a maintenance hazard — three copies drift over time.

## What changed

- **New**: `book/templates/footer.html` holds the shared footer markup.
- **`html.html` / `chapter.html`** (pandoc-templated): include via `$footer.html()$`, the pandoc partial syntax already used elsewhere (`$styles.html()$`, `$style.css()$`).
- **`library.html`** (copied as-is to build dir, doesn't go through pandoc): carries an HTML sentinel `<!-- include: footer.html -->` which the Makefile's `library.html` rule expands with `awk` at build time.
- **`CLAUDE.md`**: footer-convention note rewritten to point at `footer.html` as the single source of truth.

## Why not extract the Citation block too

Citation heading level differs across pages (h3 on index, h4 on chapter/library). Parameterizing for one tag difference is more boilerplate than it's worth; Citation stays inline.

## Test plan

- [x] `make html` succeeds
- [x] Footer renders identically (byte-for-byte) on `index.html`, a chapter page, and `library.html`
- [ ] Spot-check the deployed site after merge
