### PR TITLE
Add Q&A 1 slide deck + drop course page ToC

### DIFF
--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -286,20 +286,6 @@
     </div>
   </div>
 
-  <nav class="slides-toc">
-    <h2>Contents</h2>
-    <ul>
-      <li>
-        <a href="#lectures">Lectures</a>
-        <span class="toc-meta"> &mdash; course lectures in order</span>
-      </li>
-      <li>
-        <a href="#other-lectures">Other Lectures</a>
-        <span class="toc-meta"> &mdash; invited talks and presentations</span>
-      </li>
-    </ul>
-  </nav>
-
   <section class="slides-section" id="lectures">
     <h2>Lectures</h2>
 
@@ -350,6 +336,17 @@
           <a href="/teach/course/lec4-chap6-p2/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
           <a href="/teach/course/lec4-chap6-p2/" class="btn" target="_blank"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
           <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec4-chap6-p2.md?plain=1" class="btn btn-source" target="_blank"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
+        </div>
+      </div>
+      <div class="course-entry" id="qa-01">
+        <div>
+          <h3>Q&amp;A 1: Reader questions</h3>
+          <p class="meta">Covering lectures so far &middot; Answering questions from the issue tracker and Discord</p>
+        </div>
+        <div class="talk-actions">
+          <a href="/teach/course/qa-01/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
+          <a href="/teach/course/qa-01/" class="btn" target="_blank"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
+          <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/qa-01.md?plain=1" class="btn btn-source" target="_blank"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
         </div>
       </div>
     </div>

--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -209,6 +209,10 @@
       margin: 0;
     }
 
+    .course-entry.qa-entry {
+      background: #f7f7f7;
+    }
+
     .welcome-video {
       margin: 1.5em 0 2em;
       padding: 1.1em 1.3em;
@@ -287,7 +291,7 @@
   </div>
 
   <section class="slides-section" id="lectures">
-    <h2>Lectures</h2>
+    <h2>Primary Material</h2>
 
     <div class="course-list">
       <div class="course-entry" id="lecture-1-overview">
@@ -338,10 +342,9 @@
           <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec4-chap6-p2.md?plain=1" class="btn btn-source" target="_blank"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
         </div>
       </div>
-      <div class="course-entry" id="qa-01">
+      <div class="course-entry qa-entry" id="qa-01">
         <div>
-          <h3>Q&amp;A 1: Reader questions</h3>
-          <p class="meta">Covering lectures so far &middot; Questions from the issue tracker, Discord, and YouTube comments</p>
+          <h3>Q&amp;A 1: Reader questions, lec. 1-4</h3>
         </div>
         <div class="talk-actions">
           <a href="/teach/course/qa-01/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
@@ -353,7 +356,7 @@
   </section>
 
   <section class="other-lectures-section" id="other-lectures">
-    <h2>Other Lectures</h2>
+    <h2>Other Guest Lectures and Talks</h2>
 
     <h3>2026</h3>
 

--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -341,7 +341,7 @@
       <div class="course-entry" id="qa-01">
         <div>
           <h3>Q&amp;A 1: Reader questions</h3>
-          <p class="meta">Covering lectures so far &middot; Answering questions from the issue tracker and Discord</p>
+          <p class="meta">Covering lectures so far &middot; Questions from the issue tracker, Discord, and YouTube comments</p>
         </div>
         <div class="talk-actions">
           <a href="/teach/course/qa-01/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,5 +19,5 @@ skills = [
 ]
 teach = [
     # TODO: pin back to a PyPI release when colloquium development slows down.
-    "colloquium @ git+https://github.com/natolambert/colloquium.git",
+    "colloquium @ git+https://github.com/natolambert/colloquium.git@c3b922093572dd630ce5b1060791b3d3851fded3",
 ]

