### PR TITLE
[codex] Refine SEO metadata titles

### DIFF
--- a/book/chapters/01-introduction.md
+++ b/book/chapters/01-introduction.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "Home"
 prev-url: "https://rlhfbook.com/"
-page-title: Introduction
+page-title: "What Is RLHF? A Practical Introduction"
 search-title: "Chapter 1: Introduction"
 next-chapter: "A Tiny History of RLHF"
 next-url: "02-related-works"

--- a/book/chapters/02-related-works.md
+++ b/book/chapters/02-related-works.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "Introduction"
 prev-url: "01-introduction"
-page-title: A Tiny History of RLHF
+page-title: "RLHF History: From Preferences to ChatGPT"
 search-title: "Chapter 2: A Tiny History of RLHF"
 next-chapter: "Training Overview"
 next-url: "03-training-overview"

--- a/book/chapters/03-training-overview.md
+++ b/book/chapters/03-training-overview.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "A Tiny History of RLHF"
 prev-url: "02-related-works"
-page-title: Training Overview
+page-title: "RLHF Training Pipeline: SFT, Reward Models, RL"
 search-title: "Chapter 3: Training Overview"
 next-chapter: "Instruction Fine-Tuning"
 next-url: "04-instruction-tuning"

--- a/book/chapters/04-instruction-tuning.md
+++ b/book/chapters/04-instruction-tuning.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "Training Overview"
 prev-url: "03-training-overview"
-page-title: Instruction Fine-Tuning
+page-title: Instruction Fine-Tuning for LLMs
 search-title: "Chapter 4: Instruction Fine-Tuning"
 next-chapter: "Reward Modeling"
 next-url: "05-reward-models"

--- a/book/chapters/05-reward-models.md
+++ b/book/chapters/05-reward-models.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "Instruction Fine-Tuning"
 prev-url: "04-instruction-tuning"
-page-title: Reward Modeling
+page-title: Reward Models for RLHF
 search-title: "Chapter 5: Reward Modeling"
 next-chapter: "Reinforcement Learning"
 next-url: "06-policy-gradients"

--- a/book/chapters/06-policy-gradients.md
+++ b/book/chapters/06-policy-gradients.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "Reward Modeling"
 prev-url: "05-reward-models"
-page-title: Reinforcement Learning
+page-title: "RL for LLMs: PPO, GRPO, RLOO"
 search-title: "Chapter 6: Reinforcement Learning"
 next-chapter: "Reasoning and Inference-Time Scaling"
 next-url: "07-reasoning"

--- a/book/chapters/07-reasoning.md
+++ b/book/chapters/07-reasoning.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "Reinforcement Learning"
 prev-url: "06-policy-gradients"
-page-title: Reasoning and Inference-Time Scaling
+page-title: RLVR and Reasoning Models
 search-title: "Chapter 7: Reasoning and Inference-Time Scaling"
 next-chapter: "Direct-Alignment Algorithms"
 next-url: "08-direct-alignment"

--- a/book/chapters/08-direct-alignment.md
+++ b/book/chapters/08-direct-alignment.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "Reasoning and Inference-Time Scaling"
 prev-url: "07-reasoning"
-page-title: Direct-Alignment Algorithms
+page-title: DPO and Direct Alignment Algorithms
 search-title: "Chapter 8: Direct-Alignment Algorithms"
 next-chapter: "Rejection Sampling"
 next-url: "09-rejection-sampling"

--- a/book/chapters/09-rejection-sampling.md
+++ b/book/chapters/09-rejection-sampling.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "Direct-Alignment Algorithms"
 prev-url: "08-direct-alignment"
-page-title: Rejection Sampling
+page-title: Rejection Sampling and Best-of-N for RLHF
 search-title: "Chapter 9: Rejection Sampling"
 next-chapter: "The Nature of Preferences"
 next-url: "10-preferences"

