### PR TITLE
Add exposure bias and DAgger error analysis to OPD section

### DIFF
--- a/book/chapters/12-synthetic-data.md
+++ b/book/chapters/12-synthetic-data.md
@@ -193,7 +193,9 @@ $$ {#eq:dagger_trajectory}
 
 This $O(\epsilon L^2)$ compounding is especially pronounced for modern LLMs, which routinely generate sequences spanning thousands of tokens.
 A single suboptimal token shifts the prefix slightly out-of-distribution, and the model, having never seen this perturbed prefix, is more likely to err again, leading to degraded or hallucinatory text.
-On-policy distillation resolves this by replacing the teacher-rollout expectation in @eq:dagger_perstep with a student-rollout expectation: the student confronts its own mistakes, receives teacher feedback on the specific out-of-distribution states it visits, and learns recovery behaviors, reducing the compounding from $O(\epsilon L^2)$ to $O(\epsilon L)$.
+On-policy distillation addresses this by *iteratively* sampling completions from the current student and supervising them with the teacher at the visited states.
+The student confronts its own mistakes, receives teacher feedback on the specific out-of-distribution states it visits, and learns recovery behaviors.
+Under DAgger's interactive imitation-learning analysis, this iterative procedure reduces the compounding from $O(\epsilon L^2)$ to $O(\epsilon L)$ [@ross2011reduction].
 
 For on-policy distillation, let $s$ be a prompt, $a = (a_1,\ldots,a_L)$ be a completion sampled from the current student policy $\pi_\theta(\cdot \mid s)$, and let $s_t = (s, a_{<t})$ be the token-level state at step $t$.
 The teacher policy $\pi_T$ is fixed, so the objective compares the student's next-token distribution to the teacher's distribution on states induced by the student.

--- a/book/chapters/12-synthetic-data.md
+++ b/book/chapters/12-synthetic-data.md
@@ -155,10 +155,45 @@ The offline nature of the learning meant that the student models could suffer fr
 For example, the forward KL objective can push student models to overestimate low-probability regions of the teacher distribution.
 Together, these issues were an opening for *on-policy* distillation (OPD).
 
+This train-test gap is known as **exposure bias** [@song2026surveyonpolicydistillationlarge].
+Offline KD samples teacher trajectories $u \sim \pi_T(\cdot \mid s)$ and minimizes the per-token KL on the resulting prefixes,
+
+$$
+\mathcal{L}_{\mathrm{train}}(\theta)
+= \mathbb{E}_{u \sim \pi_T(\cdot \mid s)}
+\sum_t D_{\mathrm{KL}}\!\left(\pi_T(\cdot \mid s, u_{<t}) \;\|\; \pi_\theta(\cdot \mid s, u_{<t})\right).
+$$ {#eq:exposure_train}
+
+At inference the student instead rolls out under its own policy, so the quantity that actually matters is the expected task loss along *its own* trajectories,
+
+$$
+\mathcal{L}_{\mathrm{test}}(\theta)
+= \mathbb{E}_{a \sim \pi_\theta(\cdot \mid s)}\,\mathcal{L}_{\mathrm{task}}(s, a).
+$$ {#eq:exposure_test}
+
+Exposure bias is the direct consequence of the inequality $\pi_T(\cdot \mid s) \neq \pi_\theta(\cdot \mid s)$: the prefixes $(s, u_{<t})$ visited during training and the prefixes $(s, a_{<t})$ visited at test time are drawn from different state-visitation distributions, so the student is supervised on a set of states distinct from those it acts on.
+
 The core shift to on-policy distillation is the idea that we can tweak the optimization by sampling from the student model and measuring its distance to the teacher distribution, rather than sampling from the teacher model.
 MiniLLM noted the need to shift to a reverse KL optimization (we explain intuitively why this target can be better in Chapter 15) and proposed using KD loss functions within an online policy-gradient RL framework [@gu2024minillm].
 Other concurrent work [@agarwal2024policy] showed the promise of on-policy KD and connected the iterative process of generating from the student and grading with a teacher to imitation-learning work from the RL literature.
 To make the connection, one such imitation-learning algorithm, DAgger, iteratively trains an agent that acts in the world with its learned policy and is given feedback from an oracle policy on what action it should have taken, which can then be used to update its policy [@ross2011reduction].
+
+The cost of this gap can be quantified through imitation-learning bounds.
+Suppose the student matches the teacher within an expected per-step error $\epsilon$ on the training distribution,
+
+$$
+\mathbb{E}_{u \sim \pi_T(\cdot \mid s)}\!\left[\mathbb{I}\!\left(\pi_\theta(\cdot \mid s, u_{<t}) \neq \pi_T(\cdot \mid s, u_{<t})\right)\right] \leq \epsilon.
+$$ {#eq:dagger_perstep}
+
+The DAgger analysis [@ross2011reduction] shows that the expected loss accumulated along a length-$L$ trajectory sampled from the student then scales quadratically in $L$ [@song2026surveyonpolicydistillationlarge]:
+
+$$
+\mathbb{E}_{a \sim \pi_\theta(\cdot \mid s)}\!\left[\sum_{t=1}^{L} \ell\!\left(s, a_{<t}\right)\right] \leq O(\epsilon L^2).
+$$ {#eq:dagger_trajectory}
+
+This $O(\epsilon L^2)$ compounding is especially pronounced for modern LLMs, which routinely generate sequences spanning thousands of tokens.
+A single suboptimal token shifts the prefix slightly out-of-distribution, and the model, having never seen this perturbed prefix, is more likely to err again, leading to degraded or hallucinatory text.
+On-policy distillation resolves this by replacing the teacher-rollout expectation in @eq:dagger_perstep with a student-rollout expectation: the student confronts its own mistakes, receives teacher feedback on the specific out-of-distribution states it visits, and learns recovery behaviors, reducing the compounding from $O(\epsilon L^2)$ to $O(\epsilon L)$.
 
 For on-policy distillation, let $s$ be a prompt, $a = (a_1,\ldots,a_L)$ be a completion sampled from the current student policy $\pi_\theta(\cdot \mid s)$, and let $s_t = (s, a_{<t})$ be the token-level state at step $t$.
 The teacher policy $\pi_T$ is fixed, so the objective compares the student's next-token distribution to the teacher's distribution on states induced by the student.

--- a/book/chapters/12-synthetic-data.md
+++ b/book/chapters/12-synthetic-data.md
@@ -184,8 +184,8 @@ MiniLLM noted the need to shift to a reverse KL optimization (we explain intuiti
 Other concurrent work [@agarwal2024policy] showed the promise of on-policy KD and connected the iterative process of generating from the student and grading with a teacher to imitation-learning work from the RL literature.
 To make the connection, one such imitation-learning algorithm, DAgger, iteratively trains an agent that acts in the world with its learned policy and is given feedback from an oracle policy on what action it should have taken, which can then be used to update its policy [@ross2011reduction].
 
-The cost of this gap can be quantified through imitation-learning bounds.
-In the original discrete-action DAgger setting, suppose the learned policy matches the teacher within an expected per-step action error $\epsilon$ on the teacher-induced training distribution, where $\mathbb{I}[\cdot]$ is an indicator that returns 1 when its condition is true and 0 otherwise,
+The cost of this gap can be quantified through the supervised imitation-learning bound that motivates DAgger.
+In the original discrete-action setting, suppose the learned policy matches the teacher within an expected per-step action error $\epsilon$ on the teacher-induced training distribution, where $\mathbb{I}[\cdot]$ is an indicator that returns 1 when its condition is true and 0 otherwise,
 
 $$
 \mathbb{E}_{s_t \sim d_{\pi_T}}\!\left[
@@ -193,7 +193,7 @@ $$
 \right] \leq \epsilon.
 $$ {#eq:dagger_perstep}
 
-The DAgger analysis [@ross2011reduction] shows that the expected loss accumulated along a length-$L$ trajectory sampled from the student then scales quadratically in $L$ [@song2026surveyonpolicydistillationlarge]:
+The supervised imitation-learning analysis [@ross2011reduction] shows that the expected loss accumulated along a length-$L$ trajectory sampled from the student can scale quadratically in $L$ [@song2026surveyonpolicydistillationlarge]:
 
 $$
 \mathbb{E}_{a \sim \pi_\theta(\cdot \mid s)}\!\left[\sum_{t=1}^{L} \ell\!\left(s, a_{<t}\right)\right] \leq O(\epsilon L^2).

--- a/book/chapters/12-synthetic-data.md
+++ b/book/chapters/12-synthetic-data.md
@@ -155,22 +155,28 @@ The offline nature of the learning meant that the student models could suffer fr
 For example, the forward KL objective can push student models to overestimate low-probability regions of the teacher distribution.
 Together, these issues were an opening for *on-policy* distillation (OPD).
 
-This train-test gap is known as **exposure bias** [@song2026surveyonpolicydistillationlarge].
+This train-test gap is known as **exposure bias** [@arora-etal-2022-exposure] [@song2026surveyonpolicydistillationlarge].
 Offline KD samples teacher trajectories $u \sim \pi_T(\cdot \mid s)$ and minimizes the per-token KL on the resulting prefixes,
 
 $$
-\mathcal{L}_{\mathrm{train}}(\theta)
-= \mathbb{E}_{u \sim \pi_T(\cdot \mid s)}
-\sum_t D_{\mathrm{KL}}\!\left(\pi_T(\cdot \mid s, u_{<t}) \;\|\; \pi_\theta(\cdot \mid s, u_{<t})\right).
+\mathcal{L}_{\mathrm{KD}}(\theta)
+= \mathbb{E}_{s \sim \mathcal{D},\, u \sim \pi_T(\cdot \mid s)}
+\sum_t D_{\mathrm{KL}}\!\left(
+\pi_T(\cdot \mid s, u_{<t})
+\;\|\;
+\pi_\theta(\cdot \mid s, u_{<t})
+\right).
 $$ {#eq:exposure_train}
 
 At inference the student instead rolls out under its own policy, so the quantity that actually matters is the expected task loss along *its own* trajectories,
 
 $$
-\mathcal{L}_{\mathrm{test}}(\theta)
-= \mathbb{E}_{a \sim \pi_\theta(\cdot \mid s)}\,\mathcal{L}_{\mathrm{task}}(s, a).
+\mathcal{L}_{\mathrm{eval}}(\theta)
+= \mathbb{E}_{s \sim \mathcal{D}_{\mathrm{test}},\, a \sim \pi_\theta(\cdot \mid s)}
+\ell_{\mathrm{task}}(s, a)
 $$ {#eq:exposure_test}
 
+Here, $\ell_{\mathrm{task}}(s, a)$ denotes any downstream task loss for the completed student response, such as answer incorrectness, failed test cases, or a judge/rubric loss.
 Exposure bias is the direct consequence of the inequality $\pi_T(\cdot \mid s) \neq \pi_\theta(\cdot \mid s)$: the prefixes $(s, u_{<t})$ visited during training and the prefixes $(s, a_{<t})$ visited at test time are drawn from different state-visitation distributions, so the student is supervised on a set of states distinct from those it acts on.
 
 The core shift to on-policy distillation is the idea that we can tweak the optimization by sampling from the student model and measuring its distance to the teacher distribution, rather than sampling from the teacher model.
@@ -179,10 +185,12 @@ Other concurrent work [@agarwal2024policy] showed the promise of on-policy KD an
 To make the connection, one such imitation-learning algorithm, DAgger, iteratively trains an agent that acts in the world with its learned policy and is given feedback from an oracle policy on what action it should have taken, which can then be used to update its policy [@ross2011reduction].
 
 The cost of this gap can be quantified through imitation-learning bounds.
-Suppose the student matches the teacher within an expected per-step error $\epsilon$ on the training distribution,
+In the original discrete-action DAgger setting, suppose the learned policy matches the teacher within an expected per-step action error $\epsilon$ on the teacher-induced training distribution, where $\mathbb{I}[\cdot]$ is an indicator that returns 1 when its condition is true and 0 otherwise,
 
 $$
-\mathbb{E}_{u \sim \pi_T(\cdot \mid s)}\!\left[\mathbb{I}\!\left(\pi_\theta(\cdot \mid s, u_{<t}) \neq \pi_T(\cdot \mid s, u_{<t})\right)\right] \leq \epsilon.
+\mathbb{E}_{s_t \sim d_{\pi_T}}\!\left[
+\mathbb{I}\!\left(\pi_\theta(s_t) \neq \pi_T(s_t)\right)
+\right] \leq \epsilon.
 $$ {#eq:dagger_perstep}
 
 The DAgger analysis [@ross2011reduction] shows that the expected loss accumulated along a length-$L$ trajectory sampled from the student then scales quadratically in $L$ [@song2026surveyonpolicydistillationlarge]:
@@ -191,11 +199,16 @@ $$
 \mathbb{E}_{a \sim \pi_\theta(\cdot \mid s)}\!\left[\sum_{t=1}^{L} \ell\!\left(s, a_{<t}\right)\right] \leq O(\epsilon L^2).
 $$ {#eq:dagger_trajectory}
 
-This $O(\epsilon L^2)$ compounding is especially pronounced for modern LLMs, which routinely generate sequences spanning thousands of tokens.
+For LLMs, this discrete-action bound should be read as an analogy rather than a theoretical guarantee.
+In practice, LLMs predict full next-token distributions over long horizons, so the 0-1 action-disagreement assumption in @eq:dagger_perstep does not apply cleanly.
+Prompts or prefixes map naturally to states and sampled tokens map to actions, but token-level distillation is usually measured with distributional losses such as KL or cross-entropy, so the classic DAgger math does not transfer exactly.
+
+This kind of $O(\epsilon L^2)$ compounding is especially pronounced for modern LLMs, which routinely generate sequences spanning thousands of tokens.
 A single suboptimal token shifts the prefix slightly out-of-distribution, and the model, having never seen this perturbed prefix, is more likely to err again, leading to degraded or hallucinatory text.
 On-policy distillation addresses this by *iteratively* sampling completions from the current student and supervising them with the teacher at the visited states.
 The student confronts its own mistakes, receives teacher feedback on the specific out-of-distribution states it visits, and learns recovery behaviors.
-Under DAgger's interactive imitation-learning analysis, this iterative procedure reduces the compounding from $O(\epsilon L^2)$ to $O(\epsilon L)$ [@ross2011reduction].
+Under DAgger's interactive imitation-learning analysis, this iterative procedure can reduce the compounding from $O(\epsilon L^2)$ to $O(\epsilon L)$ [@ross2011reduction].
+For LLMs, this explains the motivation behind OPD: the exact bounds may not carry over cleanly to every token-level distillation setup, but the practical success of on-policy methods supports the underlying intuition.
 
 For on-policy distillation, let $s$ be a prompt, $a = (a_1,\ldots,a_L)$ be a completion sampled from the current student policy $\pi_\theta(\cdot \mid s)$, and let $s_t = (s, a_{<t})$ be the token-level state at step $t$.
 The teacher policy $\pi_T$ is fixed, so the objective compares the student's next-token distribution to the teacher's distribution on states induced by the student.

--- a/book/chapters/bib.bib
+++ b/book/chapters/bib.bib
@@ -3259,6 +3259,26 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   url={https://openreview.net/forum?id=3zKtaqxLhW}
 }
 
+@inproceedings{arora-etal-2022-exposure,
+    title = "Why Exposure Bias Matters: An Imitation Learning Perspective of Error Accumulation in Language Generation",
+    author = "Arora, Kushal  and
+      El Asri, Layla  and
+      Bahuleyan, Hareesh  and
+      Cheung, Jackie Chi Kit",
+    editor = "Muresan, Smaranda  and
+      Nakov, Preslav  and
+      Villavicencio, Aline",
+    booktitle = "Findings of the Association for Computational Linguistics: ACL 2022",
+    month = may,
+    year = "2022",
+    address = "Dublin, Ireland",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2022.findings-acl.58/",
+    doi = "10.18653/v1/2022.findings-acl.58",
+    pages = "700--710",
+    abstract = "Current language generation models suffer from issues such as repetition, incoherence, and hallucinations. An often-repeated hypothesis for this brittleness of generation models is that it is caused by the training and the generation procedure mismatch, also referred to as exposure bias. In this paper, we verify this hypothesis by analyzing exposure bias from an imitation learning perspective. We show that exposure bias leads to an accumulation of errors during generation, analyze why perplexity fails to capture this accumulation of errors, and empirically show that this accumulation results in poor generation quality."
+}
+
 @misc{song2026surveyonpolicydistillationlarge,
   title={A Survey of On-Policy Distillation for Large Language Models},
   author={Song, Mingyang and Zheng, Mao},

--- a/book/chapters/bib.bib
+++ b/book/chapters/bib.bib
@@ -3259,6 +3259,16 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   url={https://openreview.net/forum?id=3zKtaqxLhW}
 }
 
+@misc{song2026surveyonpolicydistillationlarge,
+  title={A Survey of On-Policy Distillation for Large Language Models},
+  author={Song, Mingyang and Zheng, Mao},
+  year={2026},
+  eprint={2604.00626},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG},
+  url={https://arxiv.org/abs/2604.00626}
+}
+
 @article{hinton2015distilling,
   title={Distilling the knowledge in a neural network},
   author={Hinton, Geoffrey and Vinyals, Oriol and Dean, Jeff},


### PR DESCRIPTION
## Summary

Adds two short, formal additions to the on-policy distillation discussion in Chapter 12 (Synthetic Data), motivating why OPD is needed beyond offline KD. Both are based on Song & Zheng's *A Survey of On-Policy Distillation for Large Language Models* (pages 4-6) and use the chapter's existing teacher/student notation (`π_T`, `π_θ`, `u`, `a`).

### 1. Exposure bias (after the offline-KD limitations paragraph)

- Names the train-test gap as **exposure bias** and cites the survey.
- Introduces two losses:
  - `L_train` — per-token KL on teacher-rollout prefixes, with `u ~ π_T(·|s)`.
  - `L_test` — expected task loss along student rollouts, with `a ~ π_θ(·|s)`.
- No `d_𝒟`-style state-visitation notation is introduced.
- Ties exposure bias to the policy inequality `π_T ≠ π_θ` and the resulting mismatch between teacher-induced prefixes `(s, u_<t)` and student-induced prefixes `(s, a_<t)`.

### 2. DAgger error analysis (right before the formal OPD setup)

- Per-step error condition (`#eq:dagger_perstep`): expected teacher-student disagreement on teacher-induced prefixes bounded by `ε`.
- Trajectory bound (`#eq:dagger_trajectory`): `O(εL²)` compounding under student rollouts, citing `ross2011reduction` and the survey.
- Keeps the survey's quote about a single suboptimal token shifting the prefix out-of-distribution and compounding into hallucinatory text.
- Closes by attributing the `O(εL²) → O(εL)` improvement to DAgger's iterative on-policy procedure (rolling out the student, querying the teacher, retraining) — softened from an earlier "expectation swap" framing per Codex review feedback.

### Bib

- Adds `@misc{song2026surveyonpolicydistillationlarge, ...}` to ` book/chapters/bib.bib `, placed next to the other distillation entries.

## Test plan

- [x] ` make html ` builds without pandoc errors and renders the new equations
- [ ] ` make pdf ` builds without LaTeX errors
- [ ] Cross-references ` @eq:dagger_perstep `, ` @eq:dagger_trajectory `, ` @eq:exposure_train `, ` @eq:exposure_test ` resolve
- [x] Visual check that the new equations sit cleanly between the existing offline-KD prose and the formal OPD setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)