### PR TITLE
Update README structure to reflect current layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,13 @@ rlhf-book/
 ├── code/                   # Reference implementations
 │   ├── policy_gradients/   # PPO, REINFORCE, GRPO, RLOO
 │   ├── reward_models/      # Preference RM, ORM, PRM training
-│   └── direct_alignment/   # DPO and variants
+│   ├── direct_alignment/   # DPO and variants
+│   └── rejection_sampling/ # Best-of-N rejection sampling
 ├── diagrams/               # Diagram source files
 │   ├── scripts/            # Python generation scripts
 │   ├── tikz/               # LaTeX/TikZ sources
 │   └── specs/              # YAML specifications
+├── teach/                  # Teaching materials (courses, slides)
 ├── build/                  # Generated output (git-ignored)
 └── Makefile                # Build system
 ```
@@ -50,7 +52,8 @@ rlhf-book/
 Reference implementations for RLHF algorithms in `code/`:
 - Policy gradient methods (PPO, REINFORCE, GRPO, RLOO, etc.)
 - Reward model training (preference RM, ORM, PRM)
-- Direct alignment methods
+- Direct alignment methods (DPO and variants)
+- Rejection sampling (best-of-N)
 
 See [code/README.md](code/README.md) for setup and usage.
 


### PR DESCRIPTION
## Summary
- Add `rejection_sampling/` under `code/` in the repository structure tree and Code Library list
- Add top-level `teach/` directory (teaching materials) to the structure tree

## Test plan
- [x] Review rendered README on the PR page

🤖 Generated with [Claude Code](https://claude.com/claude-code)