--- a/book/chapters/10-preferences.md
+++ b/book/chapters/10-preferences.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "Rejection Sampling"
 prev-url: "09-rejection-sampling"
-page-title: The Nature of Preferences
+page-title: On Human Preferences in RLHF
 search-title: "Chapter 10: The Nature of Preferences"
 next-chapter: "Preference Data"
 next-url: "11-preference-data"

--- a/book/chapters/11-preference-data.md
+++ b/book/chapters/11-preference-data.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "The Nature of Preferences"
 prev-url: "10-preferences"
-page-title: Preference Data
+page-title: Preference Data Collection for RLHF
 search-title: "Chapter 11: Preference Data"
 next-chapter: "Synthetic Data"
 next-url: "12-synthetic-data"

--- a/book/chapters/12-synthetic-data.md
+++ b/book/chapters/12-synthetic-data.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "Preference Data"
 prev-url: "11-preference-data"
-page-title: Synthetic Data
+page-title: Synthetic Data for RLHF and Post-Training
 search-title: "Chapter 12: Synthetic Data"
 next-chapter: "Tool Use and Function Calling"
 next-url: "13-tools"

--- a/book/chapters/13-tools.md
+++ b/book/chapters/13-tools.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "Synthetic Data"
 prev-url: "12-synthetic-data"
-page-title: Tool Use and Function Calling
+page-title: Tool Use and Function Calling for LLMs
 search-title: "Chapter 13: Tool Use and Function Calling"
 next-chapter: "Over-Optimization"
 next-url: "14-over-optimization"

--- a/book/chapters/14-over-optimization.md
+++ b/book/chapters/14-over-optimization.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "Tool Use and Function Calling"
 prev-url: "13-tools"
-page-title: Over-Optimization
+page-title: Reward Model Over-Optimization in RLHF
 search-title: "Chapter 14: Over-Optimization"
 next-chapter: "Regularization"
 next-url: "15-regularization"

--- a/book/chapters/15-regularization.md
+++ b/book/chapters/15-regularization.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "Over-Optimization"
 prev-url: "14-over-optimization"
-page-title: Regularization
+page-title: KL Regularization in RLHF
 search-title: "Chapter 15: Regularization"
 next-chapter: "Evaluation"
 next-url: "16-evaluation"

--- a/book/chapters/16-evaluation.md
+++ b/book/chapters/16-evaluation.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "Regularization"
 prev-url: "15-regularization"
-page-title: Evaluation
+page-title: LLM Evaluation for Post-Training
 search-title: "Chapter 16: Evaluation"
 next-chapter: "Crafting Model Character and Products"
 next-url: "17-product"

--- a/book/chapters/17-product.md
+++ b/book/chapters/17-product.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "Evaluation"
 prev-url: "16-evaluation"
-page-title: Crafting Model Character and Products
+page-title: Model Character and Product Design
 search-title: "Chapter 17: Crafting Model Character and Products"
 next-chapter: "Definitions"
 next-url: "appendix-a-definitions"

--- a/book/chapters/appendix-a-definitions.md
+++ b/book/chapters/appendix-a-definitions.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "Crafting Model Character and Products"
 prev-url: "17-product"
-page-title: "Appendix A: Definitions"
+page-title: "RLHF Definitions and Glossary"
 search-title: "Appendix A: Definitions"
 next-chapter: "Beyond \"Just Style\""
 next-url: "appendix-b-style"

--- a/book/chapters/appendix-b-style.md
+++ b/book/chapters/appendix-b-style.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "Definitions"
 prev-url: "appendix-a-definitions"
-page-title: "Appendix B: Beyond \"Just Style\""
+page-title: "Beyond Just Style: Model Behavior"
 search-title: "Appendix B: Beyond \"Just Style\""
 next-chapter: "Practical Issues"
 next-url: "appendix-c-practical"