--- a/teach/course/qa-01.md
+++ b/teach/course/qa-01.md
@@ -1,0 +1,179 @@
+---
+title: "Q&A 1: Reader questions"
+author: "Nathan Lambert"
+fonts:
+  heading: "Rubik"
+  body: "Poppins"
+bibliography: refs.bib
+figure_captions: true
+footer:
+  left: "rlhfbook.com/course"
+  center: "Q&A 1"
+  right: "Lambert {n}/{N}"
+custom_css: |
+  .slide--section-break { background: #F28482; }
+  :root {
+    --colloquium-progress-fill: #F28482;
+  }
+---
+
+<!-- layout: title-banner -->
+
+# Q&A 1: Reader questions from the series
+
+<div class="colloquium-title-eyebrow">rlhfbook.com/course</div>
+<div class="colloquium-title-rule"></div>
+
+<div class="colloquium-title-meta">
+<p class="colloquium-title-name">Nathan Lambert</p>
+<p>Round 1</p>
+<p>Spring 2026</p>
+</div>
+
+<p class="colloquium-title-note">Answering questions posted on the book issue tracker, Discord, and YouTube comments.</p>
+
+---
+
+<!-- layout: section-break -->
+<!-- title: center -->
+
+## Lecture 2 — IFT, reward models, & rejection sampling
+
+---
+
+## Q: One model vs. many for synthetic SFT data?
+
+<!-- footnote-right: From @mufeezamjad790 on YouTube -->
+
+> "For synthetic data (for SFT), what's the theory backing whether one model is better versus more than one model to generate completions?"
+
+Two angles to discuss:
+
+- **Capability ceiling** — can a single strong teacher cover the distribution, or do you need diversity (ensembling teachers) to avoid stylistic mode collapse?
+- **Diversity vs. consistency trade-off** — multi-teacher data adds coverage but mixes formatting and reasoning habits; single-teacher data is cleaner but narrower.
+
+Not much formal theory here — mostly empirical. Relevant: Self-Instruct, Orca, Tulu / OLMoE data mixes.
+
+---
+
+## Q: Should the teacher's distribution match the base model?
+
+<!-- footnote-right: From @mufeezamjad790 on YouTube -->
+
+> "Is there any consideration for choosing a teacher model that has a similar distribution as the base you're fine tuning?"
+
+Tension:
+
+- **Closer distribution** → SFT loss is lower, less "forgetting," easier to learn style. But ceiling is bounded by the teacher.
+- **Farther distribution** (e.g., distilling from a much stronger model) → bigger capability gains, but larger distribution shift ⇒ more forgetting and sometimes spurious style transfer.
+
+Practical heuristic: teacher should be **strictly stronger** on the target skill; distribution match matters more when you're worried about regressions on already-good behaviors.
+
+---
+
+## Q: Is there a unified RM benchmark across RM types?
+
+<!-- footnote-right: From @jeromeeusebius on YouTube -->
+
+> "I recall you said you worked on the RewardBench project… is there a benchmarking of the different RM models on the same labeled dataset? …we have a dataset with comparison generation info for pairs (prompt, chosen, rejected), and then the completions in the same dataset also have labels per token allowing to train with outcome reward model (ORM)."
+
+What the reader is asking: can we compare Bradley-Terry pairwise RMs vs. ORMs vs. PRMs vs. generative RMs on **one dataset** that carries both preference pairs and per-token / outcome labels?
+
+- Such a dataset is rare — most preference sets don't have step / outcome labels, and most ORM datasets don't have comparisons.
+- PRM800K-style data is closest, but not directly comparable to pref datasets.
+- This is a real open gap — worth discussing what the right evaluation object would look like.
+
+---
+
+## Q: How important is balancing domains in an SFT mix?
+
+<!-- footnote-right: From @jeromeeusebius on YouTube -->
+
+> "When composing dataset from different domains/tasks, how is it important to balance the proportion of data from each task/domain. I assume it's important to have them balanced or the training is robust enough to counter small imbalances."
+
+Key points to cover:
+
+- Mix ratios **do** matter, especially for smaller models and shorter training runs.
+- Heavily-overrepresented domains leak style/format into neighboring tasks.
+- Upsampling small-but-important domains (e.g., safety, math) is standard.
+- References: Tulu / OLMoE mix ablations, DeepSeek-R1 data composition notes.
+
+---
+
+<!-- layout: section-break -->
+<!-- title: center -->
+
+## Lecture 3 — RL motivation & math
+
+---
+
+## Q: Is GAE the only way to compute the advantage in PPO?
+
+<!-- footnote-right: From issue #382 on GitHub -->
+
+> "Post lecture 3, I'm looking at the cheatsheet and am wondering if the advantage for PPO can be computed in multiple ways and GAE (Generalized Advantage Estimator) is one of the many ways. If not, can we update the formula for PPO where we can define how $A_{t}$ is computed…"
+
+The PPO clipped objective (as written on the [cheatsheet](https://rlhfbook.com/rl-cheatsheet/)):
+
+$$J(\theta) = \mathbb{E}_t\!\left[\min\!\left(\rho_t(\theta)\, \hat{A}_t,\; \text{clip}(\rho_t(\theta),\, 1-\varepsilon,\, 1+\varepsilon)\, \hat{A}_t\right)\right]$$
+
+treats $\hat{A}_t$ as a plug-in advantage estimate. GAE is one choice; Monte-Carlo returns, $n$-step TD, and group-relative baselines (GRPO-style) are others.
+
+---
+
+## Q: Should the notation section define $T$, $K$, $G$?
+
+<!-- footnote-right: From issue #382 on GitHub -->
+
+> "Also, for the sake of completeness, we can add $T$, $K$, $G$ in the notation if that's helpful."
+
+Symbols the reader is flagging:
+
+- $T$ — trajectory / episode length (timestep horizon)
+- $K$ — number of PPO epochs per batch of rollouts
+- $G$ — group size for GRPO-style advantage estimation
+
+Currently introduced inline in their respective chapters but not consolidated in the notation table.
+
+---
+
+## Q: What is the shape of $\rho$?
+
+<!-- footnote-right: From @JGLambourne on YouTube -->
+
+> "What is the shape of rho? Is it a vector with length of the action space (vocabulary)?"
+
+Recall the importance sampling ratio at timestep $t$:
+
+$$\rho_t(\theta) = \frac{\pi_\theta(a_t \mid s_t)}{\pi_{\theta_\text{old}}(a_t \mid s_t)}$$
+
+- For a **single sampled action** $a_t$: $\rho_t$ is a **scalar** — a ratio of two probabilities, not a distribution over the vocabulary.
+- Per rollout of length $T$: you get a **vector of length $T$** (one $\rho_t$ per timestep).
+- Per batch of $B$ rollouts: a $[B, T]$ tensor.
+
+The policies $\pi_\theta(\cdot \mid s_t)$ and $\pi_{\theta_\text{old}}(\cdot \mid s_t)$ are distributions over the vocabulary, but $\rho_t$ evaluates both at the same *realized* action.
+
+---
+
+## Q: Are slides 59–61 in Lecture 3 out of order?
+
+<!-- footnote-right: From issue #382 on GitHub -->
+
+> "Slide 59, 60, 61 seem to be in jumbled order. The flow if I understand right is: 'What can we do with more conservative gradients?' → introduces 2 problems; 'PPO core idea 1: constrained updates' → trust regions/clipping; 'PPO core idea 2: Importance sampling' → importance sampling."
+
+Current order in `lec3-chap6-p1.md`:
+
+1. **PPO core idea 1: constrained updates** — introduces trust regions
+2. **What can we do with more conservative gradients?** — raises 2 follow-up problems (multi-step updates, off-policy data)
+3. **PPO core idea 2: Importance sampling** — resolves the off-policy problem
+
+Srinath's proposed order swaps (1) and (2). Worth discussing the intended narrative arc.
+
+---
+
+<!-- layout: section-break -->
+<!-- title: center -->
+
+## More answers & follow-ups
+
+Deeper slides and diagrams to be added as questions accumulate.

--- a/teach/course/qa-01.md
+++ b/teach/course/qa-01.md
@@ -30,144 +30,165 @@ custom_css: |
 <p>Spring 2026</p>
 </div>
 
-<p class="colloquium-title-note">Answering questions posted on the book issue tracker, Discord, and YouTube comments.</p>
+<p class="colloquium-title-note">Question-first templates from the issue tracker, Discord, and YouTube comments.</p>
 
 ---
 
 <!-- layout: section-break -->
 <!-- title: center -->
 
-## Lecture 2 — IFT, reward models, & rejection sampling
+## Course orientation
 
 ---
 
-## Q: One model vs. many for synthetic SFT data?
+## What prerequisites should a learner cover before this course?
 
-<!-- footnote-right: From @mufeezamjad790 on YouTube -->
-
-> "For synthetic data (for SFT), what's the theory backing whether one model is better versus more than one model to generate completions?"
-
-Two angles to discuss:
-
-- **Capability ceiling** — can a single strong teacher cover the distribution, or do you need diversity (ensembling teachers) to avoid stylistic mode collapse?
-- **Diversity vs. consistency trade-off** — multi-teacher data adds coverage but mixes formatting and reasoning habits; single-teacher data is cleaner but narrower.
-
-Not much formal theory here — mostly empirical. Relevant: Self-Instruct, Orca, Tulu / OLMoE data mixes.
+<!-- footnote-right: Source: [@subhu2005 on YouTube (Lecture 1)](https://www.youtube.com/watch?v=o6l6tJQgUg4&lc=UgxPsBySNJqPCrMZIIB4AaABAg.AV4pTgH3kgUAVNDw0ERK9m) -->
 
 ---
 
-## Q: Should the teacher's distribution match the base model?
+## Which policy-gradient derivation steps need a slower walkthrough?
 
-<!-- footnote-right: From @mufeezamjad790 on YouTube -->
+<!-- footnote-right: Source: [@matteo679 on YouTube (Lecture 3)](https://www.youtube.com/watch?v=K_Sj_-1BUMM&lc=Ugzn5NQZ6NYEcx3udtF4AaABAg) -->
 
-> "Is there any consideration for choosing a teacher model that has a similar distribution as the base you're fine tuning?"
-
-Tension:
-
-- **Closer distribution** → SFT loss is lower, less "forgetting," easier to learn style. But ceiling is bounded by the teacher.
-- **Farther distribution** (e.g., distilling from a much stronger model) → bigger capability gains, but larger distribution shift ⇒ more forgetting and sometimes spurious style transfer.
-
-Practical heuristic: teacher should be **strictly stronger** on the target skill; distribution match matters more when you're worried about regressions on already-good behaviors.
-
----
-
-## Q: Is there a unified RM benchmark across RM types?
-
-<!-- footnote-right: From @jeromeeusebius on YouTube -->
-
-> "I recall you said you worked on the RewardBench project… is there a benchmarking of the different RM models on the same labeled dataset? …we have a dataset with comparison generation info for pairs (prompt, chosen, rejected), and then the completions in the same dataset also have labels per token allowing to train with outcome reward model (ORM)."
-
-What the reader is asking: can we compare Bradley-Terry pairwise RMs vs. ORMs vs. PRMs vs. generative RMs on **one dataset** that carries both preference pairs and per-token / outcome labels?
-
-- Such a dataset is rare — most preference sets don't have step / outcome labels, and most ORM datasets don't have comparisons.
-- PRM800K-style data is closest, but not directly comparable to pref datasets.
-- This is a real open gap — worth discussing what the right evaluation object would look like.
-
----
-
-## Q: How important is balancing domains in an SFT mix?
-
-<!-- footnote-right: From @jeromeeusebius on YouTube -->
-
-> "When composing dataset from different domains/tasks, how is it important to balance the proportion of data from each task/domain. I assume it's important to have them balanced or the training is robust enough to counter small imbalances."
-
-Key points to cover:
-
-- Mix ratios **do** matter, especially for smaller models and shorter training runs.
-- Heavily-overrepresented domains leak style/format into neighboring tasks.
-- Upsampling small-but-important domains (e.g., safety, math) is standard.
-- References: Tulu / OLMoE mix ablations, DeepSeek-R1 data composition notes.
+Prompted by feedback asking for a calmer, more step-by-step explanation of the derivation section.
 
 ---
 
 <!-- layout: section-break -->
 <!-- title: center -->
 
-## Lecture 3 — RL motivation & math
+## Data & instruction tuning
 
 ---
 
-## Q: Is GAE the only way to compute the advantage in PPO?
+## For synthetic SFT data, is one teacher model better than many?
 
-<!-- footnote-right: From issue #382 on GitHub -->
-
-> "Post lecture 3, I'm looking at the cheatsheet and am wondering if the advantage for PPO can be computed in multiple ways and GAE (Generalized Advantage Estimator) is one of the many ways. If not, can we update the formula for PPO where we can define how $A_{t}$ is computed…"
-
-The PPO clipped objective (as written on the [cheatsheet](https://rlhfbook.com/rl-cheatsheet/)):
-
-$$J(\theta) = \mathbb{E}_t\!\left[\min\!\left(\rho_t(\theta)\, \hat{A}_t,\; \text{clip}(\rho_t(\theta),\, 1-\varepsilon,\, 1+\varepsilon)\, \hat{A}_t\right)\right]$$
-
-treats $\hat{A}_t$ as a plug-in advantage estimate. GAE is one choice; Monte-Carlo returns, $n$-step TD, and group-relative baselines (GRPO-style) are others.
+<!-- footnote-right: Source: [@mufeezamjad790 on YouTube (Lecture 2)](https://www.youtube.com/watch?v=4gIwiSPmQkU&lc=UgzOG5OXvEBlCy4zs5p4AaABAg) -->
 
 ---
 
-## Q: Should the notation section define $T$, $K$, $G$?
+## Should the teacher model's distribution match the base model?
 
-<!-- footnote-right: From issue #382 on GitHub -->
-
-> "Also, for the sake of completeness, we can add $T$, $K$, $G$ in the notation if that's helpful."
-
-Symbols the reader is flagging:
-
-- $T$ — trajectory / episode length (timestep horizon)
-- $K$ — number of PPO epochs per batch of rollouts
-- $G$ — group size for GRPO-style advantage estimation
-
-Currently introduced inline in their respective chapters but not consolidated in the notation table.
+<!-- footnote-right: Source: [@mufeezamjad790 on YouTube (Lecture 2)](https://www.youtube.com/watch?v=4gIwiSPmQkU&lc=UgzOG5OXvEBlCy4zs5p4AaABAg) -->
 
 ---
 
-## Q: What is the shape of $\rho$?
+## How important is balancing domains in an SFT mix?
 
-<!-- footnote-right: From @JGLambourne on YouTube -->
+<!-- footnote-right: Source: [@jeromeeusebius on YouTube (Lecture 2)](https://www.youtube.com/watch?v=4gIwiSPmQkU&lc=Ugz41N1_9VKNNZN8N7N4AaABAg) -->
 
-> "What is the shape of rho? Is it a vector with length of the action space (vocabulary)?"
+---
 
-Recall the importance sampling ratio at timestep $t$:
+<!-- layout: section-break -->
+<!-- title: center -->
+
+## Reward models & reward design
+
+---
+
+## Is there a unified benchmark across pairwise RMs, ORMs, PRMs, and generative RMs?
+
+<!-- footnote-right: Source: [@jeromeeusebius on YouTube (Lecture 2)](https://www.youtube.com/watch?v=4gIwiSPmQkU&lc=Ugz41N1_9VKNNZN8N7N4AaABAg) -->
+
+Context: the question asks whether one labeled dataset could support comparison data, per-token labels, and outcome labels for apples-to-apples RM evaluation.
+
+---
+
+## Why choose token-level rewards over sequence-level rewards?
+
+<!-- footnote-right: Source: [@dejavukun on YouTube (Lecture 3)](https://www.youtube.com/watch?v=K_Sj_-1BUMM&lc=Ugz9joGHibucDB5llqJ4AaABAg) -->
+
+---
+
+<!-- layout: section-break -->
+<!-- title: center -->
+
+## RL math & notation
+
+---
+
+## Is GAE the only way to compute the advantage in PPO?
+
+<!-- footnote-right: Source: [issue #382 on GitHub](https://github.com/natolambert/rlhf-book/issues/382) -->
+
+The PPO clipped objective on the [cheatsheet](https://rlhfbook.com/rl-cheatsheet/):
+
+$$J(\theta) = \mathbb{E}_t\!\left[\min\!\left(\rho_t(\theta)\hat{A}_t,\; \text{clip}(\rho_t(\theta),\, 1-\varepsilon,\, 1+\varepsilon)\hat{A}_t\right)\right]$$
+
+---
+
+## Should the notation section define $T$, $K$, and $G$?
+
+<!-- footnote-right: Source: [issue #382 on GitHub](https://github.com/natolambert/rlhf-book/issues/382) -->
+
+Symbols flagged: $T$, $K$, $G$.
+
+---
+
+## What is the shape of $\rho$?
+
+<!-- footnote-right: Source: [@JGLambourne on YouTube (Lecture 3)](https://www.youtube.com/watch?v=K_Sj_-1BUMM&lc=UgwC9D0I4zmtGtyyGz14AaABAg) -->
 
 $$\rho_t(\theta) = \frac{\pi_\theta(a_t \mid s_t)}{\pi_{\theta_\text{old}}(a_t \mid s_t)}$$
 
-- For a **single sampled action** $a_t$: $\rho_t$ is a **scalar** — a ratio of two probabilities, not a distribution over the vocabulary.
-- Per rollout of length $T$: you get a **vector of length $T$** (one $\rho_t$ per timestep).
-- Per batch of $B$ rollouts: a $[B, T]$ tensor.
+---
 
-The policies $\pi_\theta(\cdot \mid s_t)$ and $\pi_{\theta_\text{old}}(\cdot \mid s_t)$ are distributions over the vocabulary, but $\rho_t$ evaluates both at the same *realized* action.
+## Are slides 59-61 in Lecture 3 out of order?
+
+<!-- footnote-right: Source: [issue #382 on GitHub](https://github.com/natolambert/rlhf-book/issues/382) -->
+
+Proposed flow:
+
+1. What can we do with more conservative gradients?
+2. PPO core idea 1: constrained updates
+3. PPO core idea 2: importance sampling
 
 ---
 
-## Q: Are slides 59–61 in Lecture 3 out of order?
+<!-- layout: section-break -->
+<!-- title: center -->
 
-<!-- footnote-right: From issue #382 on GitHub -->
+## PPO implementation & debugging
 
-> "Slide 59, 60, 61 seem to be in jumbled order. The flow if I understand right is: 'What can we do with more conservative gradients?' → introduces 2 problems; 'PPO core idea 1: constrained updates' → trust regions/clipping; 'PPO core idea 2: Importance sampling' → importance sampling."
+---
 
-Current order in `lec3-chap6-p1.md`:
+## Why does PPO use `torch.max` for both policy and value losses?
 
-1. **PPO core idea 1: constrained updates** — introduces trust regions
-2. **What can we do with more conservative gradients?** — raises 2 follow-up problems (multi-step updates, off-policy data)
-3. **PPO core idea 2: Importance sampling** — resolves the off-policy problem
+<!-- footnote-right: Source: [@jacoboromerodiaz6967 on YouTube (Lecture 4)](https://www.youtube.com/watch?v=i-AIMpZHgeg&lc=UgwjmSeeAuvtuN_B85R4AaABAg) -->
 
-Srinath's proposed order swaps (1) and (2). Worth discussing the intended narrative arc.
+```python
+pg_losses1 = -advantages * ratio
+pg_losses2 = -advantages * torch.clamp(ratio, 1.0 - eps, 1.0 + eps)
+pg_loss = torch.max(pg_losses1, pg_losses2)
+
+vf_unclipped = 0.5 * (v_pred - targets) ** 2
+vf_clipped = 0.5 * (v_clip - targets) ** 2
+vf_loss = torch.max(vf_unclipped, vf_clipped)
+```
+
+---
+
+## How should we debug model collapse with sparse rewards and a strict DSL?
+
+<!-- footnote-right: Source: [@JGLambourne on YouTube (Lecture 4)](https://www.youtube.com/watch?v=i-AIMpZHgeg&lc=UgyHn_MoFfktNiZK4cJ4AaABAg) -->
+
+Context: giving a negative reward when the DSL syntax is not met did not help and could accelerate collapse.
+
+---
+
+<!-- layout: section-break -->
+<!-- title: center -->
+
+## Human feedback operations
+
+---
+
+## How should data-annotation companies stay valuable as synthetic data gets simpler?
+
+<!-- footnote-right: Source: [@lorenzogaletto4442 on YouTube (Lecture 4)](https://www.youtube.com/watch?v=i-AIMpZHgeg&lc=UgzV2pnGCuqSIV4CXRh4AaABAg) -->
+
+Context from the reader: this asks about the aside in Chapter 11 on companies that vet data annotators.
 
 ---
 
@@ -176,4 +197,8 @@ Srinath's proposed order swaps (1) and (2). Worth discussing the intended narrat
 
 ## More answers & follow-ups
 
-Deeper slides and diagrams to be added as questions accumulate.
+---
+
+## Which questions should move from backlog into future Q&A rounds?
+
+Track recurring themes as more comments arrive: data mixtures, reward granularity, PPO implementation details, and debugging unstable RL runs.

--- a/teach/course/qa-01.md
+++ b/teach/course/qa-01.md
@@ -19,15 +19,14 @@ custom_css: |
 
 <!-- layout: title-banner -->
 
-# Q&A 1: Reader questions from the series
+# Q&A 1: RLHF course student questions
 
 <div class="colloquium-title-eyebrow">rlhfbook.com/course</div>
 <div class="colloquium-title-rule"></div>
 
 <div class="colloquium-title-meta">
 <p class="colloquium-title-name">Nathan Lambert</p>
-<p>Round 1</p>
-<p>Spring 2026</p>
+<p>May 2026</p>
 </div>
 
 <p class="colloquium-title-note">Question-first templates from the issue tracker, Discord, and YouTube comments.</p>
@@ -42,6 +41,15 @@ custom_css: |
 ---
 
 ## What prerequisites should a learner cover before this course?
+
+This course is approximately designed for early AI PhD/MS students. Traditional coursework path to this course:
+* Basics of language modeling / NLP
+* Basic ML (e.g. intro to AI course and intro to ML course)
+
+With AI agents, all the material is very accessible. I encourage people to track down rabbit holes, skip videos, go out of order, and chases what excites them.
+
+Related courses: [David Silver's RL Course (2015)](https://www.youtube.com/watch?v=2pWv7GOvuf0), [UC Berkeley Deep RL (2023)](https://www.youtube.com/playlist?list=PL_iWQOsE6TfVYGEGiAOMaOzzv41Jfm_Ps), [Sutton & Barto RL Book](https://web.stanford.edu/class/psych209/Readings/SuttonBartoIPRLBook2ndEd.pdf)
+
 
 <!-- footnote-right: Source: [@subhu2005 on YouTube (Lecture 1)](https://www.youtube.com/watch?v=o6l6tJQgUg4&lc=UgxPsBySNJqPCrMZIIB4AaABAg.AV4pTgH3kgUAVNDw0ERK9m) -->
 
@@ -58,15 +66,42 @@ custom_css: |
 
 <!-- footnote-right: Source: [@mufeezamjad790 on YouTube (Lecture 2)](https://www.youtube.com/watch?v=4gIwiSPmQkU&lc=UgzOG5OXvEBlCy4zs5p4AaABAg) -->
 
+- OpenThoughts3: [QwQ-32B](https://qwenlm.github.io/blog/qwq-32b/) teacher, 1.2M examples [@guha2025openthoughts]; [release notes](https://www.openthoughts.ai/blog/ot3).
+- Similar empirical pattern in OLMo 3 reasoning SFT [@teamolmo2025olmo3].
+- Working note: [Qwen3-32B](https://huggingface.co/Qwen/Qwen3-32B) / QwQ-32B-era teachers still look unusually strong.
+- Open question: why don't bigger, newer, smarter models transfer better?
+
 ---
 
-## Should the teacher model's distribution match the base model?
+## For synthetic SFT data, is one teacher model better than many?
+
+- OpenThoughts3: [QwQ-32B](https://qwenlm.github.io/blog/qwq-32b/) teacher, 1.2M examples [@guha2025openthoughts]; [release notes](https://www.openthoughts.ai/blog/ot3).
+- Similar empirical pattern in OLMo 3 reasoning SFT [@teamolmo2025olmo3].
+- Working note: [Qwen3-32B](https://huggingface.co/Qwen/Qwen3-32B) / QwQ-32B-era teachers still look unusually strong.
+- Open question: why don't bigger, newer, smarter models transfer better?
+
+### Should the teacher model's distribution match the base model?
+
+In practice, yes but also not clear.
 
 <!-- footnote-right: Source: [@mufeezamjad790 on YouTube (Lecture 2)](https://www.youtube.com/watch?v=4gIwiSPmQkU&lc=UgzOG5OXvEBlCy4zs5p4AaABAg) -->
 
 ---
 
-## How important is balancing domains in an SFT mix?
+## For synthetic SFT data, is one teacher model better than many?
+
+- OpenThoughts3: [QwQ-32B](https://qwenlm.github.io/blog/qwq-32b/) teacher, 1.2M examples [@guha2025openthoughts]; [release notes](https://www.openthoughts.ai/blog/ot3).
+- Similar empirical pattern in OLMo 3 reasoning SFT [@teamolmo2025olmo3].
+- Working note: [Qwen3-32B](https://huggingface.co/Qwen/Qwen3-32B) / QwQ-32B-era teachers still look unusually strong.
+- Open question: why don't bigger, newer, smarter models transfer better?
+
+### Should the teacher model's distribution match the base model?
+
+In practice, yes but also not clear.
+
+### How important is balancing domains in an SFT mix?
+
+To making a general model, very, but the solutions aren't too surprising. Harder tasks get more tokens.
 
 <!-- footnote-right: Source: [@jeromeeusebius on YouTube (Lecture 2)](https://www.youtube.com/watch?v=4gIwiSPmQkU&lc=Ugz41N1_9VKNNZN8N7N4AaABAg) -->
 
@@ -85,11 +120,37 @@ custom_css: |
 
 Context: the question asks whether one labeled dataset could support comparison data, per-token labels, and outcome labels for apples-to-apples RM evaluation.
 
+**Answer: No**. Fragmentation of the community makes progress more diffuse. This is okay, and a normal evolution.
+
 ---
+<!-- columns: 50/50 -->
 
 ## Why choose token-level rewards over sequence-level rewards?
 
 <!-- footnote-right: Source: [@dejavukun on YouTube (Lecture 3)](https://www.youtube.com/watch?v=K_Sj_-1BUMM&lc=Ugz9joGHibucDB5llqJ4AaABAg) -->
+
+Careful: two different meanings.
+
+- **Reward granularity:** final-answer reward vs step/token rewards (PRM, KL, format rewards) [@lightman2023let].
+- **Loss granularity:** average by sequence vs average by active tokens; DAPO uses token-level policy-gradient loss [@yu2025dapo].
+
+```python
+# Sequence-normalized: each completion has equal weight
+loss = ((pg_loss * mask).sum(dim=1) / mask.sum(dim=1)).mean()
+
+# Token-normalized: each generated token has equal weight
+loss = (pg_loss * mask).sum() / mask.sum()
+```
+
+|||
+
+Why token-level can help:
+- local signals: KL, format rewards, PRMs, partial credit
+- long-CoT RL: more gradient on the tokens actually sampled
+- batching: normalize by active tokens, not examples
+- DAPO: token-level loss + Clip-Higher + dynamic sampling for reasoning RL [@yu2025dapo]
+
+Counterpoint: if the reward is only final-answer correctness, sequence-level advantage is still natural; GSPO pushes the ratio back to sequence level [@zheng2025gspo].
 
 ---
 
@@ -108,13 +169,39 @@ The PPO clipped objective on the [cheatsheet](https://rlhfbook.com/rl-cheatsheet
 
 $$J(\theta) = \mathbb{E}_t\!\left[\min\!\left(\rho_t(\theta)\hat{A}_t,\; \text{clip}(\rho_t(\theta),\, 1-\varepsilon,\, 1+\varepsilon)\hat{A}_t\right)\right]$$
 
+No! But I don't know of anyone using something else, or a raw value model. GAE works.
+
 ---
+<!-- columns: 50/50 -->
 
 ## What is the shape of $\rho$?
 
 <!-- footnote-right: Source: [@JGLambourne on YouTube (Lecture 3)](https://www.youtube.com/watch?v=K_Sj_-1BUMM&lc=UgwC9D0I4zmtGtyyGz14AaABAg) -->
 
 $$\rho_t(\theta) = \frac{\pi_\theta(a_t \mid s_t)}{\pi_{\theta_\text{old}}(a_t \mid s_t)}$$
+
+- $\pi(\cdot \mid s_t)$ is vocab-shaped: `[B, T, V]`
+- $\pi(a_t \mid s_t)$ is gathered at sampled tokens: `[B, T]`
+- $\rho_t$ is scalar per token; rollout tensor is `[B, T]`
+
+|||
+
+```python
+# logits/logprobs over vocab: [B, T, V]
+old_logps_all = old_policy.log_softmax(logits_old, dim=-1)
+new_logps_all = policy.log_softmax(logits_new, dim=-1)
+
+# sampled token ids: [B, T]
+actions = input_ids[:, 1:]
+
+# gather only the probabilities of the sampled tokens: [B, T]
+old_logps = old_logps_all.gather(-1, actions.unsqueeze(-1)).squeeze(-1)
+new_logps = new_logps_all.gather(-1, actions.unsqueeze(-1)).squeeze(-1)
+
+# importance ratio per sampled token: [B, T]
+rho = torch.exp(new_logps - old_logps)
+```
+
 
 ---
 
@@ -125,27 +212,46 @@ $$\rho_t(\theta) = \frac{\pi_\theta(a_t \mid s_t)}{\pi_{\theta_\text{old}}(a_t \
 
 ---
 
+<!-- columns: 52/48 -->
 ## Why does PPO use `torch.max` for both policy and value losses?
 
 <!-- footnote-right: Source: [@jacoboromerodiaz6967 on YouTube (Lecture 4)](https://www.youtube.com/watch?v=i-AIMpZHgeg&lc=UgwjmSeeAuvtuN_B85R4AaABAg) -->
 
 ```python
-pg_losses1 = -advantages * ratio
-pg_losses2 = -advantages * torch.clamp(ratio, 1.0 - eps, 1.0 + eps)
-pg_loss = torch.max(pg_losses1, pg_losses2)
+# PPO minimizes a negative policy loss
+pg_loss_unclipped = -advantages * ratio
+pg_loss_clipped = -advantages * torch.clamp(
+    ratio, 1.0 - eps, 1.0 + eps
+)
+
+# choose the more conservative / worse loss
+pg_loss = torch.max(pg_loss_unclipped, pg_loss_clipped)
+```
+
+`torch.max` matters because PPO is written as a **loss to minimize**.
+
+It selects the update that gives less improvement after clipping.
+
+|||
+
+```python
+# value clipping: do not let critic jump too far
+v_clip = old_values + torch.clamp(
+    v_pred - old_values, -vf_eps, vf_eps
+)
 
 vf_unclipped = 0.5 * (v_pred - targets) ** 2
 vf_clipped = 0.5 * (v_clip - targets) ** 2
+
+# optimize the worse value error
 vf_loss = torch.max(vf_unclipped, vf_clipped)
 ```
 
----
+Policy clipping limits policy drift.
 
-## How should we debug model collapse with sparse rewards and a strict DSL?
+Value clipping limits critic drift.
 
-<!-- footnote-right: Source: [@JGLambourne on YouTube (Lecture 4)](https://www.youtube.com/watch?v=i-AIMpZHgeg&lc=UgyHn_MoFfktNiZK4cJ4AaABAg) -->
-
-Context: giving a negative reward when the DSL syntax is not met did not help and could accelerate collapse.
+Same pattern: compare unclipped vs clipped, train on the worse one.
 
 ---
 
@@ -159,6 +265,8 @@ Context: giving a negative reward when the DSL syntax is not met did not help an
 ## How should data-annotation companies stay valuable as synthetic data gets simpler?
 
 <!-- footnote-right: Source: [@lorenzogaletto4442 on YouTube (Lecture 4)](https://www.youtube.com/watch?v=i-AIMpZHgeg&lc=UgzV2pnGCuqSIV4CXRh4AaABAg) -->
+
+A big shift underway from "grunt" low-skill work to expert domains like law, finance, healthcare, consulting, which solves a lot of the data company problems.
 
 Context from the reader: this asks about the aside in Chapter 11 on companies that vet data annotators.
 

--- a/teach/course/qa-01.md
+++ b/teach/course/qa-01.md
@@ -47,14 +47,6 @@ custom_css: |
 
 ---
 
-## Which policy-gradient derivation steps need a slower walkthrough?
-
-<!-- footnote-right: Source: [@matteo679 on YouTube (Lecture 3)](https://www.youtube.com/watch?v=K_Sj_-1BUMM&lc=Ugzn5NQZ6NYEcx3udtF4AaABAg) -->
-
-Prompted by feedback asking for a calmer, more step-by-step explanation of the derivation section.
-
----
-
 <!-- layout: section-break -->
 <!-- title: center -->
 
@@ -118,31 +110,11 @@ $$J(\theta) = \mathbb{E}_t\!\left[\min\!\left(\rho_t(\theta)\hat{A}_t,\; \text{c
 
 ---
 
-## Should the notation section define $T$, $K$, and $G$?
-
-<!-- footnote-right: Source: [issue #382 on GitHub](https://github.com/natolambert/rlhf-book/issues/382) -->
-
-Symbols flagged: $T$, $K$, $G$.
-
----
-
 ## What is the shape of $\rho$?
 
 <!-- footnote-right: Source: [@JGLambourne on YouTube (Lecture 3)](https://www.youtube.com/watch?v=K_Sj_-1BUMM&lc=UgwC9D0I4zmtGtyyGz14AaABAg) -->
 
 $$\rho_t(\theta) = \frac{\pi_\theta(a_t \mid s_t)}{\pi_{\theta_\text{old}}(a_t \mid s_t)}$$
-
----
-
-## Are slides 59-61 in Lecture 3 out of order?
-
-<!-- footnote-right: Source: [issue #382 on GitHub](https://github.com/natolambert/rlhf-book/issues/382) -->
-
-Proposed flow:
-
-1. What can we do with more conservative gradients?
-2. PPO core idea 1: constrained updates
-3. PPO core idea 2: importance sampling
 
 ---
 
@@ -192,13 +164,49 @@ Context from the reader: this asks about the aside in Chapter 11 on companies th
 
 ---
 
-<!-- layout: section-break -->
-<!-- title: center -->
+<!-- columns: 50/50 -->
+## What comes next?
 
-## More answers & follow-ups
+```box
+title: Catch up
+tone: accent
+compact: true
+content: |
+  - [Course page](https://rlhfbook.com/course)
+  - [Welcome video](https://www.youtube.com/watch?v=jQPiH-KB4B0&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y)
+  - [Lecture 1: Overview](https://www.youtube.com/watch?v=o6l6tJQgUg4&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=2)
+  - [Lecture 2: IFT, RMs, rejection sampling](https://www.youtube.com/watch?v=4gIwiSPmQkU&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=3)
+  - [Lecture 3: RL motivation & math](https://www.youtube.com/watch?v=K_Sj_-1BUMM&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=4)
+  - [Lecture 4: RL implementation & practice](https://www.youtube.com/watch?v=i-AIMpZHgeg&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=5)
+```
+
+|||
+
+```box
+title: Upcoming lectures
+tone: surface
+compact: true
+content: |
+  - **Lecture 5:** Reasoning training & inference-time scaling
+  - **Lecture 6:** Direct alignment algorithms
+  - **Later:** Preferences, preference data, synthetic data, tools, evaluation, product, and style
+```
 
 ---
 
-## Which questions should move from backlog into future Q&A rounds?
+<!-- rows: 85/15 -->
+## Thanks for watching
 
-Track recurring themes as more comments arrive: data mixtures, reward granularity, PPO implementation details, and debugging unstable RL runs.
+Questions, comments, and future Q&A prompts:
+
+- Course: [rlhfbook.com/course](https://rlhfbook.com/course)
+- Discord: [discord.gg/yz5AwK4gBR](https://discord.gg/yz5AwK4gBR)
+- GitHub: [github.com/natolambert/rlhf-book](https://github.com/natolambert/rlhf-book)
+- Newsletter: [interconnects.ai](https://www.interconnects.ai/)
+- Contact: nathan@natolambert.com
+
+===
+
+```builtwith
+repo: natolambert/colloquium
+```


### PR DESCRIPTION
## Summary

- New `teach/course/qa-01.md` — first round of a Q&A slide deck series. Each slide is a placeholder: reader's question quoted, light context in the body, attribution in the footer. I'll talk through each one live and we can flesh out follow-up slides after.
- Uses the `title-banner` layout on the title slide to make Q&A decks visually distinct from the lecture decks.
- Drops the small Contents mini-ToC from `book/templates/course.html` (the page is short enough without it) and adds the Q&A deck as an inline entry in the Lectures list, after Lecture 4.

## Questions in this round

**Lecture 2** — IFT, Reward Models, & Rejection Sampling
- One model vs. many for synthetic SFT data? — @mufeezamjad790 (YouTube)
- Should teacher distribution match the base model? — @mufeezamjad790 (YouTube)
- Unified RM benchmark across RM types on one dataset? — @jeromeeusebius (YouTube)
- How important is balancing domain proportions in an SFT mix? — @jeromeeusebius (YouTube)

**Lecture 3** — RL Motivation & Math
- What is the shape of $\rho$? — @JGLambourne (YouTube)
- Is GAE the only way to compute the advantage in PPO? — [#382](https://github.com/natolambert/rlhf-book/issues/382)
- Should the notation table define $T$, $K$, $G$? — [#382](https://github.com/natolambert/rlhf-book/issues/382)
- Are slides 59–61 in Lec 3 in the right order? — [#382](https://github.com/natolambert/rlhf-book/issues/382)

## Test plan

- [ ] Check the rendered course page on the Pages preview: Contents nav is gone, Q&A entry shows up after Lecture 4 with PDF / Slides / Source buttons.
- [ ] Confirm the Q&A deck builds (HTML + PDF) and the `title-banner` layout looks right.
- [ ] Click through each Q slide and sanity-check the per-slide footer attribution renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)