### PR TITLE
[codex] add code import smoke tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Code checks
 
 on:
   pull_request:
@@ -23,3 +23,17 @@ jobs:
 
       - name: Ruff format check
         run: uvx ruff@0.14.5 format --check .
+
+  smoke-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: code
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Run smoke tests
+        run: uv run --extra dev pytest

--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,6 +5,8 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
+- 2026-05-05: [PR #396](https://github.com/natolambert/rlhf-book/pull/396) added lightweight import and CLI smoke tests for the `code/` subpackages.
+
 ## v0.3.0
 
 - 2026-05-05: [PR #395](https://github.com/natolambert/rlhf-book/pull/395) updated the canonical DAPO and MaxRL policy-gradient reference runs.

--- a/code/CLAUDE.md
+++ b/code/CLAUDE.md
@@ -6,7 +6,7 @@
 - **Always run training commands in background** using `run_in_background: true` to avoid blocking
 - **Be careful with parallel jobs**: Only run one training job at a time unless you verify memory is available. Running too many can OOM the system.
 - **If using a DGX Spark**: ~120GB unified CPU/GPU memory — aim for <80GB usage to be safe. Flash Attention is not available on ARM64/Blackwell; the code automatically falls back to PyTorch SDPA.
-- **Before finalizing changes under `code/`**, run `uvx ruff@0.14.5 check .` and `uvx ruff@0.14.5 format --check .` — both are enforced by CI on PRs that touch `code/` (see `.github/workflows/lint.yml`). Use `uvx ruff@0.14.5 check --fix .` and `uvx ruff@0.14.5 format .` to auto-fix. Pin the version to match CI; unpinned `uvx ruff` can diverge.
+- **Before finalizing changes under `code/`**, run `uvx ruff@0.14.5 check .`, `uvx ruff@0.14.5 format --check .`, and `uv run --extra dev pytest` — all are enforced by CI on PRs that touch `code/` (see `.github/workflows/lint.yml`). Use `uvx ruff@0.14.5 check --fix .` and `uvx ruff@0.14.5 format .` to auto-fix. Pin the ruff version to match CI; unpinned `uvx ruff` can diverge.
 
 ## Contributing
 

--- a/code/CONTRIBUTING.md
+++ b/code/CONTRIBUTING.md
@@ -18,3 +18,9 @@ CI requires PRs that touch `code/` to also modify `code/CHANGELOG.md` (the file 
 ## Before Submitting
 
 If you use Claude Code, run `/pre-submit-pr` and paste its output in your PR description.
+
+## Smoke Tests
+
+When adding a new top-level code module, add its import path to `tests/test_import_smoke.py` so CI catches broken package wiring. If the module exposes a runnable CLI entrypoint, add that module to the CLI help smoke tests too.
+
+Keep these tests lightweight: they should verify imports, entrypoint wiring, and tiny helper signatures only. They should not download datasets, load models, start training, or require GPUs.

--- a/code/README.md
+++ b/code/README.md
@@ -288,6 +288,14 @@ uvx ruff format .
 
 Configuration is in `pyproject.toml` (line length 100, Python 3.12 target).
 
+## Testing
+
+The test suite intentionally starts with lightweight smoke coverage for imports and CLI entrypoints. It should not download datasets, load models, or require GPUs.
+
+```bash
+uv run --extra dev pytest
+```
+
 ## Book Chapters
 
 These examples correspond to:

--- a/code/pyproject.toml
+++ b/code/pyproject.toml
@@ -37,6 +37,7 @@ diagnostics = [
 
 # Development dependencies
 dev = [
+    "pytest>=8.0.0",
     "ruff>=0.4.0",
     "pre-commit>=3.7.0",
 ]

--- a/code/tests/test_import_smoke.py
+++ b/code/tests/test_import_smoke.py
@@ -1,0 +1,94 @@
+"""Smoke tests for the educational code package boundaries.
+
+These intentionally stop at import and CLI-help coverage. They catch broken
+module wiring without downloading datasets, loading models, or requiring GPUs.
+"""
+
+from __future__ import annotations
+
+import importlib
+import io
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+
+
+CODE_ROOT = Path(__file__).resolve().parents[1]
+
+CORE_MODULES = [
+    "direct_alignment",
+    "direct_alignment.config",
+    "direct_alignment.data",
+    "direct_alignment.loss",
+    "direct_alignment.profile_memory",
+    "direct_alignment.train",
+    "policy_gradients",
+    "policy_gradients.buffer",
+    "policy_gradients.config",
+    "policy_gradients.loss",
+    "policy_gradients.rollout",
+    "policy_gradients.train",
+    "policy_gradients.utils",
+    "rejection_sampling",
+    "rejection_sampling.config",
+    "rejection_sampling.preprocess",
+    "rejection_sampling.selection",
+    "rejection_sampling.train",
+    "rejection_sampling.utils",
+    "reward_models",
+    "reward_models.base",
+    "reward_models.train_orm",
+    "reward_models.train_preference_rm",
+    "reward_models.train_prm",
+]
+
+CLI_MODULES = [
+    "direct_alignment.train",
+    "policy_gradients.train",
+    "rejection_sampling.preprocess",
+    "rejection_sampling.train",
+    "reward_models.train_orm",
+    "reward_models.train_preference_rm",
+    "reward_models.train_prm",
+]
+
+
+@pytest.mark.parametrize("module_name", CORE_MODULES)
+def test_core_module_imports(module_name: str) -> None:
+    importlib.import_module(module_name)
+
+
+@pytest.mark.parametrize("module_name", CLI_MODULES)
+def test_cli_modules_render_help(module_name: str) -> None:
+    env = {
+        **os.environ,
+        "PYTHONPATH": f"{CODE_ROOT}{os.pathsep}{os.environ.get('PYTHONPATH', '')}",
+    }
+    result = subprocess.run(
+        [sys.executable, "-m", module_name, "--help"],
+        cwd=CODE_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert "usage:" in result.stdout.lower()
+
+
+def test_progress_bar_helper_signatures() -> None:
+    pg_utils = importlib.import_module("policy_gradients.utils")
+    rs_utils = importlib.import_module("rejection_sampling.utils")
+    console = Console(file=io.StringIO(), force_terminal=False)
+
+    pg_utils.print_step_header(consumed=0, total=1)
+    assert pg_utils.progress_bar() is not None
+
+    rs_utils.print_step_header(console=console, step=0, total=1)
+    assert rs_utils.progress_bar(console=console) is not None


### PR DESCRIPTION
## Summary

- Add pytest smoke coverage for core `code/` package imports and CLI `--help` entrypoints.
- Add a tiny helper-signature smoke test for the progress-bar functions involved in the recent rejection-sampling import break.
- Run the smoke suite in GitHub Actions alongside Ruff and document the local command.

## Why

PR #393 showed that Ruff alone can miss runtime import wiring regressions between the educational code subpackages. This keeps the first test layer intentionally small: no dataset downloads, model loading, or GPU assumptions.

## Validation

- `cd code && uvx ruff@0.14.5 check .`
- `cd code && uvx ruff@0.14.5 format --check .`
- `cd code && uv run --extra dev pytest`