--- a/book/chapters/appendix-c-practical.md
+++ b/book/chapters/appendix-c-practical.md
@@ -7,7 +7,7 @@
 ---
 prev-chapter: "Beyond \"Just Style\""
 prev-url: "appendix-b-style"
-page-title: "Appendix C: Practical Issues"
+page-title: "Practical Issues in RLHF Training"
 search-title: "Appendix C: Practical Issues"
 next-chapter: "Home"
 next-url: "https://rlhfbook.com/"

--- a/book/rl-cheatsheet/index.html
+++ b/book/rl-cheatsheet/index.html
@@ -8,11 +8,11 @@
   <meta property="og:image" content="https://rlhfbook.com/assets/rlhf-book-share.png" />
   <meta property="og:image:width" content="1920" />
   <meta property="og:image:height" content="1080" />
-  <meta property="og:title" content="RL Cheatsheet | RLHF Book by Nathan Lambert" />
+  <meta property="og:title" content="RL for LLMs Algorithms Cheatsheet | RLHF Book by Nathan Lambert" />
   <meta property="og:description" content="One-page reference of core RL loss functions: Policy Gradient, REINFORCE, PPO, GRPO, DPO, and more." />
   <meta property="og:url" content="https://rlhfbook.com/rl-cheatsheet" />
 
-  <title>RL Cheatsheet | RLHF Book by Nathan Lambert</title>
+  <title>RL for LLMs Algorithms Cheatsheet | RLHF Book by Nathan Lambert</title>
 
   <style>
     #title-block-header {

--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -8,11 +8,11 @@
   <meta property="og:image" content="https://rlhfbook.com/assets/rlhf-book-share.png" />
   <meta property="og:image:width" content="1920" />
   <meta property="og:image:height" content="1080" />
-  <meta property="og:title" content="Course | RLHF Book by Nathan Lambert" />
+  <meta property="og:title" content="RLHF Course: Lectures on Post-Training | RLHF Book by Nathan Lambert" />
   <meta property="og:description" content="Course lectures and talks on RLHF and post-training." />
   <meta property="og:url" content="https://rlhfbook.com/course" />
 
-  <title>Course | RLHF Book by Nathan Lambert</title>
+  <title>RLHF Course: Lectures on Post-Training | RLHF Book by Nathan Lambert</title>
 
   <link rel="stylesheet" href="style.css" />
   <link href="/pagefind/pagefind-ui.css" rel="stylesheet">

--- a/book/templates/library.html
+++ b/book/templates/library.html
@@ -8,11 +8,11 @@
   <meta property="og:image" content="https://rlhfbook.com/assets/rlhf-book-share.png" />
   <meta property="og:image:width" content="1920" />
   <meta property="og:image:height" content="1080" />
-  <meta property="og:title" content="RLHF Model Library | RLHF Book by Nathan Lambert" />
+  <meta property="og:title" content="RLHF Model Completions Library | RLHF Book by Nathan Lambert" />
   <meta property="og:description" content="Compare supervised finetuned models with their RLHF/DPO counterparts across shared prompts." />
   <meta property="og:url" content="https://rlhfbook.com/library" />
 
-  <title>RLHF Model Library | RLHF Book by Nathan Lambert</title>
+  <title>RLHF Model Completions Library | RLHF Book by Nathan Lambert</title>
 
   <style>
     /* Center the title block for this page only */


### PR DESCRIPTION
## Summary

- Update SEO-only `page-title` metadata across the chapter pages and appendices while leaving visible chapter titles unchanged.
- Update the Library, Course, and RL cheatsheet browser/Open Graph titles while leaving visible page headings unchanged.
- Leave internal Pagefind titles, H1s, nav labels, chapter prev/next labels, references, and indexing behavior unchanged.

## Validation

- `git diff --check`
- Ruby frontmatter parse check for all `book/chapters/*.md`

Note: I did not run a Pandoc render because `pandoc` is not installed in this local shell.