### PR TITLE
[codex] Clean up web bibliography

### DIFF
--- a/book/chapters/bib.bib
+++ b/book/chapters/bib.bib
@@ -1,5 +1,148 @@
 ### First appearing in chapter 1 (Introduction) ###
 
+@article{christiano2017deep,
+  title={Deep reinforcement learning from human preferences},
+  author={Christiano, Paul F and Leike, Jan and Brown, Tom and Martic, Miljan and Legg, Shane and Amodei, Dario},
+  journal={Advances in neural information processing systems},
+  volume={30},
+  year={2017}
+}
+
+@article{stiennon2020learning,
+  title={Learning to summarize with human feedback},
+  author={Stiennon, Nisan and Ouyang, Long and Wu, Jeffrey and Ziegler, Daniel and Lowe, Ryan and Voss, Chelsea and Radford, Alec and Amodei, Dario and Christiano, Paul F},
+  journal={Advances in Neural Information Processing Systems},
+  volume={33},
+  pages={3008--3021},
+  year={2020}
+}
+
+@article{ouyang2022training,
+  title={Training language models to follow instructions with human feedback},
+  author={Ouyang, Long and Wu, Jeffrey and Jiang, Xu and Almeida, Diogo and Wainwright, Carroll and Mishkin, Pamela and Zhang, Chong and Agarwal, Sandhini and Slama, Katarina and Ray, Alex and others},
+  journal={Advances in neural information processing systems},
+  volume={35},
+  pages={27730--27744},
+  year={2022}
+}
+
+@article{nakano2021webgpt,
+  title={Webgpt: Browser-assisted question-answering with human feedback},
+  author={Nakano, Reiichiro and Hilton, Jacob and Balaji, Suchir and Wu, Jeff and Ouyang, Long and Kim, Christina and Hesse, Christopher and Jain, Shantanu and Kosaraju, Vineet and Saunders, William and others},
+  journal={arXiv preprint arXiv:2112.09332},
+  year={2021}
+}
+
+@article{bai2022training,
+  title={Training a helpful and harmless assistant with reinforcement learning from human feedback},
+  author={Bai, Yuntao and Jones, Andy and Ndousse, Kamal and Askell, Amanda and Chen, Anna and DasSarma, Nova and Drain, Dawn and Fort, Stanislav and Ganguli, Deep and Henighan, Tom and others},
+  journal={arXiv preprint arXiv:2204.05862},
+  year={2022}
+}
+
+@article{lambert2024t,
+  title={Tulu 3: Pushing Frontiers in Open Language Model Post-Training},
+  author={Lambert, Nathan and Morrison, Jacob and Pyatkin, Valentina and Huang, Shengyi and Ivison, Hamish and Brahman, Faeze and Miranda, Lester James V and Liu, Alisa and Dziri, Nouha and Lyu, Shane and others},
+  journal={arXiv preprint arXiv:2411.15124},
+  year={2024}
+}
+
+@article{dai2023safe,
+  title={Safe RLHF: Safe Reinforcement Learning from Human Feedback},
+  author={Josef Dai and Xuehai Pan and Ruiyang Sun and Jiaming Ji and Xinbo Xu and Mickel Liu and Yizhou Wang and Yaodong Yang},
+  year={2023},
+  journal={arXiv preprint arXiv:2310.12773},
+  url={https://arxiv.org/abs/2310.12773}
+}
+
+@inproceedings{kirk2023understanding,
+  title={Understanding the effects of rlhf on llm generalisation and diversity},
+  booktitle = {International Conference on Learning Representations (ICLR)},
+  author={Kirk, Robert and Mediratta, Ishita and Nalmpantis, Christoforos and Luketina, Jelena and Hambro, Eric and Grefenstette, Edward and Raileanu, Roberta},
+  year = {2024}
+}
+
+@inproceedings{chu2025sft,
+  title={Sft memorizes, rl generalizes: A comparative study of foundation model post-training},
+  booktitle = {International Conference on Machine Learning (ICML)},
+  author={Chu, Tianzhe and Zhai, Yuexiang and Yang, Jihan and Tong, Shengbang and Xie, Saining and Schuurmans, Dale and Le, Quoc V and Levine, Sergey and Ma, Yi},
+  year = {2025}
+}
+
+@article{singhal2023long,
+  title={A long way to go: Investigating length correlations in rlhf},
+  author={Singhal, Prasann and Goyal, Tanya and Xu, Jiacheng and Durrett, Greg},
+  journal={arXiv preprint arXiv:2310.03716},
+  year={2023}
+}
+
+@inproceedings{park2024disentangling,
+  title={Disentangling length from quality in direct preference optimization},
+  booktitle = {Findings of the Association for Computational Linguistics: ACL 2024},
+  author={Park, Ryan and Rafailov, Rafael and Ermon, Stefano and Finn, Chelsea},
+  pages = {4998--5017},
+  year = {2024}
+}
+
+@inproceedings{muennighoff2024olmoe,
+  title={Olmoe: Open mixture-of-experts language models},
+  booktitle = {International Conference on Learning Representations (ICLR)},
+  author={Muennighoff, Niklas and Soldaini, Luca and Groeneveld, Dirk and Lo, Kyle and Morrison, Jacob and Min, Sewon and Shi, Weijia and Walsh, Pete and Tafjord, Oyvind and Lambert, Nathan and others},
+  year = {2025}
+}
+
+@misc{ai2_olmoe_ios_2025,
+  author = {{Allen Institute for Artificial Intelligence}},
+  title = {OLMoE, meet iOS},
+  howpublished = {\url{https://allenai.org/blog/olmoe-app}},
+  year = {2025},
+  month = {February},
+  day = {11}
+}
+
+@article{zhou2023lima,
+  title={Lima: Less is more for alignment},
+  author={Zhou, Chunting and Liu, Pengfei and Xu, Puxin and Iyer, Srinivasan and Sun, Jiao and Mao, Yuning and Ma, Xuezhe and Efrat, Avia and Yu, Ping and Yu, Lili and others},
+  journal={Advances in Neural Information Processing Systems},
+  volume={36},
+  pages={55006--55021},
+  year={2023}
+}
+
+@article{guo2025deepseek,
+  title={Deepseek-r1: Incentivizing reasoning capability in llms via reinforcement learning},
+  author={Guo, Daya and Yang, Dejian and Zhang, Haowei and Song, Junxiao and Zhang, Ruoyu and Xu, Runxin and Zhu, Qihao and Ma, Shirong and Wang, Peiyi and Bi, Xiao and others},
+  journal={arXiv preprint arXiv:2501.12948},
+  year={2025}
+}
+
+@misc{deepseekai2025deepseekv3technicalreport,
+      title={DeepSeek-V3 Technical Report},
+      author={DeepSeek-AI and Aixin Liu and Bei Feng and Bing Xue and Bingxuan Wang and Bochao Wu and Chengda Lu and Chenggang Zhao and Chengqi Deng and Chenyu Zhang and Chong Ruan and Damai Dai and Daya Guo and Dejian Yang and Deli Chen and Dongjie Ji and Erhang Li and Fangyun Lin and Fucong Dai and Fuli Luo and Guangbo Hao and Guanting Chen and Guowei Li and H. Zhang and Han Bao and Hanwei Xu and Haocheng Wang and Haowei Zhang and Honghui Ding and Huajian Xin and Huazuo Gao and Hui Li and Hui Qu and J. L. Cai and Jian Liang and Jianzhong Guo and Jiaqi Ni and Jiashi Li and Jiawei Wang and Jin Chen and Jingchang Chen and Jingyang Yuan and Junjie Qiu and Junlong Li and Junxiao Song and Kai Dong and Kai Hu and Kaige Gao and Kang Guan and Kexin Huang and Kuai Yu and Lean Wang and Lecong Zhang and Lei Xu and Leyi Xia and Liang Zhao and Litong Wang and Liyue Zhang and Meng Li and Miaojun Wang and Mingchuan Zhang and Minghua Zhang and Minghui Tang and Mingming Li and Ning Tian and Panpan Huang and Peiyi Wang and Peng Zhang and Qiancheng Wang and Qihao Zhu and Qinyu Chen and Qiushi Du and R. J. Chen and R. L. Jin and Ruiqi Ge and Ruisong Zhang and Ruizhe Pan and Runji Wang and Runxin Xu and Ruoyu Zhang and Ruyi Chen and S. S. Li and Shanghao Lu and Shangyan Zhou and Shanhuang Chen and Shaoqing Wu and Shengfeng Ye and Shengfeng Ye and Shirong Ma and Shiyu Wang and Shuang Zhou and Shuiping Yu and Shunfeng Zhou and Shuting Pan and T. Wang and Tao Yun and Tian Pei and Tianyu Sun and W. L. Xiao and Wangding Zeng and Wanjia Zhao and Wei An and Wen Liu and Wenfeng Liang and Wenjun Gao and Wenqin Yu and Wentao Zhang and X. Q. Li and Xiangyue Jin and Xianzu Wang and Xiao Bi and Xiaodong Liu and Xiaohan Wang and Xiaojin Shen and Xiaokang Chen and Xiaokang Zhang and Xiaosha Chen and Xiaotao Nie and Xiaowen Sun and Xiaoxiang Wang and Xin Cheng and Xin Liu and Xin Xie and Xingchao Liu and Xingkai Yu and Xinnan Song and Xinxia Shan and Xinyi Zhou and Xinyu Yang and Xinyuan Li and Xuecheng Su and Xuheng Lin and Y. K. Li and Y. Q. Wang and Y. X. Wei and Y. X. Zhu and Yang Zhang and Yanhong Xu and Yanhong Xu and Yanping Huang and Yao Li and Yao Zhao and Yaofeng Sun and Yaohui Li and Yaohui Wang and Yi Yu and Yi Zheng and Yichao Zhang and Yifan Shi and Yiliang Xiong and Ying He and Ying Tang and Yishi Piao and Yisong Wang and Yixuan Tan and Yiyang Ma and Yiyuan Liu and Yongqiang Guo and Yu Wu and Yuan Ou and Yuchen Zhu and Yuduan Wang and Yue Gong and Yuheng Zou and Yujia He and Yukun Zha and Yunfan Xiong and Yunxian Ma and Yuting Yan and Yuxiang Luo and Yuxiang You and Yuxuan Liu and Yuyang Zhou and Z. F. Wu and Z. Z. Ren and Zehui Ren and Zhangli Sha and Zhe Fu and Zhean Xu and Zhen Huang and Zhen Zhang and Zhenda Xie and Zhengyan Zhang and Zhewen Hao and Zhibin Gou and Zhicheng Ma and Zhigang Yan and Zhihong Shao and Zhipeng Xu and Zhiyu Wu and Zhongyu Zhang and Zhuoshu Li and Zihui Gu and Zijia Zhu and Zijun Liu and Zilin Li and Ziwei Xie and Ziyang Song and Ziyi Gao and Zizheng Pan},
+      year={2025},
+      eprint={2412.19437},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2412.19437},
+}
+
+@article{khatri2025art,
+  title={The art of scaling reinforcement learning compute for llms},
+  author={Khatri, Devvrit and Madaan, Lovish and Tiwari, Rishabh and Bansal, Rachit and Duvvuri, Sai Surya and Zaheer, Manzil and Dhillon, Inderjit S and Brandfonbrener, David and Agarwal, Rishabh},
+  journal={arXiv preprint arXiv:2510.13786},
+  year={2025}
+}
+
+@misc{teamolmo2025olmo3,
+  title={ Olmo 3 },
+  author={ Team Olmo and Allyson Ettinger and Amanda Bertsch and Bailey Kuehl and David Graham and David Heineman and Dirk Groeneveld and Faeze Brahman and Finbarr Timbers and Hamish Ivison and Jacob Morrison and Jake Poznanski and Kyle Lo and Luca Soldaini and Matt Jordan and Mayee Chen and Michael Noukhovitch and Nathan Lambert and Pete Walsh and Pradeep Dasigi and Robert Berry and Saumya Malik and Saurabh Shah and Scott Geng and Shane Arora and Shashank Gupta and Taira Anderson and Teng Xiao and Tyler Murray and Tyler Romero and Victoria Graf and Akari Asai and Akshita Bhagia and Alexander Wettig and Alisa Liu and Aman Rangapur and Chloe Anastasiades and Costa Huang and Dustin Schwenk and Harsh Trivedi and Ian Magnusson and Jaron Lochner and Jiacheng Liu and Lester James V. Miranda and Maarten Sap and Malia Morgan and Michael Schmitz and Michal Guerquin and Michael Wilson and Regan Huff and Ronan Le Bras and Rui Xin and Rulin Shao and Sam Skjonsberg and Shannon Zejiang Shen and Shuyue Stella Li and Tucker Wilde and Valentina Pyatkin and Will Merrill and Yapei Chang and Yuling Gu and Zhiyuan Zeng and Ashish Sabharwal and Luke Zettlemoyer and Pang Wei Koh and Ali Farhadi and Noah A. Smith and Hannaneh Hajishirzi },
+  year={ 2025 },
+  eprint={ 2512.13961 },
+  archivePrefix={arXiv},
+  primaryClass={ cs.CL },
+  url={https://arxiv.org/abs/2512.13961}
+}
+
 @misc{alpaca,
   author = {Rohan Taori and Ishaan Gulrajani and Tianyi Zhang and Yann Dubois and Xuechen Li and Carlos Guestrin and Percy Liang and Tatsunori B. Hashimoto },
   title = {Stanford Alpaca: An Instruction-following LLaMA model},
@@ -35,21 +178,34 @@
     urldate   = {2023-06-30}
 }
 
+@article{askell2021general,
+  title={A general language assistant as a laboratory for alignment},
+  author={Askell, Amanda and Bai, Yuntao and Chen, Anna and Drain, Dawn and Ganguli, Deep and Henighan, Tom and Jones, Andy and Joseph, Nicholas and Mann, Ben and DasSarma, Nova and others},
+  journal={arXiv preprint arXiv:2112.00861},
+  year={2021}
+}
+
+@article{bai2022constitutional,
+  title={Constitutional ai: Harmlessness from ai feedback},
+  author={Bai, Yuntao and Kadavath, Saurav and Kundu, Sandipan and Askell, Amanda and Kernion, Jackson and Jones, Andy and Chen, Anna and Goldie, Anna and Mirhoseini, Azalia and McKinnon, Cameron and others},
+  journal={arXiv preprint arXiv:2212.08073},
+  year={2022}
+}
+
+@article{rafailov2024direct,
+  title={Direct preference optimization: Your language model is secretly a reward model},
+  author={Rafailov, Rafael and Sharma, Archit and Mitchell, Eric and Manning, Christopher D and Ermon, Stefano and Finn, Chelsea},
+  journal={Advances in Neural Information Processing Systems},
+  volume={36},
+  year={2023}
+}
+
 @inproceedings{tunstall2023zephyr,
   title={Zephyr: Direct Distillation of {LM} Alignment},
   author={Lewis Tunstall and Edward Emanuel Beeching and Nathan Lambert and Nazneen Rajani and Kashif Rasul and Younes Belkada and Shengyi Huang and Leandro Von Werra and Cl{\'e}mentine Fourrier and Nathan Habib and Nathan Sarrazin and Omar Sanseviero and Alexander M Rush and Thomas Wolf},
   booktitle={First Conference on Language Modeling},
   year={2024},
   url={https://openreview.net/forum?id=aKkAwZB6JV}
-}
-
-@article{zhou2023lima,
-  title={Lima: Less is more for alignment},
-  author={Zhou, Chunting and Liu, Pengfei and Xu, Puxin and Iyer, Srinivasan and Sun, Jiao and Mao, Yuning and Ma, Xuezhe and Efrat, Avia and Yu, Ping and Yu, Lili and others},
-  journal={Advances in Neural Information Processing Systems},
-  volume={36},
-  pages={55006--55021},
-  year={2023}
 }
 
 @article{ivison2023camels,
@@ -65,67 +221,6 @@
   year={2023}
 }
 
-@article{adler2024nemotron,
-  title={Nemotron-4 340B Technical Report},
-  author={Adler, Bo and Agarwal, Niket and Aithal, Ashwath and Anh, Dong H and Bhattacharya, Pallab and Brundyn, Annika and Casper, Jared and Catanzaro, Bryan and Clay, Sharon and Cohen, Jonathan and others},
-  journal={arXiv preprint arXiv:2406.11704},
-  year={2024}
-}
-
-@article{christiano2017deep,
-  title={Deep reinforcement learning from human preferences},
-  author={Christiano, Paul F and Leike, Jan and Brown, Tom and Martic, Miljan and Legg, Shane and Amodei, Dario},
-  journal={Advances in neural information processing systems},
-  volume={30},
-  year={2017}
-}
-
-@article{stiennon2020learning,
-  title={Learning to summarize with human feedback},
-  author={Stiennon, Nisan and Ouyang, Long and Wu, Jeffrey and Ziegler, Daniel and Lowe, Ryan and Voss, Chelsea and Radford, Alec and Amodei, Dario and Christiano, Paul F},
-  journal={Advances in Neural Information Processing Systems},
-  volume={33},
-  pages={3008--3021},
-  year={2020}
-}
-
-@article{nakano2021webgpt,
-  title={Webgpt: Browser-assisted question-answering with human feedback},
-  author={Nakano, Reiichiro and Hilton, Jacob and Balaji, Suchir and Wu, Jeff and Ouyang, Long and Kim, Christina and Hesse, Christopher and Jain, Shantanu and Kosaraju, Vineet and Saunders, William and others},
-  journal={arXiv preprint arXiv:2112.09332},
-  year={2021}
-}
-
-@article{ouyang2022training,
-  title={Training language models to follow instructions with human feedback},
-  author={Ouyang, Long and Wu, Jeffrey and Jiang, Xu and Almeida, Diogo and Wainwright, Carroll and Mishkin, Pamela and Zhang, Chong and Agarwal, Sandhini and Slama, Katarina and Ray, Alex and others},
-  journal={Advances in neural information processing systems},
-  volume={35},
-  pages={27730--27744},
-  year={2022}
-}
-
-@article{askell2021general,
-  title={A general language assistant as a laboratory for alignment},
-  author={Askell, Amanda and Bai, Yuntao and Chen, Anna and Drain, Dawn and Ganguli, Deep and Henighan, Tom and Jones, Andy and Joseph, Nicholas and Mann, Ben and DasSarma, Nova and others},
-  journal={arXiv preprint arXiv:2112.00861},
-  year={2021}
-}
-
-@article{bai2022training,
-  title={Training a helpful and harmless assistant with reinforcement learning from human feedback},
-  author={Bai, Yuntao and Jones, Andy and Ndousse, Kamal and Askell, Amanda and Chen, Anna and DasSarma, Nova and Drain, Dawn and Fort, Stanislav and Ganguli, Deep and Henighan, Tom and others},
-  journal={arXiv preprint arXiv:2204.05862},
-  year={2022}
-}
-
-@article{bai2022constitutional,
-  title={Constitutional ai: Harmlessness from ai feedback},
-  author={Bai, Yuntao and Kadavath, Saurav and Kundu, Sandipan and Askell, Amanda and Kernion, Jackson and Jones, Andy and Chen, Anna and Goldie, Anna and Mirhoseini, Azalia and McKinnon, Cameron and others},
-  journal={arXiv preprint arXiv:2212.08073},
-  year={2022}
-}
-
 @article{dubey2024llama,
   title={The llama 3 herd of models},
   author={Grattafiori, Aaron and Dubey, Abhimanyu and Jauhri, Abhinav and Pandey, Abhinav and Kadian, Abhishek and Al-Dahle, Ahmad and Letman, Aiesha and Mathur, Akhil and Schelten, Alan and Yang, Amy and Fan, Angela and others},
@@ -133,89 +228,11 @@
   year={2024}
 }
 
-@article{rafailov2024direct,
-  title={Direct preference optimization: Your language model is secretly a reward model},
-  author={Rafailov, Rafael and Sharma, Archit and Mitchell, Eric and Manning, Christopher D and Ermon, Stefano and Finn, Chelsea},
-  journal={Advances in Neural Information Processing Systems},
-  volume={36},
-  year={2023}
-}
-
-@article{lambert2024t,
-  title={Tulu 3: Pushing Frontiers in Open Language Model Post-Training},
-  author={Lambert, Nathan and Morrison, Jacob and Pyatkin, Valentina and Huang, Shengyi and Ivison, Hamish and Brahman, Faeze and Miranda, Lester James V and Liu, Alisa and Dziri, Nouha and Lyu, Shane and others},
-  journal={arXiv preprint arXiv:2411.15124},
+@article{adler2024nemotron,
+  title={Nemotron-4 340B Technical Report},
+  author={Adler, Bo and Agarwal, Niket and Aithal, Ashwath and Anh, Dong H and Bhattacharya, Pallab and Brundyn, Annika and Casper, Jared and Catanzaro, Bryan and Clay, Sharon and Cohen, Jonathan and others},
+  journal={arXiv preprint arXiv:2406.11704},
   year={2024}
-}
-
-@article{guo2025deepseek,
-  title={Deepseek-r1: Incentivizing reasoning capability in llms via reinforcement learning},
-  author={Guo, Daya and Yang, Dejian and Zhang, Haowei and Song, Junxiao and Zhang, Ruoyu and Xu, Runxin and Zhu, Qihao and Ma, Shirong and Wang, Peiyi and Bi, Xiao and others},
-  journal={arXiv preprint arXiv:2501.12948},
-  year={2025}
-}
-
-@inproceedings{kirk2023understanding,
-  title={Understanding the effects of rlhf on llm generalisation and diversity},
-  booktitle = {International Conference on Learning Representations (ICLR)},
-  author={Kirk, Robert and Mediratta, Ishita and Nalmpantis, Christoforos and Luketina, Jelena and Hambro, Eric and Grefenstette, Edward and Raileanu, Roberta},
-  year = {2024}
-}
-
-@inproceedings{chu2025sft,
-  title={Sft memorizes, rl generalizes: A comparative study of foundation model post-training},
-  booktitle = {International Conference on Machine Learning (ICML)},
-  author={Chu, Tianzhe and Zhai, Yuexiang and Yang, Jihan and Tong, Shengbang and Xie, Saining and Schuurmans, Dale and Le, Quoc V and Levine, Sergey and Ma, Yi},
-  year = {2025}
-}
-
-@misc{chen2025retainingdoingroleonpolicy,
-  title={Retaining by Doing: The Role of On-Policy Data in Mitigating Forgetting},
-  author={Howard Chen and Noam Razin and Karthik Narasimhan and Danqi Chen},
-  year={2025},
-  eprint={2510.18874},
-  archivePrefix={arXiv},
-  primaryClass={cs.LG},
-  url={https://arxiv.org/abs/2510.18874},
-}
-
-@inproceedings{shenfeld2026rls,
-title={{RL}'s Razor: Why Online Reinforcement Learning Forgets Less},
-author={Idan Shenfeld and Jyothish Pari and Pulkit Agrawal},
-booktitle={The Fourteenth International Conference on Learning Representations},
-year={2026},
-url={https://openreview.net/forum?id=7HNRYT4V44}
-}
-
-@inproceedings{park2024disentangling,
-  title={Disentangling length from quality in direct preference optimization},
-  booktitle = {Findings of the Association for Computational Linguistics: ACL 2024},
-  author={Park, Ryan and Rafailov, Rafael and Ermon, Stefano and Finn, Chelsea},
-  pages = {4998--5017},
-  year = {2024}
-}
-
-@article{singhal2023long,
-  title={A long way to go: Investigating length correlations in rlhf},
-  author={Singhal, Prasann and Goyal, Tanya and Xu, Jiacheng and Durrett, Greg},
-  journal={arXiv preprint arXiv:2310.03716},
-  year={2023}
-}
-
-@inproceedings{muennighoff2024olmoe,
-  title={Olmoe: Open mixture-of-experts language models},
-  booktitle = {International Conference on Learning Representations (ICLR)},
-  author={Muennighoff, Niklas and Soldaini, Luca and Groeneveld, Dirk and Lo, Kyle and Morrison, Jacob and Min, Sewon and Shi, Weijia and Walsh, Pete and Tafjord, Oyvind and Lambert, Nathan and others},
-  year = {2025}
-}
-
-@misc{ai2_olmoe_ios_2025,
-  author = {{Allen Institute for Artificial Intelligence}},
-  title = {OLMoE, meet iOS},
-  howpublished = {\url{https://allenai.org/blog/olmoe-app}},
-  year = {2025},
-  month = {February},
-  day = {11}
 }
 
 ### End chapter 1 ###
@@ -230,6 +247,20 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   number={136},
   pages={1--46},
   year={2017}
+}
+
+@article{kaufmann2023survey,
+  title={A survey of reinforcement learning from human feedback},
+  journal = {Transactions on Machine Learning Research (TMLR)},
+  author={Kaufmann, Timo and Weng, Paul and Bengs, Viktor and H{\"u}llermeier, Eyke},
+  year = {2025}
+}
+
+@article{casper2023open,
+  title={Open problems and fundamental limitations of reinforcement learning from human feedback},
+  journal = {Transactions on Machine Learning Research (TMLR)},
+  author={Casper, Stephen and Davies, Xander and Shi, Claudia and Gilbert, Thomas Krendl and Scheurer, J{\'e}r{\'e}my and Rando, Javier and Freedman, Rachel and Korbak, Tomasz and Lindner, David and Freire, Pedro and others},
+  year = {2023}
 }
 
 @inproceedings{knox2008tamer,
@@ -250,6 +281,14 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   organization={PMLR}
 }
 
+@article{ibarz2018reward,
+  title={Reward learning from human preferences and demonstrations in atari},
+  author={Ibarz, Borja and Leike, Jan and Pohlen, Tobias and Irving, Geoffrey and Legg, Shane and Amodei, Dario},
+  journal={Advances in neural information processing systems},
+  volume={31},
+  year={2018}
+}
+
 @inproceedings{warnell2018deep,
   title={Deep tamer: Interactive agent shaping in high-dimensional state spaces},
   author={Warnell, Garrett and Waytowich, Nicholas and Lawhern, Vernon and Stone, Peter},
@@ -259,11 +298,62 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   year={2018}
 }
 
-@article{kaufmann2023survey,
-  title={A survey of reinforcement learning from human feedback},
-  journal = {Transactions on Machine Learning Research (TMLR)},
-  author={Kaufmann, Timo and Weng, Paul and Bengs, Viktor and H{\"u}llermeier, Eyke},
-  year = {2025}
+@article{leike2018scalable,
+  title={Scalable agent alignment via reward modeling: a research direction},
+  author={Leike, Jan and Krueger, David and Everitt, Tom and Martic, Miljan and Maini, Vishal and Legg, Shane},
+  journal={arXiv preprint arXiv:1811.07871},
+  year={2018}
+}
+
+@article{ziegler2019fine,
+  title={Fine-tuning language models from human preferences},
+  author={Ziegler, Daniel M and Stiennon, Nisan and Wu, Jeffrey and Brown, Tom B and Radford, Alec and Amodei, Dario and Christiano, Paul and Irving, Geoffrey},
+  journal={arXiv preprint arXiv:1909.08593},
+  year={2019}
+}
+
+@article{wu2021recursively,
+  title={Recursively summarizing books with human feedback},
+  author={Wu, Jeff and Ouyang, Long and Ziegler, Daniel M and Stiennon, Nisan and Lowe, Ryan and Leike, Jan and Christiano, Paul},
+  journal={arXiv preprint arXiv:2109.10862},
+  year={2021}
+}
+
+@article{menick2022teaching,
+  title={Teaching language models to support answers with verified quotes},
+  author={Menick, Jacob and Trebacz, Maja and Mikulik, Vladimir and Aslanides, John and Song, Francis and Chadwick, Martin and Glaese, Mia and Young, Susannah and Campbell-Gillingham, Lucy and Irving, Geoffrey and others},
+  journal={arXiv preprint arXiv:2203.11147},
+  year={2022}
+}
+
+@article{glaese2022improving,
+  title={Improving alignment of dialogue agents via targeted human judgements},
+  author={Glaese, Amelia and McAleese, Nat and Tr{\k{e}}bacz, Maja and Aslanides, John and Firoiu, Vlad and Ewalds, Timo and Rauh, Maribeth and Weidinger, Laura and Chadwick, Martin and Thacker, Phoebe and others},
+  journal={arXiv preprint arXiv:2209.14375},
+  year={2022}
+}
+
+@inproceedings{gao2023scaling,
+  title={Scaling laws for reward model overoptimization},
+  author={Gao, Leo and Schulman, John and Hilton, Jacob},
+  booktitle={International Conference on Machine Learning},
+  pages={10835--10866},
+  year={2023},
+  organization={PMLR}
+}
+
+@article{ganguli2022red,
+  title={Red teaming language models to reduce harms: Methods, scaling behaviors, and lessons learned},
+  author={Ganguli, Deep and Lovitt, Liane and Kernion, Jackson and Askell, Amanda and Bai, Yuntao and Kadavath, Saurav and Mann, Ben and Perez, Ethan and Schiefer, Nicholas and Ndousse, Kamal and others},
+  journal={arXiv preprint arXiv:2209.07858},
+  year={2022}
+}
+
+@inproceedings{ramamurthy2022reinforcement,
+  title={Is reinforcement learning (not) for natural language processing: Benchmarks, baselines, and building blocks for natural language policy optimization},
+  booktitle = {International Conference on Learning Representations (ICLR)},
+  author={Ramamurthy, Rajkumar and Ammanabrolu, Prithviraj and Brantley, Kiant{\'e} and Hessel, Jack and Sifa, Rafet and Bauckhage, Christian and Hajishirzi, Hannaneh and Choi, Yejin},
+  year = {2023}
 }
 
 @inproceedings{havrilla-etal-2023-trlx,
@@ -295,61 +385,12 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   howpublished = {\url{https://github.com/huggingface/trl}}
 }
 
-@article{ibarz2018reward,
-  title={Reward learning from human preferences and demonstrations in atari},
-  author={Ibarz, Borja and Leike, Jan and Pohlen, Tobias and Irving, Geoffrey and Legg, Shane and Amodei, Dario},
-  journal={Advances in neural information processing systems},
-  volume={31},
-  year={2018}
-}
-
-@article{leike2018scalable,
-  title={Scalable agent alignment via reward modeling: a research direction},
-  author={Leike, Jan and Krueger, David and Everitt, Tom and Martic, Miljan and Maini, Vishal and Legg, Shane},
-  journal={arXiv preprint arXiv:1811.07871},
-  year={2018}
-}
-
-@article{ziegler2019fine,
-  title={Fine-tuning language models from human preferences},
-  author={Ziegler, Daniel M and Stiennon, Nisan and Wu, Jeffrey and Brown, Tom B and Radford, Alec and Amodei, Dario and Christiano, Paul and Irving, Geoffrey},
-  journal={arXiv preprint arXiv:1909.08593},
-  year={2019}
-}
-
-@article{wu2021recursively,
-  title={Recursively summarizing books with human feedback},
-  author={Wu, Jeff and Ouyang, Long and Ziegler, Daniel M and Stiennon, Nisan and Lowe, Ryan and Leike, Jan and Christiano, Paul},
-  journal={arXiv preprint arXiv:2109.10862},
-  year={2021}
-}
-
-@article{ganguli2022red,
-  title={Red teaming language models to reduce harms: Methods, scaling behaviors, and lessons learned},
-  author={Ganguli, Deep and Lovitt, Liane and Kernion, Jackson and Askell, Amanda and Bai, Yuntao and Kadavath, Saurav and Mann, Ben and Perez, Ethan and Schiefer, Nicholas and Ndousse, Kamal and others},
-  journal={arXiv preprint arXiv:2209.07858},
-  year={2022}
-}
-
-@article{glaese2022improving,
-  title={Improving alignment of dialogue agents via targeted human judgements},
-  author={Glaese, Amelia and McAleese, Nat and Tr{\k{e}}bacz, Maja and Aslanides, John and Firoiu, Vlad and Ewalds, Timo and Rauh, Maribeth and Weidinger, Laura and Chadwick, Martin and Thacker, Phoebe and others},
-  journal={arXiv preprint arXiv:2209.14375},
-  year={2022}
-}
-
-@article{menick2022teaching,
-  title={Teaching language models to support answers with verified quotes},
-  author={Menick, Jacob and Trebacz, Maja and Mikulik, Vladimir and Aslanides, John and Song, Francis and Chadwick, Martin and Glaese, Mia and Young, Susannah and Campbell-Gillingham, Lucy and Irving, Geoffrey and others},
-  journal={arXiv preprint arXiv:2203.11147},
-  year={2022}
-}
-
-@inproceedings{lightman2023let,
-  title={Let's verify step by step},
-  booktitle = {International Conference on Learning Representations (ICLR)},
-  author={Lightman, Hunter and Kosaraju, Vineet and Burda, Yura and Edwards, Harri and Baker, Bowen and Lee, Teddy and Leike, Jan and Schulman, John and Sutskever, Ilya and Cobbe, Karl},
-  year = {2024}
+@misc{openai2022chatgpt,
+  title = {ChatGPT: Optimizing Language Models for Dialogue},
+  author = {{OpenAI}},
+  year = {2022},
+  howpublished = {\url{https://openai.com/blog/chatgpt/}},
+  note = {Training a LM with RLHF for suitable use as an all-purpose chat bot.}
 }
 
 @article{touvron2023llama,
@@ -359,27 +400,11 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   year={2023}
 }
 
-@inproceedings{gao2023scaling,
-  title={Scaling laws for reward model overoptimization},
-  author={Gao, Leo and Schulman, John and Hilton, Jacob},
-  booktitle={International Conference on Machine Learning},
-  pages={10835--10866},
-  year={2023},
-  organization={PMLR}
-}
-
-@inproceedings{ramamurthy2022reinforcement,
-  title={Is reinforcement learning (not) for natural language processing: Benchmarks, baselines, and building blocks for natural language policy optimization},
+@inproceedings{lightman2023let,
+  title={Let's verify step by step},
   booktitle = {International Conference on Learning Representations (ICLR)},
-  author={Ramamurthy, Rajkumar and Ammanabrolu, Prithviraj and Brantley, Kiant{\'e} and Hessel, Jack and Sifa, Rafet and Bauckhage, Christian and Hajishirzi, Hannaneh and Choi, Yejin},
-  year = {2023}
-}
-
-@article{casper2023open,
-  title={Open problems and fundamental limitations of reinforcement learning from human feedback},
-  journal = {Transactions on Machine Learning Research (TMLR)},
-  author={Casper, Stephen and Davies, Xander and Shi, Claudia and Gilbert, Thomas Krendl and Scheurer, J{\'e}r{\'e}my and Rando, Javier and Freedman, Rachel and Korbak, Tomasz and Lindner, David and Freire, Pedro and others},
-  year = {2023}
+  author={Lightman, Hunter and Kosaraju, Vineet and Burda, Yura and Edwards, Harri and Baker, Bowen and Lee, Teddy and Leike, Jan and Schulman, John and Sutskever, Ilya and Cobbe, Karl},
+  year = {2024}
 }
 
 @inproceedings{kumar2024training,
@@ -405,14 +430,6 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   note         = {Accessed: 2024-10-18}
 }
 
-@misc{openai2022chatgpt,
-  title = {ChatGPT: Optimizing Language Models for Dialogue},
-  author = {{OpenAI}},
-  year = {2022},
-  howpublished = {\url{https://openai.com/blog/chatgpt/}},
-  note = {Training a LM with RLHF for suitable use as an all-purpose chat bot.}
-}
-
 ### End chapter 2 ###
 
 ### First appearing in chapter 3 (Training Overview) ###
@@ -424,13 +441,6 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   year={2018}
 }
 
-@article{cohere2025command,
-  title={Command A: An Enterprise-Ready Large Language Model},
-  author={Cohere, Team and Ahmadian, Arash and Ahmed, Marwan and Alammar, Jay and Alnumay, Yazeed and Althammer, Sophia and Arkhangorodsky, Arkady and Aryabumi, Viraat and Aumiller, Dennis and Avalos, Rapha{\"e}l and others},
-  journal={arXiv preprint arXiv:2504.00698},
-  year={2025}
-}
-
 @article{lambert2022illustrating,
   author = {Lambert, Nathan and Castricato, Louis and von Werra, Leandro and Havrilla, Alex},
   title = {Illustrating Reinforcement Learning from Human Feedback (RLHF)},
@@ -439,11 +449,18 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   note = {https://huggingface.co/blog/rlhf},
 }
 
-@article{alrashed2024smoltulu,
-  title={SmolTulu: Higher Learning Rate to Batch Size Ratios Can Lead to Better Reasoning in SLMs},
-  author={Alrashed, Sultan},
-  journal={arXiv preprint arXiv:2412.08347},
-  year={2024}
+@article{li2022branch,
+  title={Branch-train-merge: Embarrassingly parallel training of expert language models},
+  author={Li, Margaret and Gururangan, Suchin and Dettmers, Tim and Lewis, Mike and Althoff, Tim and Smith, Noah A and Zettlemoyer, Luke},
+  journal={arXiv preprint arXiv:2208.03306},
+  year={2022}
+}
+
+@article{cohere2025command,
+  title={Command A: An Enterprise-Ready Large Language Model},
+  author={Cohere, Team and Ahmadian, Arash and Ahmed, Marwan and Alammar, Jay and Alnumay, Yazeed and Althammer, Sophia and Arkhangorodsky, Arkady and Aryabumi, Viraat and Aumiller, Dennis and Avalos, Rapha{\"e}l and others},
+  journal={arXiv preprint arXiv:2504.00698},
+  year={2025}
 }
 
 @article{olmo20242,
@@ -453,21 +470,11 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   year={2024}
 }
 
-@misc{seed2025seed,
-  title={Seed1.5-Thinking: Advancing Superb Reasoning Models with Reinforcement Learning},
-  author={ByteDance Seed and Jiaze Chen and Tiantian Fan and Xin Liu and Lingjun Liu and Zhiqi Lin and Mingxuan Wang and Chengyi Wang and Xiangpeng Wei and Wenyuan Xu and Yufeng Yuan and Yu Yue and Lin Yan and Qiying Yu and Xiaochen Zuo and Chi Zhang and Ruofei Zhu and Zhecheng An and Zhihao Bai and Yu Bao and Xingyan Bin and Jiangjie Chen and Feng Chen and Hongmin Chen and Riwei Chen and Liangqiang Chen and Zixin Chen and Jinsong Chen and Siyan Chen and Kaiyuan Chen and Zhi Chen and Jin Chen and Jiecao Chen and Jinxin Chi and Weinan Dai and Ning Dai and Jiahui Dai and Shihan Dou and Yantao Du and Zhengyin Du and Jianhui Duan and Chen Dun and Ting-Han Fan and Jiazhan Feng and Junda Feng and Ziyuan Feng and Yuwei Fu and Wenqi Fu and Hanjie Fu and Hao Ge and Hongyi Guo and Mingji Han and Li Han and Wenhao Hao and Xintong Hao and Qianyu He and Jerry He and Feng He and Wen Heng and Zehua Hong and Qi Hou and Liang Hu and Shengding Hu and Nan Hu and Kai Hua and Qi Huang and Ziyue Huang and Hongzhi Huang and Zihao Huang and Ting Huang and Wenhao Huang and Wei Jia and Bin Jia and Xiaoying Jia and Yuhua Jiang and Haobin Jiang and Ziheng Jiang and Kaihua Jiang and Chengquan Jiang and Jianpeng Jiao and Xiaoran Jin and Xing Jin and Xunhao Lai and Zheng Li and Xiang Li and Liyi Li and Hongkai Li and Zheng Li and Shengxian Wan and Ya Wang and Yunshui Li and Chenggang Li and Niuniu Li and Siyu Li and Xi Li and Xiao Li and Aoyan Li and Yuntao Li and Nianning Liang and Xinnian Liang and Haibin Lin and Weijian Lin and Ye Lin and Zhicheng Liu and Guanlin Liu and Guanlin Liu and Chenxiao Liu and Yan Liu and Gaohong Liu and Juncai Liu and Chundian Liu and Deyi Liu and Kaibo Liu and Siyao Liu and Qi Liu and Yongfei Liu and Kang Liu and Gan Liu and Boyi Liu and Rui Long and Chenwei Lou and Weiqiang Lou and Xiang Luo and Yao Luo and Caiping Lv and Heyang Lv and Bole Ma and Qianli Ma and Hongzhi Ma and Yiyuan Ma and Jin Ma and Wenchang Ma and Tingting Ma and Chen Mao and Qiyang Min and Zhe Nan and Guanghan Ning and Jinxiang Ou and Haojie Pan and Renming Pang and Yanghua Peng and Tao Peng and Lihua Qian and Lihua Qian and Mu Qiao and Meng Qu and Cheng Ren and Hongbin Ren and Yong Shan and Wei Shen and Ke Shen and Kai Shen and Guangming Sheng and Jinlong Shi and Wenlei Shi and Guang Shi and Shuai Shuai Cao and Yuxin Song and Zuquan Song and Jing Su and Yifan Sun and Tao Sun and Zewei Sun and Borui Wan and Zihan Wang and Xiaohui Wang and Xi Wang and Shuguang Wang and Jun Wang and Qinlong Wang and Chenyuan Wang and Shuai Wang and Zihan Wang and Changbao Wang and Jiaqiang Wang and Shihang Wang and Xuwu Wang and Zaiyuan Wang and Yuxuan Wang and Wenqi Wang and Taiqing Wang and Chengzhi Wei and Houmin Wei and Ziyun Wei and Shufa Wei and Zheng Wu and Yonghui Wu and Yangjun Wu and Bohong Wu and Shuang Wu and Jingqiao Wu and Ning Wu and Shuangzhi Wu and Jianmin Wu and Chenguang Xi and Fan Xia and Yuqiao Xian and Liang Xiang and Boren Xiang and Bowen Xiao and Zhen Xiao and Xia Xiao and Yongsheng Xiao and Chao Xin and Shulin Xin and Yuwen Xiong and Jingjing Xu and Ziwen Xu and Chenyin Xu and Jiayi Xu and Yifan Xu and Wei Xu and Yufei Xu and Shikun Xu and Shipeng Yan and Shen Yan and Qingping Yang and Xi Yang and Tianhao Yang and Yuehang Yang and Yuan Yang and Ximing Yang and Zeyu Yang and Guang Yang and Yifan Yang and Xuesong Yao and Bairen Yi and Fan Yin and Jianian Yin and Ziqiang Ying and Xiangyu Yu and Hongli Yu and Song Yu and Menghan Yu and Huan Yu and Siyu Yuan and Jun Yuan and Yutao Zeng and Tianyang Zhan and Zheng Zhang and Yun Zhang and Mofan Zhang and Wang Zhang and Ru Zhang and Zhi Zhang and Tianqi Zhang and Xinyi Zhang and Zhexi Zhang and Sijun Zhang and Wenqiang Zhang and Xiangxiang Zhang and Yongtao Zhang and Yuyu Zhang and Ge Zhang and He Zhang and Yue Zhang and Renjie Zheng and Ningxin Zheng and Zhuolin Zheng and Yaowei Zheng and Chen Zheng and Xiaoyun Zhi and Wanjun Zhong and Cheng Zhong and Zheng Zhong and Baoquan Zhong and Xun Zhou and Na Zhou and Huan Zhou and Hang Zhu and Defa Zhu and Wenjia Zhu and Lei Zuo},
-  year={2025},
-  eprint={2504.13914},
-  archivePrefix={arXiv},
-  primaryClass={cs.CL},
-  url={https://arxiv.org/abs/2504.13914}
-}
-
-@article{li2022branch,
-  title={Branch-train-merge: Embarrassingly parallel training of expert language models},
-  author={Li, Margaret and Gururangan, Suchin and Dettmers, Tim and Lewis, Mike and Althoff, Tim and Smith, Noah A and Zettlemoyer, Luke},
-  journal={arXiv preprint arXiv:2208.03306},
-  year={2022}
+@article{alrashed2024smoltulu,
+  title={SmolTulu: Higher Learning Rate to Batch Size Ratios Can Lead to Better Reasoning in SLMs},
+  author={Alrashed, Sultan},
+  journal={arXiv preprint arXiv:2412.08347},
+  year={2024}
 }
 
 @misc{yang2025qwen3,
@@ -486,6 +493,16 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   author={Xia, Bingquan and Shen, Bowen and Zhu, Dawei and Zhang, Di and Wang, Gang and Zhang, Hailin and Liu, Huaqiu and Xiao, Jiebao and Dong, Jinhao and Zhao, Liang and others},
   journal={arXiv preprint arXiv:2505.07608},
   year={2025}
+}
+
+@misc{seed2025seed,
+  title={Seed1.5-Thinking: Advancing Superb Reasoning Models with Reinforcement Learning},
+  author={ByteDance Seed and Jiaze Chen and Tiantian Fan and Xin Liu and Lingjun Liu and Zhiqi Lin and Mingxuan Wang and Chengyi Wang and Xiangpeng Wei and Wenyuan Xu and Yufeng Yuan and Yu Yue and Lin Yan and Qiying Yu and Xiaochen Zuo and Chi Zhang and Ruofei Zhu and Zhecheng An and Zhihao Bai and Yu Bao and Xingyan Bin and Jiangjie Chen and Feng Chen and Hongmin Chen and Riwei Chen and Liangqiang Chen and Zixin Chen and Jinsong Chen and Siyan Chen and Kaiyuan Chen and Zhi Chen and Jin Chen and Jiecao Chen and Jinxin Chi and Weinan Dai and Ning Dai and Jiahui Dai and Shihan Dou and Yantao Du and Zhengyin Du and Jianhui Duan and Chen Dun and Ting-Han Fan and Jiazhan Feng and Junda Feng and Ziyuan Feng and Yuwei Fu and Wenqi Fu and Hanjie Fu and Hao Ge and Hongyi Guo and Mingji Han and Li Han and Wenhao Hao and Xintong Hao and Qianyu He and Jerry He and Feng He and Wen Heng and Zehua Hong and Qi Hou and Liang Hu and Shengding Hu and Nan Hu and Kai Hua and Qi Huang and Ziyue Huang and Hongzhi Huang and Zihao Huang and Ting Huang and Wenhao Huang and Wei Jia and Bin Jia and Xiaoying Jia and Yuhua Jiang and Haobin Jiang and Ziheng Jiang and Kaihua Jiang and Chengquan Jiang and Jianpeng Jiao and Xiaoran Jin and Xing Jin and Xunhao Lai and Zheng Li and Xiang Li and Liyi Li and Hongkai Li and Zheng Li and Shengxian Wan and Ya Wang and Yunshui Li and Chenggang Li and Niuniu Li and Siyu Li and Xi Li and Xiao Li and Aoyan Li and Yuntao Li and Nianning Liang and Xinnian Liang and Haibin Lin and Weijian Lin and Ye Lin and Zhicheng Liu and Guanlin Liu and Guanlin Liu and Chenxiao Liu and Yan Liu and Gaohong Liu and Juncai Liu and Chundian Liu and Deyi Liu and Kaibo Liu and Siyao Liu and Qi Liu and Yongfei Liu and Kang Liu and Gan Liu and Boyi Liu and Rui Long and Chenwei Lou and Weiqiang Lou and Xiang Luo and Yao Luo and Caiping Lv and Heyang Lv and Bole Ma and Qianli Ma and Hongzhi Ma and Yiyuan Ma and Jin Ma and Wenchang Ma and Tingting Ma and Chen Mao and Qiyang Min and Zhe Nan and Guanghan Ning and Jinxiang Ou and Haojie Pan and Renming Pang and Yanghua Peng and Tao Peng and Lihua Qian and Lihua Qian and Mu Qiao and Meng Qu and Cheng Ren and Hongbin Ren and Yong Shan and Wei Shen and Ke Shen and Kai Shen and Guangming Sheng and Jinlong Shi and Wenlei Shi and Guang Shi and Shuai Shuai Cao and Yuxin Song and Zuquan Song and Jing Su and Yifan Sun and Tao Sun and Zewei Sun and Borui Wan and Zihan Wang and Xiaohui Wang and Xi Wang and Shuguang Wang and Jun Wang and Qinlong Wang and Chenyuan Wang and Shuai Wang and Zihan Wang and Changbao Wang and Jiaqiang Wang and Shihang Wang and Xuwu Wang and Zaiyuan Wang and Yuxuan Wang and Wenqi Wang and Taiqing Wang and Chengzhi Wei and Houmin Wei and Ziyun Wei and Shufa Wei and Zheng Wu and Yonghui Wu and Yangjun Wu and Bohong Wu and Shuang Wu and Jingqiao Wu and Ning Wu and Shuangzhi Wu and Jianmin Wu and Chenguang Xi and Fan Xia and Yuqiao Xian and Liang Xiang and Boren Xiang and Bowen Xiao and Zhen Xiao and Xia Xiao and Yongsheng Xiao and Chao Xin and Shulin Xin and Yuwen Xiong and Jingjing Xu and Ziwen Xu and Chenyin Xu and Jiayi Xu and Yifan Xu and Wei Xu and Yufei Xu and Shikun Xu and Shipeng Yan and Shen Yan and Qingping Yang and Xi Yang and Tianhao Yang and Yuehang Yang and Yuan Yang and Ximing Yang and Zeyu Yang and Guang Yang and Yifan Yang and Xuesong Yao and Bairen Yi and Fan Yin and Jianian Yin and Ziqiang Ying and Xiangyu Yu and Hongli Yu and Song Yu and Menghan Yu and Huan Yu and Siyu Yuan and Jun Yuan and Yutao Zeng and Tianyang Zhan and Zheng Zhang and Yun Zhang and Mofan Zhang and Wang Zhang and Ru Zhang and Zhi Zhang and Tianqi Zhang and Xinyi Zhang and Zhexi Zhang and Sijun Zhang and Wenqiang Zhang and Xiangxiang Zhang and Yongtao Zhang and Yuyu Zhang and Ge Zhang and He Zhang and Yue Zhang and Renjie Zheng and Ningxin Zheng and Zhuolin Zheng and Yaowei Zheng and Chen Zheng and Xiaoyun Zhi and Wanjun Zhong and Cheng Zhong and Zheng Zhong and Baoquan Zhong and Xun Zhou and Na Zhou and Huan Zhou and Hang Zhu and Defa Zhu and Wenjia Zhu and Lei Zuo},
+  year={2025},
+  eprint={2504.13914},
+  archivePrefix={arXiv},
+  primaryClass={cs.CL},
+  url={https://arxiv.org/abs/2504.13914}
 }
 
 ### End chapter 3 ###
@@ -542,6 +559,13 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
     pages = "3470--3487",
 }
 
+@article{wallace2024instruction,
+  title={The instruction hierarchy: Training llms to prioritize privileged instructions},
+  author={Wallace, Eric and Xiao, Kai and Leike, Reimar and Weng, Lilian and Heidecke, Johannes and Beutel, Alex},
+  journal={arXiv preprint arXiv:2404.13208},
+  year={2024}
+}
+
 @article{dettmers2023qlora,
   title={Qlora: Efficient finetuning of quantized llms},
   author={Dettmers, Tim and Pagnoni, Artidoro and Holtzman, Ari and Zettlemoyer, Luke},
@@ -560,16 +584,19 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   howpublished = {\url{https://huggingface.co/datasets/HuggingFaceH4/no_robots}}
 }
 
-@article{wallace2024instruction,
-  title={The instruction hierarchy: Training llms to prioritize privileged instructions},
-  author={Wallace, Eric and Xiao, Kai and Leike, Reimar and Weng, Lilian and Heidecke, Johannes and Beutel, Alex},
-  journal={arXiv preprint arXiv:2404.13208},
-  year={2024}
-}
-
 ### End chapter 4 ###
 
 ### First appearing in chapter 5 (Reward Models) ###
+
+@inproceedings{ng2000algorithms,
+  title={Algorithms for inverse reinforcement learning.},
+  author={Ng, Andrew Y and Russell, Stuart and others},
+  booktitle = {Proceedings of the Seventeenth International Conference on Machine Learning},
+  pages = {663–-670},
+  numpages = {8},
+  series = {ICML '00},
+  year={2000}
+}
 
 @article{BradleyTerry,
  ISSN = {00063444},
@@ -585,6 +612,104 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
  year = {1952}
 }
 
+@inproceedings{zhu2024starling,
+  title={Starling-7b: Improving helpfulness and harmlessness with rlaif},
+  author={Zhu, Banghua and Frick, Evan and Wu, Tianhao and Zhu, Hanlin and Ganesan, Karthik and Chiang, Wei-Lin and Zhang, Jian and Jiao, Jiantao},
+  booktitle={First Conference on Language Modeling},
+  year={2024}
+}
+
+@inproceedings{liu2019learning,
+  title={Learning plackett-luce mixtures from partial preferences},
+  author={Liu, Ao and Zhao, Zhibing and Liao, Chao and Lu, Pinyan and Xia, Lirong},
+  booktitle={Proceedings of the AAAI Conference on Artificial Intelligence},
+  volume={33},
+  number={01},
+  pages={4328--4335},
+  year={2019}
+}
+
+@inproceedings{zhu2023principled,
+  title={Principled reinforcement learning with human feedback from pairwise or k-wise comparisons},
+  author={Zhu, Banghua and Jordan, Michael and Jiao, Jiantao},
+  booktitle={International Conference on Machine Learning},
+  pages={43037--43067},
+  year={2023},
+  organization={PMLR}
+}
+
+@article{cobbe2021gsm8k,
+  title={Training Verifiers to Solve Math Word Problems},
+  author={Cobbe, Karl and Kosaraju, Vineet and Bavarian, Mohammad and Chen, Mark and Jun, Heewoo and Kaiser, Lukasz and Plappert, Matthias and Tworek, Jerry and Hilton, Jacob and Nakano, Reiichiro and Hesse, Christopher and Schulman, John},
+  journal={arXiv preprint arXiv:2110.14168},
+  year={2021}
+}
+
+@article{lyu2025exploring,
+  title={Exploring the Limit of Outcome Reward for Learning Mathematical Reasoning},
+  author={Lyu, Chengqi and Gao, Songyang and Gu, Yuzhe and Zhang, Wenwei and Gao, Jianfei and Liu, Kuikun and Wang, Ziyi and Li, Shuaibin and Zhao, Qian and Huang, Haian and others},
+  journal={arXiv preprint arXiv:2502.06781},
+  year={2025}
+}
+
+@article{zheng2023judging,
+  title={Judging llm-as-a-judge with mt-bench and chatbot arena},
+  author={Zheng, Lianmin and Chiang, Wei-Lin and Sheng, Ying and Zhuang, Siyuan and Wu, Zhanghao and Zhuang, Yonghao and Lin, Zi and Li, Zhuohan and Li, Dacheng and Xing, Eric and others},
+  journal={Advances in Neural Information Processing Systems},
+  volume={36},
+  pages={46595--46623},
+  year={2023}
+}
+
+@article{dubois2024length,
+  title={Length-controlled alpacaeval: A simple way to debias automatic evaluators},
+  author={Dubois, Yann and Galambosi, Bal{\'a}zs and Liang, Percy and Hashimoto, Tatsunori B},
+  journal={arXiv preprint arXiv:2404.04475},
+  year={2024}
+}
+
+@inproceedings{li2024crowdsourced,
+  title={From Crowdsourced Data to High-Quality Benchmarks: Arena-Hard and BenchBuilder Pipeline},
+  booktitle = {International Conference on Machine Learning (ICML)},
+  author={Li, Tianle and Chiang, Wei-Lin and Frick, Evan and Dunlap, Lisa and Wu, Tianhao and Zhu, Banghua and Gonzalez, Joseph E and Stoica, Ion},
+  year = {2025}
+}
+
+@inproceedings{lin2024wildbench,
+  title={WILDBENCH: Benchmarking LLMs with Challenging Tasks from Real Users in the Wild},
+  booktitle = {International Conference on Learning Representations (ICLR)},
+  author={Lin, Bill Yuchen and Deng, Yuntian and Chandu, Khyathi and Brahman, Faeze and Ravichander, Abhilasha and Pyatkin, Valentina and Dziri, Nouha and Bras, Ronan Le and Choi, Yejin},
+  year = {2025}
+}
+
+@article{mahan2024generative,
+  title={Generative Reward Models},
+  author={Mahan, Dakota and Phung, Duy Van and Rafailov, Rafael and Blagden, Chase and Lile, Nathan and Castricato, Louis and Franken, Jan-Philipp and Finn, Chelsea and Albalak, Alon},
+  year={2024},
+  url={https://www.synthlabs.ai/pdf/Generative_Reward_Models.pdf}
+}
+
+@inproceedings{zhang2024generative,
+  title={Generative verifiers: Reward modeling as next-token prediction},
+  booktitle = {International Conference on Learning Representations (ICLR)},
+  author={Zhang, Lunjun and Hosseini, Arian and Bansal, Hritik and Kazemi, Mehran and Kumar, Aviral and Agarwal, Rishabh},
+  year = {2025}
+}
+
+@article{ankner2024critique,
+  title={Critique-out-loud reward models},
+  author={Ankner, Zachary and Paul, Mansheej and Cui, Brandon and Chang, Jonathan D and Ammanabrolu, Prithviraj},
+  journal={arXiv preprint arXiv:2408.11791},
+  year={2024}
+}
+
+@inproceedings{kim2023prometheus,
+  title={Prometheus: Inducing fine-grained evaluation capability in language models},
+  author={Kim, Seungone and Shin, Jamin and Cho, Yejin and Jang, Joel and Longpre, Shayne and Lee, Hwaran and Yun, Sangdoo and Shin, Seongjin and Kim, Sungdong and Thorne, James and others},
+  booktitle={The Twelfth International Conference on Learning Representations},
+  year={2024}
+}
+
 @inproceedings{lambert2024rewardbench,
   title={Rewardbench: Evaluating reward models for language modeling},
   booktitle = {Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
@@ -592,10 +717,31 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   year = {2025}
 }
 
+@inproceedings{wen2024rethinking,
+  title={Rethinking Reward Model Evaluation: Are We Barking up the Wrong Tree?},
+  booktitle = {International Conference on Learning Representations (ICLR)},
+  author={Wen, Xueru and Lou, Jie and Lu, Yaojie and Lin, Hongyu and Yu, Xing and Lu, Xinyu and He, Ben and Han, Xianpei and Zhang, Debing and Sun, Le},
+  year = {2025}
+}
+
 @inproceedings{zhou2024rmb,
   title={RMB: Comprehensively Benchmarking Reward Models in LLM Alignment},
   booktitle = {International Conference on Learning Representations (ICLR)},
   author={Zhou, Enyu and Zheng, Guodong and Wang, Binghai and Xi, Zhiheng and Dou, Shihan and Bao, Rong and Shen, Wei and Xiong, Limao and Fan, Jessica and Mou, Yurong and others},
+  year = {2025}
+}
+
+@article{malik2025rewardbench,
+  title={RewardBench 2: Advancing Reward Model Evaluation},
+  author={Malik, Saumya and Pyatkin, Valentina and Land, Sander and Morrison, Jacob and Smith, Noah A and Hajishirzi, Hannaneh and Lambert, Nathan},
+  journal={arXiv preprint arXiv:2506.01937},
+  year={2025}
+}
+
+@inproceedings{frick2024evaluate,
+  title={How to Evaluate Reward Models for RLHF},
+  booktitle = {International Conference on Learning Representations (ICLR)},
+  author={Frick, Evan and Li, Tianle and Chen, Connor and Chiang, Wei-Lin and Angelopoulos, Anastasios N and Jiao, Jiantao and Zhu, Banghua and Gonzalez, Joseph E and Stoica, Ion},
   year = {2025}
 }
 
@@ -613,11 +759,11 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   year = {2025}
 }
 
-@article{chen2024mj,
-  title={MJ-Bench: Is Your Multimodal Reward Model Really a Good Judge for Text-to-Image Generation?},
-  author={Chen, Zhaorun and Du, Yichao and Wen, Zichen and Zhou, Yiyang and Cui, Chenhang and Weng, Zhenzhen and Tu, Haoqin and Wang, Chaoqi and Tong, Zhengwei and Huang, Qinglan and others},
-  journal={arXiv preprint arXiv:2407.04842},
-  year={2024}
+@inproceedings{jin2024rag,
+  title={RAG-RewardBench: Benchmarking Reward Models in Retrieval Augmented Generation for Preference Alignment},
+  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
+  author={Jin, Zhuoran and Yuan, Hongbang and Men, Tianyi and Cao, Pengfei and Chen, Yubo and Liu, Kang and Zhao, Jun},
+  year = {2025}
 }
 
 @article{wu2025rewordbench,
@@ -627,25 +773,21 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   year={2025}
 }
 
-@article{yasunaga2025multimodal,
-  title={Multimodal rewardbench: Holistic evaluation of reward models for vision language models},
-  author={Yasunaga, Michihiro and Zettlemoyer, Luke and Ghazvininejad, Marjan},
-  journal={arXiv preprint arXiv:2502.14191},
-  year={2025}
-}
-
-@article{li2024vlrewardbench,
-  title={VLRewardBench: A Challenging Benchmark for Vision-Language Generative Reward Models},
-  author={Li, Lei and Wei, Yuancheng and Xie, Zhihui and Yang, Xuqing and Song, Yifan and Wang, Peiyi and An, Chenxin and Liu, Tianyu and Li, Sujian and Lin, Bill Yuchen and others},
-  journal={arXiv preprint arXiv:2411.17451},
+@article{kim2024evaluating,
+  title={Evaluating robustness of reward models for mathematical reasoning},
+  author={Kim, Sunghwan and Kang, Dongjin and Kwon, Taeyoon and Chae, Hyungjoo and Won, Jungsoo and Lee, Dongha and Yeo, Jinyoung},
+  journal={arXiv preprint arXiv:2410.01729},
   year={2024}
 }
 
-@article{ruan2025vlrmbench,
-  title={Vlrmbench: A comprehensive and challenging benchmark for vision-language reward models},
-  author={Ruan, Jiacheng and Yuan, Wenzhen and Gao, Xian and Guo, Ye and Zhang, Daoxin and Xu, Zhe and Hu, Yao and Liu, Ting and Fu, Yuzhuo},
-  journal={arXiv preprint arXiv:2503.07478},
-  year={2025}
+@inproceedings{liu2024acemath,
+  title        = {AceMath: Advancing Frontier Math Reasoning with Post-Training and Reward Modeling},
+  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
+  author       = {Zihan Liu and Yang Chen and Mohammad Shoeybi and Bryan Catanzaro and Wei Ping},
+  year = {2025},
+  archivePrefix= {arXiv},
+  primaryClass = {cs.CL},
+  url          = {https://arxiv.org/abs/2412.15084}
 }
 
 @inproceedings{song2025prmbench,
@@ -653,6 +795,16 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
   author={Song, Mingyang and Su, Zhaochen and Qu, Xiaoye and Zhou, Jiawei and Cheng, Yu},
   year = {2025}
+}
+
+@inproceedings{zheng2024processbench,
+  title        = {ProcessBench: Identifying Process Errors in Mathematical Reasoning},
+  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
+  author       = {Chujie Zheng and Zhenru Zhang and Beichen Zhang and Runji Lin and Keming Lu and Bowen Yu and Dayiheng Liu and Jingren Zhou and Junyang Lin},
+  year = {2025},
+  archivePrefix= {arXiv},
+  primaryClass = {cs.AI},
+  url          = {https://arxiv.org/abs/2412.06559}
 }
 
 @article{wang2025visualprm,
@@ -671,105 +823,6 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   archivePrefix = {arXiv},
   primaryClass = {cs.CV},
   url = {https://arxiv.org/abs/2503.20271}
-}
-
-@inproceedings{wen2024rethinking,
-  title={Rethinking Reward Model Evaluation: Are We Barking up the Wrong Tree?},
-  booktitle = {International Conference on Learning Representations (ICLR)},
-  author={Wen, Xueru and Lou, Jie and Lu, Yaojie and Lin, Hongyu and Yu, Xing and Lu, Xinyu and He, Ben and Han, Xianpei and Zhang, Debing and Sun, Le},
-  year = {2025}
-}
-
-@inproceedings{jin2024rag,
-  title={RAG-RewardBench: Benchmarking Reward Models in Retrieval Augmented Generation for Preference Alignment},
-  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
-  author={Jin, Zhuoran and Yuan, Hongbang and Men, Tianyi and Cao, Pengfei and Chen, Yubo and Liu, Kang and Zhao, Jun},
-  year = {2025}
-}
-
-@inproceedings{frick2024evaluate,
-  title={How to Evaluate Reward Models for RLHF},
-  booktitle = {International Conference on Learning Representations (ICLR)},
-  author={Frick, Evan and Li, Tianle and Chen, Connor and Chiang, Wei-Lin and Angelopoulos, Anastasios N and Jiao, Jiantao and Zhu, Banghua and Gonzalez, Joseph E and Stoica, Ion},
-  year = {2025}
-}
-
-@article{kim2024evaluating,
-  title={Evaluating robustness of reward models for mathematical reasoning},
-  author={Kim, Sunghwan and Kang, Dongjin and Kwon, Taeyoon and Chae, Hyungjoo and Won, Jungsoo and Lee, Dongha and Yeo, Jinyoung},
-  journal={arXiv preprint arXiv:2410.01729},
-  year={2024}
-}
-
-@inproceedings{zhu2023principled,
-  title={Principled reinforcement learning with human feedback from pairwise or k-wise comparisons},
-  author={Zhu, Banghua and Jordan, Michael and Jiao, Jiantao},
-  booktitle={International Conference on Machine Learning},
-  pages={43037--43067},
-  year={2023},
-  organization={PMLR}
-}
-
-@inproceedings{wang2024interpretable,
-  title={Interpretable Preferences via Multi-Objective Reward Modeling and Mixture-of-Experts},
-  booktitle = {Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  author={Wang, Haoxiang and Xiong, Wei and Xie, Tengyang and Zhao, Han and Zhang, Tong},
-  year = {2024}
-}
-
-@inproceedings{zhang2024generative,
-  title={Generative verifiers: Reward modeling as next-token prediction},
-  booktitle = {International Conference on Learning Representations (ICLR)},
-  author={Zhang, Lunjun and Hosseini, Arian and Bansal, Hritik and Kazemi, Mehran and Kumar, Aviral and Agarwal, Rishabh},
-  year = {2025}
-}
-
-@article{mahan2024generative,
-  title={Generative Reward Models},
-  author={Mahan, Dakota and Phung, Duy Van and Rafailov, Rafael and Blagden, Chase and Lile, Nathan and Castricato, Louis and Franken, Jan-Philipp and Finn, Chelsea and Albalak, Alon},
-  year={2024},
-  url={https://www.synthlabs.ai/pdf/Generative_Reward_Models.pdf}
-}
-
-@article{wang2024helpsteer2,
-  title={HelpSteer2: Open-source dataset for training top-performing reward models},
-  author={Wang, Zhilin and Dong, Yi and Delalleau, Olivier and Zeng, Jiaqi and Shen, Gerald and Egert, Daniel and Zhang, Jimmy J and Sreedhar, Makesh Narsimhan and Kuchaiev, Oleksii},
-  journal={arXiv preprint arXiv:2406.08673},
-  year={2024}
-}
-
-@article{ankner2024critique,
-  title={Critique-out-loud reward models},
-  author={Ankner, Zachary and Paul, Mansheej and Cui, Brandon and Chang, Jonathan D and Ammanabrolu, Prithviraj},
-  journal={arXiv preprint arXiv:2408.11791},
-  year={2024}
-}
-
-@inproceedings{park2024offsetbias,
-  title={Offsetbias: Leveraging debiased data for tuning evaluators},
-  booktitle = {Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  author={Park, Junsoo and Jwa, Seungyeon and Ren, Meiying and Kim, Daeyoung and Choi, Sanghyuk},
-  year = {2024}
-}
-
-@inproceedings{liu2024acemath,
-  title        = {AceMath: Advancing Frontier Math Reasoning with Post-Training and Reward Modeling},
-  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
-  author       = {Zihan Liu and Yang Chen and Mohammad Shoeybi and Bryan Catanzaro and Wei Ping},
-  year = {2025},
-  archivePrefix= {arXiv},
-  primaryClass = {cs.CL},
-  url          = {https://arxiv.org/abs/2412.15084}
-}
-
-@inproceedings{zheng2024processbench,
-  title        = {ProcessBench: Identifying Process Errors in Mathematical Reasoning},
-  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
-  author       = {Chujie Zheng and Zhenru Zhang and Beichen Zhang and Runji Lin and Keming Lu and Bowen Yu and Dayiheng Liu and Jingren Zhou and Junyang Lin},
-  year = {2025},
-  archivePrefix= {arXiv},
-  primaryClass = {cs.AI},
-  url          = {https://arxiv.org/abs/2412.06559}
 }
 
 @inproceedings{men2025agentrewardbench,
@@ -795,77 +848,79 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   url          = {https://arxiv.org/abs/2510.18596}
 }
 
-@inproceedings{liu2019learning,
-  title={Learning plackett-luce mixtures from partial preferences},
-  author={Liu, Ao and Zhao, Zhibing and Liao, Chao and Lu, Pinyan and Xia, Lirong},
-  booktitle={Proceedings of the AAAI Conference on Artificial Intelligence},
-  volume={33},
-  number={01},
-  pages={4328--4335},
-  year={2019}
-}
-
-@inproceedings{zhu2024starling,
-  title={Starling-7b: Improving helpfulness and harmlessness with rlaif},
-  author={Zhu, Banghua and Frick, Evan and Wu, Tianhao and Zhu, Hanlin and Ganesan, Karthik and Chiang, Wei-Lin and Zhang, Jian and Jiao, Jiantao},
-  booktitle={First Conference on Language Modeling},
+@article{chen2024mj,
+  title={MJ-Bench: Is Your Multimodal Reward Model Really a Good Judge for Text-to-Image Generation?},
+  author={Chen, Zhaorun and Du, Yichao and Wen, Zichen and Zhou, Yiyang and Cui, Chenhang and Weng, Zhenzhen and Tu, Haoqin and Wang, Chaoqi and Tong, Zhengwei and Huang, Qinglan and others},
+  journal={arXiv preprint arXiv:2407.04842},
   year={2024}
 }
 
-@article{lyu2025exploring,
-  title={Exploring the Limit of Outcome Reward for Learning Mathematical Reasoning},
-  author={Lyu, Chengqi and Gao, Songyang and Gu, Yuzhe and Zhang, Wenwei and Gao, Jianfei and Liu, Kuikun and Wang, Ziyi and Li, Shuaibin and Zhao, Qian and Huang, Haian and others},
-  journal={arXiv preprint arXiv:2502.06781},
+@article{yasunaga2025multimodal,
+  title={Multimodal rewardbench: Holistic evaluation of reward models for vision language models},
+  author={Yasunaga, Michihiro and Zettlemoyer, Luke and Ghazvininejad, Marjan},
+  journal={arXiv preprint arXiv:2502.14191},
   year={2025}
 }
 
-@article{zheng2023judging,
-  title={Judging llm-as-a-judge with mt-bench and chatbot arena},
-  author={Zheng, Lianmin and Chiang, Wei-Lin and Sheng, Ying and Zhuang, Siyuan and Wu, Zhanghao and Zhuang, Yonghao and Lin, Zi and Li, Zhuohan and Li, Dacheng and Xing, Eric and others},
-  journal={Advances in Neural Information Processing Systems},
-  volume={36},
-  pages={46595--46623},
-  year={2023}
+@article{li2024vlrewardbench,
+  title={VLRewardBench: A Challenging Benchmark for Vision-Language Generative Reward Models},
+  author={Li, Lei and Wei, Yuancheng and Xie, Zhihui and Yang, Xuqing and Song, Yifan and Wang, Peiyi and An, Chenxin and Liu, Tianyu and Li, Sujian and Lin, Bill Yuchen and others},
+  journal={arXiv preprint arXiv:2411.17451},
+  year={2024}
 }
 
-@inproceedings{lin2024wildbench,
-  title={WILDBENCH: Benchmarking LLMs with Challenging Tasks from Real Users in the Wild},
+@article{ruan2025vlrmbench,
+  title={Vlrmbench: A comprehensive and challenging benchmark for vision-language reward models},
+  author={Ruan, Jiacheng and Yuan, Wenzhen and Gao, Xian and Guo, Ye and Zhang, Daoxin and Xu, Zhe and Hu, Yao and Liu, Ting and Fu, Yuzhuo},
+  journal={arXiv preprint arXiv:2503.07478},
+  year={2025}
+}
+
+@inproceedings{wang2024interpretable,
+  title={Interpretable Preferences via Multi-Objective Reward Modeling and Mixture-of-Experts},
+  booktitle = {Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  author={Wang, Haoxiang and Xiong, Wei and Xie, Tengyang and Zhao, Han and Zhang, Tong},
+  year = {2024}
+}
+
+@article{wang2024helpsteer2,
+  title={HelpSteer2: Open-source dataset for training top-performing reward models},
+  author={Wang, Zhilin and Dong, Yi and Delalleau, Olivier and Zeng, Jiaqi and Shen, Gerald and Egert, Daniel and Zhang, Jimmy J and Sreedhar, Makesh Narsimhan and Kuchaiev, Oleksii},
+  journal={arXiv preprint arXiv:2406.08673},
+  year={2024}
+}
+
+@inproceedings{wang2024helpsteer2p,
+  title={HelpSteer2-Preference: Complementing Ratings with Preferences},
   booktitle = {International Conference on Learning Representations (ICLR)},
-  author={Lin, Bill Yuchen and Deng, Yuntian and Chandu, Khyathi and Brahman, Faeze and Ravichander, Abhilasha and Pyatkin, Valentina and Dziri, Nouha and Bras, Ronan Le and Choi, Yejin},
+  author={Wang, Zhilin and Bukharin, Alexander and Delalleau, Olivier and Egert, Daniel and Shen, Gerald and Zeng, Jiaqi and Kuchaiev, Oleksii and Dong, Yi},
   year = {2025}
 }
 
-@inproceedings{li2024crowdsourced,
-  title={From Crowdsourced Data to High-Quality Benchmarks: Arena-Hard and BenchBuilder Pipeline},
-  booktitle = {International Conference on Machine Learning (ICML)},
-  author={Li, Tianle and Chiang, Wei-Lin and Frick, Evan and Dunlap, Lisa and Wu, Tianhao and Zhu, Banghua and Gonzalez, Joseph E and Stoica, Ion},
-  year = {2025}
-}
-
-@article{dubois2024length,
-  title={Length-controlled alpacaeval: A simple way to debias automatic evaluators},
-  author={Dubois, Yann and Galambosi, Bal{\'a}zs and Liang, Percy and Hashimoto, Tatsunori B},
-  journal={arXiv preprint arXiv:2404.04475},
-  year={2024}
-}
-
-@inproceedings{kim2023prometheus,
-  title={Prometheus: Inducing fine-grained evaluation capability in language models},
-  author={Kim, Seungone and Shin, Jamin and Cho, Yejin and Jang, Joel and Longpre, Shayne and Lee, Hwaran and Yun, Sangdoo and Shin, Seongjin and Kim, Sungdong and Thorne, James and others},
-  booktitle={The Twelfth International Conference on Learning Representations},
-  year={2024}
-}
-
-@article{cobbe2021gsm8k,
-  title={Training Verifiers to Solve Math Word Problems},
-  author={Cobbe, Karl and Kosaraju, Vineet and Bavarian, Mohammad and Chen, Mark and Jun, Heewoo and Kaiser, Lukasz and Plappert, Matthias and Tworek, Jerry and Hilton, Jacob and Nakano, Reiichiro and Hesse, Christopher and Schulman, John},
-  journal={arXiv preprint arXiv:2110.14168},
-  year={2021}
+@inproceedings{park2024offsetbias,
+  title={Offsetbias: Leveraging debiased data for tuning evaluators},
+  booktitle = {Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  author={Park, Junsoo and Jwa, Seungyeon and Ren, Meiying and Kim, Daeyoung and Choi, Sanghyuk},
+  year = {2024}
 }
 
 ### End chapter 5 ###
 
 ### First appearing in chapter 6 (Policy Gradients) ###
+
+@inproceedings{ahmadian2024back,
+  title={Back to basics: Revisiting reinforce style optimization for learning from human feedback in llms},
+  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
+  author={Ahmadian, Arash and Cremer, Chris and Gall{\'e}, Matthias and Fadaee, Marzieh and Kreutzer, Julia and Pietquin, Olivier and {\"U}st{\"u}n, Ahmet and Hooker, Sara},
+  year = {2024}
+}
+
+@inproceedings{schulman2015high,
+  title={High-dimensional continuous control using generalized advantage estimation},
+  author={Schulman, John and Moritz, Philipp and Levine, Sergey and Jordan, Michael and Abbeel, Pieter},
+  booktitle={Proceedings of the International Conference on Learning Representations (ICLR)},
+  year =2016
+}
 
 @article{williams1992simple,
   title={Simple statistical gradient-following algorithms for connectionist reinforcement learning},
@@ -875,6 +930,20 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   pages={229--256},
   year={1992},
   publisher={Springer}
+}
+
+@misc{huang2024putting,
+  author       = {Shengyi Costa Huang and Arash Ahmadian and Cohere For AI},
+  title        = {Putting RL back in RLHF},
+  year         = {2024},
+  howpublished = {\url{https://huggingface.co/blog/putting_rl_back_in_rlhf_with_rloo}},
+  note         = {Accessed: 2025-01-15}
+}
+
+@article{kool2019buy,
+  title={Buy 4 reinforce samples, get a baseline for free!},
+  author={Kool, Wouter and van Hoof, Herke and Welling, Max},
+  year={2019}
 }
 
 @article{schulman2017proximal,
@@ -889,6 +958,86 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   author={Berner, Christopher and Brockman, Greg and Chan, Brooke and Cheung, Vicki and D{\k{e}}biak, Przemys{\l}aw and Dennison, Christy and Farhi, David and Fischer, Quirin and Hashme, Shariq and Hesse, Chris and others},
   journal={arXiv preprint arXiv:1912.06680},
   year={2019}
+}
+
+@article{liu2025understanding,
+  title={Understanding R1-Zero-Like Training: A Critical Perspective},
+  author={Liu, Zichen and Chen, Changyu and Li, Wenjun and Qi, Penghui and Pang, Tianyu and Du, Chao and Lee, Wee Sun and Lin, Min},
+  journal={arXiv preprint arXiv:2503.20783},
+  year={2025},
+  month={Mar},
+  url={https://arxiv.org/abs/2503.20783}
+}
+
+@book{nocedal2006numerical,
+  title={Numerical optimization},
+  author={Nocedal, Jorge and Wright, Stephen J},
+  year={2006},
+  publisher={Springer}
+}
+
+@inproceedings{schulman2015trust,
+  title={Trust region policy optimization},
+  author={Schulman, John and Levine, Sergey and Abbeel, Pieter and Jordan, Michael and Moritz, Philipp},
+  booktitle={International conference on machine learning},
+  pages={1889--1897},
+  year={2015},
+  organization={PMLR}
+}
+
+@article{shao2024deepseekmath,
+  title={Deepseekmath: Pushing the limits of mathematical reasoning in open language models},
+  author={Shao, Zhihong and Wang, Peiyi and Zhu, Qihao and Xu, Runxin and Song, Junxiao and Bi, Xiao and Zhang, Haowei and Zhang, Mingchuan and Li, YK and Wu, Y and others},
+  journal={arXiv preprint arXiv:2402.03300},
+  year={2024}
+}
+
+@misc{zheng2025gspo,
+  title         = {Group Sequence Policy Optimization},
+  author        = {Zheng, Chujie and Liu, Shixuan and Li, Mingze and Chen, Xiong-Hui and Yu, Bowen and Gao, Chang and Dang, Kai and Liu, Yuqiong and Men, Rui and Yang, An and Zhou, Jingren and Lin, Junyang},
+  year          = {2025},
+  eprint        = {2507.18071},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.LG},
+  doi           = {10.48550/arXiv.2507.18071},
+  url           = {https://arxiv.org/abs/2507.18071}
+}
+
+@misc{minimax2025minimax_m1,
+      title={MiniMax-M1: Scaling Test-Time Compute Efficiently with Lightning Attention},
+      author={MiniMax},
+      year={2025},
+      eprint={2506.13585},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      doi={10.48550/arXiv.2506.13585},
+      url={https://arxiv.org/abs/2506.13585},
+}
+
+@misc{leroux2025topr,
+  title         = {Tapered Off-Policy {REINFORCE}: Stable and efficient reinforcement learning for {LLMs}},
+  author        = {Le Roux, Nicolas and Bellemare, Marc G. and Lebensold, Jonathan and Bergeron, Arnaud and Greaves, Joshua and Fr{\'e}chette, Alex and Pelletier, Carolyne and Thibodeau-Laufer, Eric and Toth, S{\'a}ndor and Work, Sam},
+  year          = {2025},
+  eprint        = {2503.14286},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.LG},
+  doi           = {10.48550/arXiv.2503.14286},
+  url           = {https://arxiv.org/abs/2503.14286}
+}
+
+@inproceedings{ivison2024unpacking,
+  title={Unpacking DPO and PPO: Disentangling Best Practices for Learning from Preference Feedback},
+  booktitle = {Advances in Neural Information Processing Systems (NeurIPS)},
+  author={Ivison, Hamish and Wang, Yizhong and Liu, Jiacheng and Wu, Zeqiu and Pyatkin, Valentina and Lambert, Nathan and Smith, Noah A and Choi, Yejin and Hajishirzi, Hannaneh},
+  year = {2024}
+}
+
+@misc{schulman2016klapprox,
+  author = {Schulman, John},
+  title = {Approximating KL-divergence},
+  year = {2016},
+  howpublished = {\url{http://joschu.net/blog/kl-approx.html}},
+  note = {Accessed: 2024-10-01}
 }
 
 @inproceedings{huang2024n,
@@ -907,33 +1056,6 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   url     = "https://lilianweng.github.io/posts/2018-04-08-policy-gradient/"
 }
 
-@article{kool2019buy,
-  title={Buy 4 reinforce samples, get a baseline for free!},
-  author={Kool, Wouter and van Hoof, Herke and Welling, Max},
-  year={2019}
-}
-
-@inproceedings{schulman2015high,
-  title={High-dimensional continuous control using generalized advantage estimation},
-  author={Schulman, John and Moritz, Philipp and Levine, Sergey and Jordan, Michael and Abbeel, Pieter},
-  booktitle={Proceedings of the International Conference on Learning Representations (ICLR)},
-  year =2016
-}
-
-@misc{seita2017gae,
-  author = {Daniel Seita},
-  title = {Notes on the Generalized Advantage Estimation Paper},
-  year = {2017},
-  url = {https://danieltakeshi.github.io/2017/04/02/notes-on-the-generalized-advantage-estimation-paper/}
-}
-
-@inproceedings{ivison2024unpacking,
-  title={Unpacking DPO and PPO: Disentangling Best Practices for Learning from Preference Feedback},
-  booktitle = {Advances in Neural Information Processing Systems (NeurIPS)},
-  author={Ivison, Hamish and Wang, Yizhong and Liu, Jiacheng and Wu, Zeqiu and Pyatkin, Valentina and Lambert, Nathan and Smith, Noah A and Choi, Yejin and Hajishirzi, Hannaneh},
-  year = {2024}
-}
-
 @misc{yu2025dapo,
   author = {Yu, Qiying and Zhang, Zheng and Zhu, Ruofei and Yuan, Yufeng and Yue, Yu and Fan, Tiantian and Liu, Gaohong and Liu, Lingjun and Liu, Xin and Lin, Haibin and Lin, Zhiqi and Ma, Bole and Sheng, Guangming and Tong, Yuxuan and Zhang, Chi and Zhang, Mofan and Zhang, Wang and Zhu, Hang and Zhu, Jinhua and Chen, Jiaze and Chen, Jiangjie and Wang, Chengyi and Yu, Hongli and Dai, Weinan and Song, Yuxuan and Wei, Xiangpeng and Zhou, Hao and Liu, Jingjing and Ma, Wei-Ying and Zhang, Ya-Qin and Qiao, Mu and Yan, Lin and Wu, Yonghui and Wang, Mingxuan},
   title = {DAPO: an Open-Source LLM Reinforcement Learning System at Scale},
@@ -942,92 +1064,11 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   note = {Available at \url{https://dapo-sia.github.io/static/pdf/dapo_paper.pdf}}
 }
 
-@article{gao2025sapo,
-  title={Soft Adaptive Policy Optimization},
-  author={Gao, Chang and Zheng, Chujie and Chen, Xiong-Hui and Dang, Kai and Liu, Shixuan and Yu, Bowen and Yang, An and Bai, Shuai and Zhou, Jingren and Lin, Junyang},
-  journal={arXiv preprint arXiv:2511.20347},
-  year={2025},
-  month={Nov},
-  url={https://arxiv.org/abs/2511.20347}
-}
-
 @inproceedings{baheti2023leftover,
   title={Leftover lunch: advantage-based offline reinforcement learning for language models},
   booktitle = {International Conference on Learning Representations (ICLR)},
   author={Baheti, Ashutosh and Lu, Ximing and Brahman, Faeze and Bras, Ronan Le and Sap, Maarten and Riedl, Mark},
   year = {2024}
-}
-
-@article{yuan2025vapo,
-  title={VAPO: Efficient and Reliable Reinforcement Learning for Advanced Reasoning Tasks},
-  author={Yuan, Yufeng and Yu, Qiying and Zuo, Xiaochen and Zhu, Ruofei and Xu, Wenyuan and Chen, Jiaze and Wang, Chengyi and Fan, TianTian and Du, Zhengyin and Wei, Xiangpeng and others},
-  journal={arXiv preprint arXiv:2504.05118},
-  year={2025}
-}
-
-@article{yuan2025s,
-  title={What's Behind PPO's Collapse in Long-CoT? Value Optimization Holds the Secret},
-  author={Yuan, Yufeng and Yue, Yu and Zhu, Ruofei and Fan, Tiantian and Yan, Lin},
-  journal={arXiv preprint arXiv:2503.01491},
-  year={2025}
-}
-
-@article{liu2025understanding,
-  title={Understanding R1-Zero-Like Training: A Critical Perspective},
-  author={Liu, Zichen and Chen, Changyu and Li, Wenjun and Qi, Penghui and Pang, Tianyu and Du, Chao and Lee, Wee Sun and Lin, Min},
-  journal={arXiv preprint arXiv:2503.20783},
-  year={2025},
-  month={Mar},
-  url={https://arxiv.org/abs/2503.20783}
-}
-
-@inproceedings{flet2024contrastive,
-  title={Contrastive Policy Gradient: Aligning LLMs on sequence-level scores in a supervised-friendly fashion},
-  booktitle = {Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  author={Flet-Berliac, Yannis and Grinsztajn, Nathan and Strub, Florian and Wu, Bill and Choi, Eugene and Cremer, Chris and Ahmadian, Arash and Chandak, Yash and Azar, Mohammad Gheshlaghi and Pietquin, Olivier and others},
-  year = {2024}
-}
-
-@inproceedings{li2023remax,
-  title={Remax: A simple, effective, and efficient reinforcement learning method for aligning large language models},
-  author={Li, Ziniu and Xu, Tian and Zhang, Yushun and Lin, Zhihang and Yu, Yang and Sun, Ruoyu and Luo, Zhi-Quan},
-  booktitle={Forty-first International Conference on Machine Learning},
-  year={2024}
-}
-
-@article{team2025kimi,
-  title={Kimi k1. 5: Scaling reinforcement learning with llms},
-  author={Team, Kimi and Du, Angang and Gao, Bofei and Xing, Bowei and Jiang, Changjiu and Chen, Cheng and Li, Cheng and Xiao, Chenjun and Du, Chenzhuang and Liao, Chonghua and others},
-  journal={arXiv preprint arXiv:2501.12599},
-  year={2025}
-}
-
-@article{wu2023pairwise,
-  title={Pairwise proximal policy optimization: Harnessing relative feedback for llm alignment},
-  author={Wu, Tianhao and Zhu, Banghua and Zhang, Ruoyu and Wen, Zhaojin and Ramchandran, Kannan and Jiao, Jiantao},
-  journal={arXiv preprint arXiv:2310.00212},
-  year={2023}
-}
-
-@article{gunter2024apple,
-  title={Apple intelligence foundation language models},
-  author={Gunter, Tom and Wang, Zirui and Wang, Chong and Pang, Ruoming and Narayanan, Andy and Zhang, Aonan and Zhang, Bowen and Chen, Chen and Chiu, Chung-Cheng and Qiu, David and others},
-  journal={arXiv preprint arXiv:2407.21075},
-  year={2024}
-}
-
-@article{zhang2025improving,
-  title={Improving LLM General Preference Alignment via Optimistic Online Mirror Descent},
-  author={Zhang, Yuheng and Yu, Dian and Ge, Tao and Song, Linfeng and Zeng, Zhichen and Mi, Haitao and Jiang, Nan and Yu, Dong},
-  journal={arXiv preprint arXiv:2502.16852},
-  year={2025}
-}
-
-@inproceedings{tomar2020mirror,
-  title={Mirror descent policy optimization},
-  booktitle = {International Conference on Learning Representations (ICLR)},
-  author={Tomar, Manan and Shani, Lior and Efroni, Yonathan and Ghavamzadeh, Mohammad},
-  year = {2022}
 }
 
 @inproceedings{noukhovitch2024asynchronous,
@@ -1052,73 +1093,13 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
 }
 
 @misc{primeintellectteam2025intellect2reasoningmodeltrained,
-      title={INTELLECT-2: A Reasoning Model Trained Through Globally Decentralized Reinforcement Learning}, 
+      title={INTELLECT-2: A Reasoning Model Trained Through Globally Decentralized Reinforcement Learning},
       author={Prime Intellect Team and Sami Jaghouar and Justus Mattern and Jack Min Ong and Jannik Straube and Manveer Basra and Aaron Pazdera and Kushal Thaman and Matthew Di Ferrante and Felix Gabriel and Fares Obeid and Kemal Erdem and Michael Keiblinger and Johannes Hagemann},
       year={2025},
       eprint={2505.07291},
       archivePrefix={arXiv},
       primaryClass={cs.LG},
-      url={https://arxiv.org/abs/2505.07291}, 
-}
-
-@article{shao2024deepseekmath,
-  title={Deepseekmath: Pushing the limits of mathematical reasoning in open language models},
-  author={Shao, Zhihong and Wang, Peiyi and Zhu, Qihao and Xu, Runxin and Song, Junxiao and Bi, Xiao and Zhang, Haowei and Zhang, Mingchuan and Li, YK and Wu, Y and others},
-  journal={arXiv preprint arXiv:2402.03300},
-  year={2024}
-}
-
-@book{nocedal2006numerical,
-  title={Numerical optimization},
-  author={Nocedal, Jorge and Wright, Stephen J},
-  year={2006},
-  publisher={Springer}
-}
-
-@inproceedings{schulman2015trust,
-  title={Trust region policy optimization},
-  author={Schulman, John and Levine, Sergey and Abbeel, Pieter and Jordan, Michael and Moritz, Philipp},
-  booktitle={International conference on machine learning},
-  pages={1889--1897},
-  year={2015},
-  organization={PMLR}
-}
-
-@misc{huang2024putting,
-  author       = {Shengyi Costa Huang and Arash Ahmadian and Cohere For AI},
-  title        = {Putting RL back in RLHF},
-  year         = {2024},
-  howpublished = {\url{https://huggingface.co/blog/putting_rl_back_in_rlhf_with_rloo}},
-  note         = {Accessed: 2025-01-15}
-}
-
-@inproceedings{ahmadian2024back,
-  title={Back to basics: Revisiting reinforce style optimization for learning from human feedback in llms},
-  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
-  author={Ahmadian, Arash and Cremer, Chris and Gall{\'e}, Matthias and Fadaee, Marzieh and Kreutzer, Julia and Pietquin, Olivier and {\"U}st{\"u}n, Ahmet and Hooker, Sara},
-  year = {2024}
-}
-
-@misc{zheng2025gspo,
-  title         = {Group Sequence Policy Optimization},
-  author        = {Zheng, Chujie and Liu, Shixuan and Li, Mingze and Chen, Xiong-Hui and Yu, Bowen and Gao, Chang and Dang, Kai and Liu, Yuqiong and Men, Rui and Yang, An and Zhou, Jingren and Lin, Junyang},
-  year          = {2025},
-  eprint        = {2507.18071},
-  archivePrefix = {arXiv},
-  primaryClass  = {cs.LG},
-  doi           = {10.48550/arXiv.2507.18071},
-  url           = {https://arxiv.org/abs/2507.18071}
-}
-
-@misc{leroux2025topr,
-  title         = {Tapered Off-Policy {REINFORCE}: Stable and efficient reinforcement learning for {LLMs}},
-  author        = {Le Roux, Nicolas and Bellemare, Marc G. and Lebensold, Jonathan and Bergeron, Arnaud and Greaves, Joshua and Fr{\'e}chette, Alex and Pelletier, Carolyne and Thibodeau-Laufer, Eric and Toth, S{\'a}ndor and Work, Sam},
-  year          = {2025},
-  eprint        = {2503.14286},
-  archivePrefix = {arXiv},
-  primaryClass  = {cs.LG},
-  doi           = {10.48550/arXiv.2503.14286},
-  url           = {https://arxiv.org/abs/2503.14286}
+      url={https://arxiv.org/abs/2505.07291},
 }
 
 @article{ionides2008truncated,
@@ -1138,15 +1119,237 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   year={2025}
 }
 
+@misc{seita2017gae,
+  author = {Daniel Seita},
+  title = {Notes on the Generalized Advantage Estimation Paper},
+  year = {2017},
+  url = {https://danieltakeshi.github.io/2017/04/02/notes-on-the-generalized-advantage-estimation-paper/}
+}
+
+@article{wu2023pairwise,
+  title={Pairwise proximal policy optimization: Harnessing relative feedback for llm alignment},
+  author={Wu, Tianhao and Zhu, Banghua and Zhang, Ruoyu and Wen, Zhaojin and Ramchandran, Kannan and Jiao, Jiantao},
+  journal={arXiv preprint arXiv:2310.00212},
+  year={2023}
+}
+
+@article{gao2025sapo,
+  title={Soft Adaptive Policy Optimization},
+  author={Gao, Chang and Zheng, Chujie and Chen, Xiong-Hui and Dang, Kai and Liu, Shixuan and Yu, Bowen and Yang, An and Bai, Shuai and Zhou, Jingren and Lin, Junyang},
+  journal={arXiv preprint arXiv:2511.20347},
+  year={2025},
+  month={Nov},
+  url={https://arxiv.org/abs/2511.20347}
+}
+
+@inproceedings{flet2024contrastive,
+  title={Contrastive Policy Gradient: Aligning LLMs on sequence-level scores in a supervised-friendly fashion},
+  booktitle = {Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  author={Flet-Berliac, Yannis and Grinsztajn, Nathan and Strub, Florian and Wu, Bill and Choi, Eugene and Cremer, Chris and Ahmadian, Arash and Chandak, Yash and Azar, Mohammad Gheshlaghi and Pietquin, Olivier and others},
+  year = {2024}
+}
+
+@inproceedings{li2023remax,
+  title={Remax: A simple, effective, and efficient reinforcement learning method for aligning large language models},
+  author={Li, Ziniu and Xu, Tian and Zhang, Yushun and Lin, Zhihang and Yu, Yang and Sun, Ruoyu and Luo, Zhi-Quan},
+  booktitle={Forty-first International Conference on Machine Learning},
+  year={2024}
+}
+
+@article{gunter2024apple,
+  title={Apple intelligence foundation language models},
+  author={Gunter, Tom and Wang, Zirui and Wang, Chong and Pang, Ruoming and Narayanan, Andy and Zhang, Aonan and Zhang, Bowen and Chen, Chen and Chiu, Chung-Cheng and Qiu, David and others},
+  journal={arXiv preprint arXiv:2407.21075},
+  year={2024}
+}
+
+@article{team2025kimi,
+  title={Kimi k1. 5: Scaling reinforcement learning with llms},
+  author={Team, Kimi and Du, Angang and Gao, Bofei and Xing, Bowei and Jiang, Changjiu and Chen, Cheng and Li, Cheng and Xiao, Chenjun and Du, Chenzhuang and Liao, Chonghua and others},
+  journal={arXiv preprint arXiv:2501.12599},
+  year={2025}
+}
+
+@inproceedings{tomar2020mirror,
+  title={Mirror descent policy optimization},
+  booktitle = {International Conference on Learning Representations (ICLR)},
+  author={Tomar, Manan and Shani, Lior and Efroni, Yonathan and Ghavamzadeh, Mohammad},
+  year = {2022}
+}
+
+@article{zhang2025improving,
+  title={Improving LLM General Preference Alignment via Optimistic Online Mirror Descent},
+  author={Zhang, Yuheng and Yu, Dian and Ge, Tao and Song, Linfeng and Zeng, Zhichen and Mi, Haitao and Jiang, Nan and Yu, Dong},
+  journal={arXiv preprint arXiv:2502.16852},
+  year={2025}
+}
+
+@article{yuan2025vapo,
+  title={VAPO: Efficient and Reliable Reinforcement Learning for Advanced Reasoning Tasks},
+  author={Yuan, Yufeng and Yu, Qiying and Zuo, Xiaochen and Zhu, Ruofei and Xu, Wenyuan and Chen, Jiaze and Wang, Chengyi and Fan, TianTian and Du, Zhengyin and Wei, Xiangpeng and others},
+  journal={arXiv preprint arXiv:2504.05118},
+  year={2025}
+}
+
+@article{yuan2025s,
+  title={What's Behind PPO's Collapse in Long-CoT? Value Optimization Holds the Secret},
+  author={Yuan, Yufeng and Yue, Yu and Zhu, Ruofei and Fan, Tiantian and Yan, Lin},
+  journal={arXiv preprint arXiv:2503.01491},
+  year={2025}
+}
+
 ### End chapter 6 ###
 
 ### First appearing in chapter 7 (Reasoning) ###
 
-@article{aggarwal2025l1,
-  title={L1: Controlling how long a reasoning model thinks with reinforcement learning},
-  author={Aggarwal, Pranjal and Welleck, Sean},
-  journal={arXiv preprint arXiv:2503.04697},
+@misc{irpan2018deep,
+  title={Deep Reinforcement Learning Doesn't Work Yet},
+  author={Alex Irpan},
+  year={2018},
+  url={https://www.alexirpan.com/2018/02/14/rl-hard.html}
+}
+
+@inproceedings{henderson2018deep,
+  title={Deep Reinforcement Learning that Matters},
+  author={Henderson, Peter and Islam, Riashat and Bachman, Philip and Pineau, Joelle and Precup, Doina and Meger, David},
+  booktitle={Proceedings of the AAAI Conference on Artificial Intelligence},
+  volume={32},
+  number={1},
+  year={2018},
+  url={https://ojs.aaai.org/index.php/AAAI/article/view/11694}
+}
+
+@inproceedings{mirhoseini2020chip,
+  title={Chip placement with deep reinforcement learning},
+  booktitle = {Design, Automation and Test in Europe (DATE)},
+  author={Mirhoseini, Azalia and Goldie, Anna and Yazgan, Mustafa and Jiang, Joe and Songhori, Ebrahim and Wang, Shen and Lee, Young-Joon and Johnson, Eric and Pathak, Omkar and Bae, Sungmin and others},
+  year = {2023}
+}
+
+@article{schrittwieser2020mastering,
+  title={Mastering atari, go, chess and shogi by planning with a learned model},
+  author={Schrittwieser, Julian and Antonoglou, Ioannis and Hubert, Thomas and Simonyan, Karen and Sifre, Laurent and Schmitt, Simon and Guez, Arthur and Lockhart, Edward and Hassabis, Demis and Graepel, Thore and others},
+  journal={Nature},
+  volume={588},
+  number={7839},
+  pages={604--609},
+  year={2020},
+  publisher={Nature Publishing Group UK London}
+}
+
+@inproceedings{cusumano2025robust,
+  title={Robust autonomy emerges from self-play},
+  booktitle = {International Conference on Machine Learning (ICML)},
+  author={Cusumano-Towner, Marco and Hafner, David and Hertzberg, Alex and Huval, Brody and Petrenko, Aleksei and Vinitsky, Eugene and Wijmans, Erik and Killian, Taylor and Bowers, Stuart and Sener, Ozan and others},
+  year = {2025}
+}
+
+@inproceedings{sheng2024hybridflow,
+  title   = {HybridFlow: A Flexible and Efficient RLHF Framework},
+  booktitle = {European Conference on Computer Systems (EuroSys)},
+  author  = {Guangming Sheng and Chi Zhang and Zilingfeng Ye and Xibin Wu and Wang Zhang and Ru Zhang and Yanghua Peng and Haibin Lin and Chuan Wu},
+  year = {2025},
+}
+
+@article{hu2024openrlhf,
+  title={OpenRLHF: An Easy-to-use, Scalable and High-performance RLHF Framework},
+  author={Jian Hu and Xibin Wu and Zilin Zhu and Xianyu and Weixun Wang and Dehao Zhang and Yu Cao},
+  journal={arXiv preprint arXiv:2405.11143},
+  year={2024}
+}
+
+@article{liu2023don,
+  title={Don't throw away your value model! Generating more preferable text with Value-Guided Monte-Carlo Tree Search decoding},
+  author={Liu, Jiacheng and Cohen, Andrew and Pasunuru, Ramakanth and Choi, Yejin and Hajishirzi, Hannaneh and Celikyilmaz, Asli},
+  journal={arXiv preprint arXiv:2309.15028},
+  year={2023}
+}
+
+@article{brown2024large,
+  title={Large language monkeys: Scaling inference compute with repeated sampling},
+  author={Brown, Bradley and Juravsky, Jordan and Ehrlich, Ryan and Clark, Ronald and Le, Quoc V and R{\'e}, Christopher and Mirhoseini, Azalia},
+  journal={arXiv preprint arXiv:2407.21787},
+  year={2024}
+}
+
+@article{liu2025inference,
+  title={Inference-Time Scaling for Generalist Reward Modeling},
+  author={Liu, Zijun and Wang, Peiyi and Xu, Runxin and Ma, Shirong and Ruan, Chong and Li, Peng and Liu, Yang and Wu, Yu},
+  journal={arXiv preprint arXiv:2504.02495},
   year={2025}
+}
+
+@article{muennighoff2025s1,
+  title={s1: Simple test-time scaling},
+  author={Muennighoff, Niklas and Yang, Zitong and Shi, Weijia and Li, Xiang Lisa and Fei-Fei, Li and Hajishirzi, Hannaneh and Zettlemoyer, Luke and Liang, Percy and Cand{\`e}s, Emmanuel and Hashimoto, Tatsunori},
+  journal={arXiv preprint arXiv:2501.19393},
+  year={2025}
+}
+
+@article{chen2024more,
+  title={Are more llm calls all you need? towards scaling laws of compound inference systems},
+  author={Chen, Lingjiao and Davis, Jared Quincy and Hanin, Boris and Bailis, Peter and Stoica, Ion and Zaharia, Matei and Zou, James},
+  journal={arXiv preprint arXiv:2403.02419},
+  year={2024}
+}
+
+@inproceedings{zelikman2022star,
+title={{ST}aR: Bootstrapping Reasoning With Reasoning},
+author={Eric Zelikman and Yuhuai Wu and Jesse Mu and Noah Goodman},
+booktitle={Advances in Neural Information Processing Systems},
+editor={Alice H. Oh and Alekh Agarwal and Danielle Belgrave and Kyunghyun Cho},
+year={2022},
+url={https://openreview.net/forum?id=_3ELRdg2sgI}
+}
+
+@article{Zelikman2024QuietSTaRLM,
+  title={Quiet-STaR: Language Models Can Teach Themselves to Think Before Speaking},
+  author={E. Zelikman and Georges Harik and Yijia Shao and Varuna Jayasiri and Nick Haber and Noah D. Goodman},
+  journal={COLM},
+  year={2024},
+  volume={abs/2403.09629},
+}
+
+@inproceedings{hoffman2023training,
+title={Training Chain-of-Thought via Latent-Variable Inference},
+author={Matthew Douglas Hoffman and Du Phan and david dohan and Sholto Douglas and Tuan Anh Le and Aaron T Parisi and Pavel Sountsov and Charles Sutton and Sharad Vikram and Rif A. Saurous},
+booktitle={Thirty-seventh Conference on Neural Information Processing Systems},
+year={2023},
+url={https://openreview.net/forum?id=a147pIS2Co}
+}
+
+@misc{VinePPO,
+      title={VinePPO: Unlocking RL Potential For LLM Reasoning Through Refined Credit Assignment},
+      author={Amirhossein Kazemnejad and Milad Aghajohari and Eva Portelance and Alessandro Sordoni and Siva Reddy and Aaron Courville and Nicolas Le Roux},
+      year={2024},
+      eprint={2410.01679},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG},
+      url={https://arxiv.org/abs/2410.01679},
+}
+
+@inproceedings{gehring2024rlefgroundingcodellms,
+      title={RLEF: Grounding Code LLMs in Execution Feedback with Reinforcement Learning},
+  booktitle = {International Conference on Machine Learning (ICML)},
+      author={Jonas Gehring and Kunhao Zheng and Jade Copet and Vegard Mella and Taco Cohen and Gabriel Synnaeve},
+      year = {2025},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2410.02089},
+}
+
+@inproceedings{xu2024dpo,
+  title={Is dpo superior to ppo for llm alignment? a comprehensive study},
+  booktitle = {International Conference on Machine Learning (ICML)},
+  author={Xu, Shusheng and Fu, Wei and Gao, Jiaxuan and Ye, Wenjie and Liu, Weilin and Mei, Zhiyu and Wang, Guangju and Yu, Chao and Wu, Yi},
+  year = {2024}
+}
+
+@article{amit2024models,
+  title={Models that prove their own correctness},
+  journal = {Electron. Colloquium Comput. Complex.},
+  author={Amit, Noga and Goldwasser, Shafi and Paradise, Orr and Rothblum, Guy},
+  year = {2024}
 }
 
 @article{hu2025openreasonerzero,
@@ -1163,10 +1366,41 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   year={2025}
 }
 
+@article{bercovich2025llamanemotron,
+  title={Llama‑Nemotron: Efficient Reasoning Models},
+  author={Bercovich, Akhiad and Levy, Itay and Golan, Izik and others},
+  journal={arXiv preprint arXiv:2505.00949},
+  year={2025}
+}
+
+@article{liu2025hunyuan,
+  title={Hunyuan‑TurboS: Advancing Large Language Models through Mamba‑Transformer Synergy and Adaptive Chain‑of‑Thought},
+  author={Liu, Ao and Zhou, Botong and Xu, Can and others},
+  journal={arXiv preprint arXiv:2505.15431},
+  year={2025}
+}
+
 @article{he2025skyworkor1,
   title={Skywork Open Reasoner 1 Technical Report},
   author={He, Jujie and Liu, Jiacai and Liu, Chris Yuhao and others},
   journal={arXiv preprint arXiv:2505.22312},
+  year={2025}
+}
+
+@misc{coreteam2025mimovltechnicalreport,
+      title={MiMo-VL Technical Report},
+      author={Core Team and Zihao Yue and Zhenru Lin and Yifan Song and Weikun Wang and Shuhuai Ren and Shuhao Gu and Shicheng Li and Peidian Li and Liang Zhao and Lei Li and Kainan Bao and Hao Tian and Hailin Zhang and Gang Wang and Dawei Zhu and Cici and Chenhong He and Bowen Ye and Bowen Shen and Zihan Zhang and Zihan Jiang and Zhixian Zheng and Zhichao Song and Zhenbo Luo and Yue Yu and Yudong Wang and Yuanyuan Tian and Yu Tu and Yihan Yan and Yi Huang and Xu Wang and Xinzhe Xu and Xingchen Song and Xing Zhang and Xing Yong and Xin Zhang and Xiangwei Deng and Wenyu Yang and Wenhan Ma and Weiwei Lv and Weiji Zhuang and Wei Liu and Sirui Deng and Shuo Liu and Shimao Chen and Shihua Yu and Shaohui Liu and Shande Wang and Rui Ma and Qiantong Wang and Peng Wang and Nuo Chen and Menghang Zhu and Kangyang Zhou and Kang Zhou and Kai Fang and Jun Shi and Jinhao Dong and Jiebao Xiao and Jiaming Xu and Huaqiu Liu and Hongshen Xu and Heng Qu and Haochen Zhao and Hanglong Lv and Guoan Wang and Duo Zhang and Dong Zhang and Di Zhang and Chong Ma and Chang Liu and Can Cai and Bingquan Xia},
+      year={2025},
+      eprint={2506.03569},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2506.03569},
+}
+
+@article{guha2025openthoughts,
+  title={OpenThoughts: Data Recipes for Reasoning Models},
+  author={Guha, Etash and Marten, Ryan and Keh, Sedrick and others},
+  journal={arXiv preprint arXiv:2506.04178},
   year={2025}
 }
 
@@ -1180,41 +1414,14 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   note={Technical report}
 }
 
-@article{guha2025openthoughts,
-  title={OpenThoughts: Data Recipes for Reasoning Models},
-  author={Guha, Etash and Marten, Ryan and Keh, Sedrick and others},
-  journal={arXiv preprint arXiv:2506.04178},
-  year={2025}
-}
-
-@article{liu2025hunyuan,
-  title={Hunyuan‑TurboS: Advancing Large Language Models through Mamba‑Transformer Synergy and Adaptive Chain‑of‑Thought},
-  author={Liu, Ao and Zhou, Botong and Xu, Can and others},
-  journal={arXiv preprint arXiv:2505.15431},
-  year={2025}
-}
-
-@misc{mimo2025flash,
-  title={MiMo-V2-Flash Technical Report},
-  author={{Xiaomi LLM-Core Team} and Xiao, Bangjun and Xia, Bingquan and Yang, Bo and Gao, Bofei and Shen, Bowen and others},
-  year={2026},
-  month=jan,
-  eprint={2601.02780},
+@misc{kimiteam2025kimik2,
+  title={ Kimi K2: Open Agentic Intelligence },
+  author={  Kimi Team and Yifan Bai and Yiping Bao and Guanduo Chen and Jiahao Chen and Ningxin Chen and Ruijue Chen and Yanru Chen and Yuankun Chen and Yutian Chen and Zhuofu Chen and Jialei Cui and Hao Ding and Mengnan Dong and Angang Du and Chenzhuang Du and Dikang Du and Yulun Du and Yu Fan and Yichen Feng and Kelin Fu and Bofei Gao and Hongcheng Gao and Peizhong Gao and Tong Gao and Xinran Gu and Longyu Guan and Haiqing Guo and Jianhang Guo and Hao Hu and Xiaoru Hao and Tianhong He and Weiran He and Wenyang He and Chao Hong and Yangyang Hu and Zhenxing Hu and Weixiao Huang and Zhiqi Huang and Zihao Huang and Tao Jiang and Zhejun Jiang and Xinyi Jin and Yongsheng Kang and Guokun Lai and Cheng Li and Fang Li and Haoyang Li and Ming Li and Wentao Li and Yanhao Li and Yiwei Li and Zhaowei Li and Zheming Li and Hongzhan Lin and Xiaohan Lin and Zongyu Lin and Chengyin Liu and Chenyu Liu and Hongzhang Liu and Jingyuan Liu and Junqi Liu and Liang Liu and Shaowei Liu and T. Y. Liu and Tianwei Liu and Weizhou Liu and Yangyang Liu and Yibo Liu and Yiping Liu and Yue Liu and Zhengying Liu and Enzhe Lu and Lijun Lu and Shengling Ma and Xinyu Ma and Yingwei Ma and Shaoguang Mao and Jie Mei and Xin Men and Yibo Miao and Siyuan Pan and Yebo Peng and Ruoyu Qin and Bowen Qu and Zeyu Shang and Lidong Shi and Shengyuan Shi and Xinjie Sun and Flood Sung and Heyi Tang and Jiawen Tao and Qifeng Teng and Chensi Wang and Dinglu Wang and Feng Wang and Haiming Wang and Jianzhou Wang and Jiaxing Wang and Jinhong Wang and Shengjie Wang and Shuyi Wang and Yao Wang and Yejie Wang and Yiqin Wang and Yuxin Wang and Yuzhi Wang and Zhaoji Wang and Zhengtao Wang and Zhexu Wang and Chu Wei and Qianqian Wei and Wenhao Wu and Xingzhe Wu and Yuxin Wu and Chenjun Xiao and Xiaotong Xie and Weimin Xiong and Boyu Xu and Jing Xu and Jinjing Xu and L. H. Xu and Lin Xu and Suting Xu and Weixin Xu and Xinran Xu and Yangchuan Xu and Ziyao Xu and Junjie Yan and Yuzi Yan and Xiaofei Yang and Ying Yang and Zhen Yang and Zhilin Yang and Zonghan Yang and Haotian Yao and Xingcheng Yao and Wenjie Ye and Zhuorui Ye and Bohong Yin and Longhui Yu and Enming Yuan and Hongbang Yuan and Mengjie Yuan and Haobing Zhan and Dehao Zhang and Hao Zhang and Wanlu Zhang and Xiaobin Zhang and Yangkun Zhang and Yizhi Zhang and Yongting Zhang and Yu Zhang and Yutao Zhang and Yutong Zhang and Zheng Zhang and Haotian Zhao and Yikai Zhao and Huabin Zheng and Shaojie Zheng and Jianren Zhou and Xinyu Zhou and Zaida Zhou and Zhen Zhu and Weiyu Zhuang and Xinxing Zu },
+  year={ 2025 },
+  eprint={ 2507.20534 },
   archivePrefix={arXiv},
-  primaryClass={cs.CL},
-  doi={10.48550/arXiv.2601.02780},
-  url={https://arxiv.org/abs/2601.02780}
-}
-
-@misc{minimax2025minimax_m1,
-      title={MiniMax-M1: Scaling Test-Time Compute Efficiently with Lightning Attention},
-      author={MiniMax},
-      year={2025},
-      eprint={2506.13585},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL},
-      doi={10.48550/arXiv.2506.13585},
-      url={https://arxiv.org/abs/2506.13585},
+  primaryClass={ cs.LG },
+  url={https://arxiv.org/abs/2507.20534}
 }
 
 @misc{zeng2025glm45,
@@ -1229,26 +1436,6 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   primaryClass = {cs.CL},
   doi          = {10.48550/arXiv.2508.06471},
   url          = {https://arxiv.org/abs/2508.06471}
-}
-
-@misc{coreteam2025mimovltechnicalreport,
-      title={MiMo-VL Technical Report}, 
-      author={Core Team and Zihao Yue and Zhenru Lin and Yifan Song and Weikun Wang and Shuhuai Ren and Shuhao Gu and Shicheng Li and Peidian Li and Liang Zhao and Lei Li and Kainan Bao and Hao Tian and Hailin Zhang and Gang Wang and Dawei Zhu and Cici and Chenhong He and Bowen Ye and Bowen Shen and Zihan Zhang and Zihan Jiang and Zhixian Zheng and Zhichao Song and Zhenbo Luo and Yue Yu and Yudong Wang and Yuanyuan Tian and Yu Tu and Yihan Yan and Yi Huang and Xu Wang and Xinzhe Xu and Xingchen Song and Xing Zhang and Xing Yong and Xin Zhang and Xiangwei Deng and Wenyu Yang and Wenhan Ma and Weiwei Lv and Weiji Zhuang and Wei Liu and Sirui Deng and Shuo Liu and Shimao Chen and Shihua Yu and Shaohui Liu and Shande Wang and Rui Ma and Qiantong Wang and Peng Wang and Nuo Chen and Menghang Zhu and Kangyang Zhou and Kang Zhou and Kai Fang and Jun Shi and Jinhao Dong and Jiebao Xiao and Jiaming Xu and Huaqiu Liu and Hongshen Xu and Heng Qu and Haochen Zhao and Hanglong Lv and Guoan Wang and Duo Zhang and Dong Zhang and Di Zhang and Chong Ma and Chang Liu and Can Cai and Bingquan Xia},
-      year={2025},
-      eprint={2506.03569},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL},
-      url={https://arxiv.org/abs/2506.03569}, 
-}
-
-@misc{kimiteam2025kimik2,
-  title={ Kimi K2: Open Agentic Intelligence },
-  author={  Kimi Team and Yifan Bai and Yiping Bao and Guanduo Chen and Jiahao Chen and Ningxin Chen and Ruijue Chen and Yanru Chen and Yuankun Chen and Yutian Chen and Zhuofu Chen and Jialei Cui and Hao Ding and Mengnan Dong and Angang Du and Chenzhuang Du and Dikang Du and Yulun Du and Yu Fan and Yichen Feng and Kelin Fu and Bofei Gao and Hongcheng Gao and Peizhong Gao and Tong Gao and Xinran Gu and Longyu Guan and Haiqing Guo and Jianhang Guo and Hao Hu and Xiaoru Hao and Tianhong He and Weiran He and Wenyang He and Chao Hong and Yangyang Hu and Zhenxing Hu and Weixiao Huang and Zhiqi Huang and Zihao Huang and Tao Jiang and Zhejun Jiang and Xinyi Jin and Yongsheng Kang and Guokun Lai and Cheng Li and Fang Li and Haoyang Li and Ming Li and Wentao Li and Yanhao Li and Yiwei Li and Zhaowei Li and Zheming Li and Hongzhan Lin and Xiaohan Lin and Zongyu Lin and Chengyin Liu and Chenyu Liu and Hongzhang Liu and Jingyuan Liu and Junqi Liu and Liang Liu and Shaowei Liu and T. Y. Liu and Tianwei Liu and Weizhou Liu and Yangyang Liu and Yibo Liu and Yiping Liu and Yue Liu and Zhengying Liu and Enzhe Lu and Lijun Lu and Shengling Ma and Xinyu Ma and Yingwei Ma and Shaoguang Mao and Jie Mei and Xin Men and Yibo Miao and Siyuan Pan and Yebo Peng and Ruoyu Qin and Bowen Qu and Zeyu Shang and Lidong Shi and Shengyuan Shi and Xinjie Sun and Flood Sung and Heyi Tang and Jiawen Tao and Qifeng Teng and Chensi Wang and Dinglu Wang and Feng Wang and Haiming Wang and Jianzhou Wang and Jiaxing Wang and Jinhong Wang and Shengjie Wang and Shuyi Wang and Yao Wang and Yejie Wang and Yiqin Wang and Yuxin Wang and Yuzhi Wang and Zhaoji Wang and Zhengtao Wang and Zhexu Wang and Chu Wei and Qianqian Wei and Wenhao Wu and Xingzhe Wu and Yuxin Wu and Chenjun Xiao and Xiaotong Xie and Weimin Xiong and Boyu Xu and Jing Xu and Jinjing Xu and L. H. Xu and Lin Xu and Suting Xu and Weixin Xu and Xinran Xu and Yangchuan Xu and Ziyao Xu and Junjie Yan and Yuzi Yan and Xiaofei Yang and Ying Yang and Zhen Yang and Zhilin Yang and Zonghan Yang and Haotian Yao and Xingcheng Yao and Wenjie Ye and Zhuorui Ye and Bohong Yin and Longhui Yu and Enming Yuan and Hongbang Yuan and Mengjie Yuan and Haobing Zhan and Dehao Zhang and Hao Zhang and Wanlu Zhang and Xiaobin Zhang and Yangkun Zhang and Yizhi Zhang and Yongting Zhang and Yu Zhang and Yutao Zhang and Yutong Zhang and Zheng Zhang and Haotian Zhao and Yikai Zhao and Huabin Zheng and Shaojie Zheng and Jianren Zhou and Xinyu Zhou and Zaida Zhou and Zhen Zhu and Weiyu Zhuang and Xinxing Zu },
-  year={ 2025 },
-  eprint={ 2507.20534 },
-  archivePrefix={arXiv},
-  primaryClass={ cs.LG },
-  url={https://arxiv.org/abs/2507.20534}
 }
 
 @misc{nvidia2025nemotronnano2,
@@ -1291,13 +1478,6 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   url={https://arxiv.org/abs/2510.18855}
 }
 
-@article{liu2025k2,
-  title={K2-V2: A 360-Open, Reasoning-Enhanced LLM},
-  author={Liu, Zhengzhong and Tang, Liping and Jin, Linghao and Li, Haonan and Ranjan, Nikhil and Fan, Desai and Rohatgi, Shaurya and Fan, Richard and Pangarkar, Omkar and Wang, Huijuan and others},
-  journal={arXiv preprint arXiv:2512.06201},
-  year={2025}
-}
-
 @misc{deepseekai2025v32,
   title={ DeepSeek-V3.2: Pushing the Frontier of Open Large Language Models },
   author={ DeepSeek-AI },
@@ -1308,118 +1488,35 @@ url={https://openreview.net/forum?id=7HNRYT4V44}
   url={https://arxiv.org/abs/2512.02556}
 }
 
-@misc{shao2025spurious,
-  title={Spurious Rewards: Rethinking Training Signals in RLVR},
-  author={Rulin Shao and Shuyue Stella Li and Rui Xin and Scott Geng and Yiping Wang and Sewoong Oh and Simon Shaolei Du and Nathan Lambert and Sewon Min and Ranjay Krishna and Yulia Tsvetkov and Hannaneh Hajishirzi and Pang Wei Koh and Luke Zettlemoyer},
-  year={2025},
-  howpublished={\url{https://rethink-rlvr.notion.site/Spurious-Rewards-Rethinking-Training-Signals-in-RLVR-1f4df34dac1880948858f95aeb88872f}},
-  note={Notion Blog}
-}
-
-@misc{irpan2018deep,
-  title={Deep Reinforcement Learning Doesn't Work Yet},
-  author={Alex Irpan},
-  year={2018},
-  url={https://www.alexirpan.com/2018/02/14/rl-hard.html}
-}
-
-@inproceedings{henderson2018deep,
-  title={Deep Reinforcement Learning that Matters},
-  author={Henderson, Peter and Islam, Riashat and Bachman, Philip and Pineau, Joelle and Precup, Doina and Meger, David},
-  booktitle={Proceedings of the AAAI Conference on Artificial Intelligence},
-  volume={32},
-  number={1},
-  year={2018},
-  url={https://ojs.aaai.org/index.php/AAAI/article/view/11694}
-}
-
-@article{liu2023don,
-  title={Don't throw away your value model! Generating more preferable text with Value-Guided Monte-Carlo Tree Search decoding},
-  author={Liu, Jiacheng and Cohen, Andrew and Pasunuru, Ramakanth and Choi, Yejin and Hajishirzi, Hannaneh and Celikyilmaz, Asli},
-  journal={arXiv preprint arXiv:2309.15028},
-  year={2023}
-}
-
-@article{chen2024more,
-  title={Are more llm calls all you need? towards scaling laws of compound inference systems},
-  author={Chen, Lingjiao and Davis, Jared Quincy and Hanin, Boris and Bailis, Peter and Stoica, Ion and Zaharia, Matei and Zou, James},
-  journal={arXiv preprint arXiv:2403.02419},
-  year={2024}
-}
-
-@article{muennighoff2025s1,
-  title={s1: Simple test-time scaling},
-  author={Muennighoff, Niklas and Yang, Zitong and Shi, Weijia and Li, Xiang Lisa and Fei-Fei, Li and Hajishirzi, Hannaneh and Zettlemoyer, Luke and Liang, Percy and Cand{\`e}s, Emmanuel and Hashimoto, Tatsunori},
-  journal={arXiv preprint arXiv:2501.19393},
+@article{liu2025k2,
+  title={K2-V2: A 360-Open, Reasoning-Enhanced LLM},
+  author={Liu, Zhengzhong and Tang, Liping and Jin, Linghao and Li, Haonan and Ranjan, Nikhil and Fan, Desai and Rohatgi, Shaurya and Fan, Richard and Pangarkar, Omkar and Wang, Huijuan and others},
+  journal={arXiv preprint arXiv:2512.06201},
   year={2025}
 }
 
-@inproceedings{sheng2024hybridflow,
-  title   = {HybridFlow: A Flexible and Efficient RLHF Framework},
-  booktitle = {European Conference on Computer Systems (EuroSys)},
-  author  = {Guangming Sheng and Chi Zhang and Zilingfeng Ye and Xibin Wu and Wang Zhang and Ru Zhang and Yanghua Peng and Haibin Lin and Chuan Wu},
-  year = {2025},
+@techreport{nvidia2025nemotron3nano,
+  title       = {Nemotron 3 Nano: Open, Efficient Mixture-of-Experts Hybrid Mamba-Transformer Model for Agentic Reasoning},
+  author      = {{NVIDIA}},
+  institution = {NVIDIA},
+  type        = {Technical Report},
+  year        = {2025},
+  month       = {December},
+  note        = {Dated 2025-12-15},
+  url         = {https://research.nvidia.com/labs/nemotron/files/NVIDIA-Nemotron-3-Nano-Technical-Report.pdf}
 }
 
-@article{hu2024openrlhf,
-  title={OpenRLHF: An Easy-to-use, Scalable and High-performance RLHF Framework},
-  author={Jian Hu and Xibin Wu and Zilin Zhu and Xianyu and Weixun Wang and Dehao Zhang and Yu Cao},
-  journal={arXiv preprint arXiv:2405.11143},
-  year={2024}
+@misc{mimo2025flash,
+  title={MiMo-V2-Flash Technical Report},
+  author={{Xiaomi LLM-Core Team} and Xiao, Bangjun and Xia, Bingquan and Yang, Bo and Gao, Bofei and Shen, Bowen and others},
+  year={2026},
+  month=jan,
+  eprint={2601.02780},
+  archivePrefix={arXiv},
+  primaryClass={cs.CL},
+  doi={10.48550/arXiv.2601.02780},
+  url={https://arxiv.org/abs/2601.02780}
 }
-
-@inproceedings{zelikman2022star,
-title={{ST}aR: Bootstrapping Reasoning With Reasoning},
-author={Eric Zelikman and Yuhuai Wu and Jesse Mu and Noah Goodman},
-booktitle={Advances in Neural Information Processing Systems},
-editor={Alice H. Oh and Alekh Agarwal and Danielle Belgrave and Kyunghyun Cho},
-year={2022},
-url={https://openreview.net/forum?id=_3ELRdg2sgI}
-}
-
-@article{Zelikman2024QuietSTaRLM,
-  title={Quiet-STaR: Language Models Can Teach Themselves to Think Before Speaking},
-  author={E. Zelikman and Georges Harik and Yijia Shao and Varuna Jayasiri and Nick Haber and Noah D. Goodman},
-  journal={COLM},
-  year={2024},
-  volume={abs/2403.09629},
-}
-
-@inproceedings{hoffman2023training,
-title={Training Chain-of-Thought via Latent-Variable Inference},
-author={Matthew Douglas Hoffman and Du Phan and david dohan and Sholto Douglas and Tuan Anh Le and Aaron T Parisi and Pavel Sountsov and Charles Sutton and Sharad Vikram and Rif A. Saurous},
-booktitle={Thirty-seventh Conference on Neural Information Processing Systems},
-year={2023},
-url={https://openreview.net/forum?id=a147pIS2Co}
-}
-
-@inproceedings{gehring2024rlefgroundingcodellms,
-      title={RLEF: Grounding Code LLMs in Execution Feedback with Reinforcement Learning},
-  booktitle = {International Conference on Machine Learning (ICML)}, 
-      author={Jonas Gehring and Kunhao Zheng and Jade Copet and Vegard Mella and Taco Cohen and Gabriel Synnaeve},
-      year = {2025},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL},
-      url={https://arxiv.org/abs/2410.02089}, 
-}
-
-@misc{VinePPO,
-      title={VinePPO: Unlocking RL Potential For LLM Reasoning Through Refined Credit Assignment}, 
-      author={Amirhossein Kazemnejad and Milad Aghajohari and Eva Portelance and Alessandro Sordoni and Siva Reddy and Aaron Courville and Nicolas Le Roux},
-      year={2024},
-      eprint={2410.01679},
-      archivePrefix={arXiv},
-      primaryClass={cs.LG},
-      url={https://arxiv.org/abs/2410.01679}, 
-}
-
-@article{amit2024models,
-  title={Models that prove their own correctness},
-  journal = {Electron. Colloquium Comput. Complex.},
-  author={Amit, Noga and Goldwasser, Shafi and Paradise, Orr and Rothblum, Guy},
-  year = {2024}
-}
-
 
 @misc{wang2025ragenunderstandingselfevolutionllm,
   title={RAGEN: Understanding Self-Evolution in LLM Agents via Multi-Turn Reinforcement Learning},
@@ -1428,6 +1525,14 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   eprint={2504.20073},
   archivePrefix={arXiv},
   primaryClass={cs.LG}
+}
+
+@misc{shao2025spurious,
+  title={Spurious Rewards: Rethinking Training Signals in RLVR},
+  author={Rulin Shao and Shuyue Stella Li and Rui Xin and Scott Geng and Yiping Wang and Sewoong Oh and Simon Shaolei Du and Nathan Lambert and Sewon Min and Ranjay Krishna and Yulia Tsvetkov and Hannaneh Hajishirzi and Pang Wei Koh and Luke Zettlemoyer},
+  year={2025},
+  howpublished={\url{https://rethink-rlvr.notion.site/Spurious-Rewards-Rethinking-Training-Signals-in-RLVR-1f4df34dac1880948858f95aeb88872f}},
+  note={Notion Blog}
 }
 
 @misc{anthropic2025claude4,
@@ -1439,35 +1544,10 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   note         = {Accessed: 2025-06-13}
 }
 
-@article{schrittwieser2020mastering,
-  title={Mastering atari, go, chess and shogi by planning with a learned model},
-  author={Schrittwieser, Julian and Antonoglou, Ioannis and Hubert, Thomas and Simonyan, Karen and Sifre, Laurent and Schmitt, Simon and Guez, Arthur and Lockhart, Edward and Hassabis, Demis and Graepel, Thore and others},
-  journal={Nature},
-  volume={588},
-  number={7839},
-  pages={604--609},
-  year={2020},
-  publisher={Nature Publishing Group UK London}
-}
-
-@inproceedings{mirhoseini2020chip,
-  title={Chip placement with deep reinforcement learning},
-  booktitle = {Design, Automation and Test in Europe (DATE)},
-  author={Mirhoseini, Azalia and Goldie, Anna and Yazgan, Mustafa and Jiang, Joe and Songhori, Ebrahim and Wang, Shen and Lee, Young-Joon and Johnson, Eric and Pathak, Omkar and Bae, Sungmin and others},
-  year = {2023}
-}
-
-@inproceedings{cusumano2025robust,
-  title={Robust autonomy emerges from self-play},
-  booktitle = {International Conference on Machine Learning (ICML)},
-  author={Cusumano-Towner, Marco and Hafner, David and Hertzberg, Alex and Huval, Brody and Petrenko, Aleksei and Vinitsky, Eugene and Wijmans, Erik and Killian, Taylor and Bowers, Stuart and Sener, Ozan and others},
-  year = {2025}
-}
-
-@article{khatri2025art,
-  title={The art of scaling reinforcement learning compute for llms},
-  author={Khatri, Devvrit and Madaan, Lovish and Tiwari, Rishabh and Bansal, Rachit and Duvvuri, Sai Surya and Zaheer, Manzil and Dhillon, Inderjit S and Brandfonbrener, David and Agarwal, Rishabh},
-  journal={arXiv preprint arXiv:2510.13786},
+@article{aggarwal2025l1,
+  title={L1: Controlling how long a reasoning model thinks with reinforcement learning},
+  author={Aggarwal, Pranjal and Welleck, Sean},
+  journal={arXiv preprint arXiv:2503.04697},
   year={2025}
 }
 
@@ -1475,28 +1555,18 @@ url={https://openreview.net/forum?id=a147pIS2Co}
 
 ### First appearing in chapter 8 (Direct Alignment) ###
 
-@inproceedings{xu2024dpo,
-  title={Is dpo superior to ppo for llm alignment? a comprehensive study},
-  booktitle = {International Conference on Machine Learning (ICML)},
-  author={Xu, Shusheng and Fu, Wei and Gao, Jiaxuan and Ye, Wenjie and Liu, Weilin and Mei, Zhiyu and Wang, Guangju and Yu, Chao and Wu, Yi},
+@article{zhao2023slic,
+  title={Slic-hf: Sequence likelihood calibration with human feedback},
+  author={Zhao, Yao and Joshi, Rishabh and Liu, Tianqi and Khalman, Misha and Saleh, Mohammad and Liu, Peter J},
+  journal={arXiv preprint arXiv:2305.10425},
+  year={2023}
+}
+
+@inproceedings{gao2024rebel,
+  title={Rebel: Reinforcement learning via regressing relative rewards},
+  booktitle = {Advances in Neural Information Processing Systems (NeurIPS)},
+  author={Gao, Zhaolin and Chang, Jonathan D and Zhan, Wenhao and Oertell, Owen and Swamy, Gokul and Brantley, Kiant{\'e} and Joachims, Thorsten and Bagnell, J Andrew and Lee, Jason D and Sun, Wen},
   year = {2024}
-}
-
-@misc{teamolmo2025olmo3,
-  title={ Olmo 3 },
-  author={ Team Olmo and Allyson Ettinger and Amanda Bertsch and Bailey Kuehl and David Graham and David Heineman and Dirk Groeneveld and Faeze Brahman and Finbarr Timbers and Hamish Ivison and Jacob Morrison and Jake Poznanski and Kyle Lo and Luca Soldaini and Matt Jordan and Mayee Chen and Michael Noukhovitch and Nathan Lambert and Pete Walsh and Pradeep Dasigi and Robert Berry and Saumya Malik and Saurabh Shah and Scott Geng and Shane Arora and Shashank Gupta and Taira Anderson and Teng Xiao and Tyler Murray and Tyler Romero and Victoria Graf and Akari Asai and Akshita Bhagia and Alexander Wettig and Alisa Liu and Aman Rangapur and Chloe Anastasiades and Costa Huang and Dustin Schwenk and Harsh Trivedi and Ian Magnusson and Jaron Lochner and Jiacheng Liu and Lester James V. Miranda and Maarten Sap and Malia Morgan and Michael Schmitz and Michal Guerquin and Michael Wilson and Regan Huff and Ronan Le Bras and Rui Xin and Rulin Shao and Sam Skjonsberg and Shannon Zejiang Shen and Shuyue Stella Li and Tucker Wilde and Valentina Pyatkin and Will Merrill and Yapei Chang and Yuling Gu and Zhiyuan Zeng and Ashish Sabharwal and Luke Zettlemoyer and Pang Wei Koh and Ali Farhadi and Noah A. Smith and Hannaneh Hajishirzi },
-  year={ 2025 },
-  eprint={ 2512.13961 },
-  archivePrefix={arXiv},
-  primaryClass={ cs.CL },
-  url={https://arxiv.org/abs/2512.13961}
-}
-
-@misc{bakouch2025smollm3,
-  title={{SmolLM3: smol, multilingual, long-context reasoner}},
-  author={Bakouch, Elie and Ben Allal, Loubna and Lozhkov, Anton and Tazi, Nouamane and Tunstall, Lewis and Patiño, Carlos Miguel and Beeching, Edward and Roucher, Aymeric and Reedi, Aksel Joonas and Gallouédec, Quentin and Rasul, Kashif and Habib, Nathan and Fourrier, Clémentine and Kydlicek, Hynek and Penedo, Guilherme and Larcher, Hugo and Morlon, Mathieu and Srivastav, Vaibhav and Lochner, Joshua and Nguyen, Xuan-Son and Raffel, Colin and von Werra, Leandro and Wolf, Thomas},
-  year={2025},
-  howpublished={\url{https://huggingface.co/blog/smollm3}}
 }
 
 @inproceedings{azar2024general,
@@ -1506,27 +1576,6 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   pages={4447--4455},
   year={2024},
   organization={PMLR}
-}
-
-@article{zhao2023slic,
-  title={Slic-hf: Sequence likelihood calibration with human feedback},
-  author={Zhao, Yao and Joshi, Rishabh and Liu, Tianqi and Khalman, Misha and Saleh, Mohammad and Liu, Peter J},
-  journal={arXiv preprint arXiv:2305.10425},
-  year={2023}
-}
-
-@article{singhal2024d2po,
-  title={D2po: Discriminator-guided dpo with response evaluation models},
-  author={Singhal, Prasann and Lambert, Nathan and Niekum, Scott and Goyal, Tanya and Durrett, Greg},
-  journal={arXiv preprint arXiv:2405.01511},
-  year={2024}
-}
-
-@article{guo2024direct,
-  title={Direct language model alignment from online ai feedback},
-  author={Guo, Shangmin and Zhang, Biao and Liu, Tianlin and Liu, Tianqi and Khalman, Misha and Llinares, Felipe and Rame, Alexandre and Mesnard, Thomas and Zhao, Yao and Piot, Bilal and others},
-  journal={arXiv preprint arXiv:2402.04792},
-  year={2024}
 }
 
 @inproceedings{amini2024direct,
@@ -1550,53 +1599,6 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   journal={Advances in Neural Information Processing Systems},
   volume={37},
   pages={124198--124235},
-  year={2025}
-}
-
-@inproceedings{zhao2024rainbowpo,
-  title={Rainbowpo: A unified framework for combining improvements in preference optimization},
-  booktitle = {International Conference on Learning Representations (ICLR)},
-  author={Zhao, Hanyang and Winata, Genta Indra and Das, Anirban and Zhang, Shi-Xiong and Yao, David D and Tang, Wenpin and Sahu, Sambit},
-  year = {2025}
-}
-
-@article{rosset2024direct,
-  title={Direct nash optimization: Teaching language models to self-improve with general preferences},
-  author={Rosset, Corby and Cheng, Ching-An and Mitra, Arindam and Santacroce, Michael and Awadallah, Ahmed and Xie, Tengyang},
-  journal={arXiv preprint arXiv:2404.03715},
-  year={2024}
-}
-
-@inproceedings{ross2011reduction,
-  title={A Reduction of Imitation Learning and Structured Prediction to No-Regret Online Learning},
-  author={Ross, Stephane and Gordon, Geoffrey and Bagnell, Drew},
-  booktitle={Proceedings of the Fourteenth International Conference on Artificial Intelligence and Statistics},
-  pages={627--635},
-  year={2011},
-  editor={Gordon, Geoffrey and Dunson, David and Dudik, Miroslav},
-  volume={15},
-  series={Proceedings of Machine Learning Research},
-  address={Fort Lauderdale, FL, USA},
-  month={11--13 Apr},
-  publisher={PMLR},
-  eprint={1011.0686},
-  archivePrefix={arXiv},
-  primaryClass={cs.LG},
-  doi={10.48550/arXiv.1011.0686},
-  url={https://proceedings.mlr.press/v15/ross11a.html}
-}
-
-@inproceedings{jung2024binary,
-  title={Binary classifier optimization for large language model alignment},
-  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
-  author={Jung, Seungjae and Han, Gunsoo and Nam, Daniel Wontae and On, Kyoung-Woon},
-  year = {2025}
-}
-
-@article{gorbatovski2025differences,
-  title={The Differences Between Direct Alignment Algorithms are a Blur},
-  author={Gorbatovski, Alexey and Shaposhnikov, Boris and Sinii, Viacheslav and Malakhov, Alexey and Gavrilov, Daniil},
-  journal={arXiv preprint arXiv:2502.01237},
   year={2025}
 }
 
@@ -1626,6 +1628,70 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   booktitle = {International Conference on Machine Learning (ICML)},
   author={Gupta, Aman and Tang, Shao and Song, Qingquan and Zhu, Sirou and Hong, Jiwoo and Saha, Ankan and Gupta, Viral and Lee, Noah and Kim, Eunki and Zhu, Siyu and others},
   year = {2025}
+}
+
+@article{guo2024direct,
+  title={Direct language model alignment from online ai feedback},
+  author={Guo, Shangmin and Zhang, Biao and Liu, Tianlin and Liu, Tianqi and Khalman, Misha and Llinares, Felipe and Rame, Alexandre and Mesnard, Thomas and Zhao, Yao and Piot, Bilal and others},
+  journal={arXiv preprint arXiv:2402.04792},
+  year={2024}
+}
+
+@article{singhal2024d2po,
+  title={D2po: Discriminator-guided dpo with response evaluation models},
+  author={Singhal, Prasann and Lambert, Nathan and Niekum, Scott and Goyal, Tanya and Durrett, Greg},
+  journal={arXiv preprint arXiv:2405.01511},
+  year={2024}
+}
+
+@article{rosset2024direct,
+  title={Direct nash optimization: Teaching language models to self-improve with general preferences},
+  author={Rosset, Corby and Cheng, Ching-An and Mitra, Arindam and Santacroce, Michael and Awadallah, Ahmed and Xie, Tengyang},
+  journal={arXiv preprint arXiv:2404.03715},
+  year={2024}
+}
+
+@inproceedings{jung2024binary,
+  title={Binary classifier optimization for large language model alignment},
+  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
+  author={Jung, Seungjae and Han, Gunsoo and Nam, Daniel Wontae and On, Kyoung-Woon},
+  year = {2025}
+}
+
+@inproceedings{zhao2024rainbowpo,
+  title={Rainbowpo: A unified framework for combining improvements in preference optimization},
+  booktitle = {International Conference on Learning Representations (ICLR)},
+  author={Zhao, Hanyang and Winata, Genta Indra and Das, Anirban and Zhang, Shi-Xiong and Yao, David D and Tang, Wenpin and Sahu, Sambit},
+  year = {2025}
+}
+
+@article{gorbatovski2025differences,
+  title={The Differences Between Direct Alignment Algorithms are a Blur},
+  author={Gorbatovski, Alexey and Shaposhnikov, Boris and Sinii, Viacheslav and Malakhov, Alexey and Gavrilov, Daniil},
+  journal={arXiv preprint arXiv:2502.01237},
+  year={2025}
+}
+
+@misc{bakouch2025smollm3,
+  title={{SmolLM3: smol, multilingual, long-context reasoner}},
+  author={Bakouch, Elie and Ben Allal, Loubna and Lozhkov, Anton and Tazi, Nouamane and Tunstall, Lewis and Patiño, Carlos Miguel and Beeching, Edward and Roucher, Aymeric and Reedi, Aksel Joonas and Gallouédec, Quentin and Rasul, Kashif and Habib, Nathan and Fourrier, Clémentine and Kydlicek, Hynek and Penedo, Guilherme and Larcher, Hugo and Morlon, Mathieu and Srivastav, Vaibhav and Lochner, Joshua and Nguyen, Xuan-Son and Raffel, Colin and von Werra, Leandro and Wolf, Thomas},
+  year={2025},
+  howpublished={\url{https://huggingface.co/blog/smollm3}}
+}
+
+@inproceedings{geng2025the,
+  title={The Delta Learning Hypothesis: Preference Tuning on Weak Data can Yield Strong Gains},
+  author={Scott Geng and Hamish Ivison and Chun-Liang Li and Maarten Sap and Jerry Li and Ranjay Krishna and Pang Wei Koh},
+  booktitle={Second Conference on Language Modeling},
+  year={2025},
+  url={https://openreview.net/forum?id=9rwtezthwo}
+}
+
+@article{panickssery2024llm,
+  title={Llm evaluators recognize and favor their own generations},
+  author={Panickssery, Arjun and Bowman, Samuel and Feng, Shi},
+  journal={Advances in Neural Information Processing Systems},
+  year={2024}
 }
 
 @inproceedings{tajwar2024preference,
@@ -1679,121 +1745,6 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   year={2023}
 }
 
-@techreport{widrow1960adaptive,
-  title={Adaptive switching circuits},
-  author={Widrow, Bernard and Hoff, Marcian E},
-  year={1960},
-  institution={Stanford Univ Ca Stanford Electronics Labs}
-}
-
-@inproceedings{singh2009rewards,
-  title={Where do rewards come from},
-  author={Singh, Satinder and Lewis, Richard L and Barto, Andrew G},
-  booktitle={Proceedings of the annual conference of the cognitive science society},
-  pages={2601--2606},
-  year={2009},
-  organization={Cognitive Science Society}
-}
-
-@book{skinner2019behavior,
-  title={The behavior of organisms: An experimental analysis},
-  author={Skinner, Burrhus Frederic},
-  year={2019},
-  publisher={BF Skinner Foundation}
-}
-
-@article{thorndike1927law,
-  title={The law of effect},
-  author={Thorndike, Edward L},
-  journal={The American journal of psychology},
-  volume={39},
-  number={1/4},
-  pages={212--222},
-  year={1927},
-  publisher={JSTOR}
-}
-
-@book{arnauld1861port,
-  title={The Port-Royal Logic},
-  author={Arnauld, Antoine},
-  year={1662},
-}
-
-@book{bentham1823hedonic,
-  title={An Introduction to the Principles of Morals and Legislation},
-  author={Bentham, Jeremy},
-  year={1823},
-}
-
-@article{von1947theory,
-  title={Theory of games and economic behavior, 2nd rev},
-  author={Von Neumann, John and Morgenstern, Oskar},
-  year={1947},
-  publisher={Princeton university press}
-}
-
-@article{ramsey2016truth,
-  title={Truth and probability},
-  author={Ramsey, Frank P},
-  journal={Readings in Formal Epistemology: Sourcebook},
-  pages={21--45},
-  year={2016},
-  publisher={Springer}
-}
-
-@article{arrow1950difficulty,
-  title={A difficulty in the concept of social welfare},
-  author={Arrow, Kenneth J},
-  journal={Journal of political economy},
-  volume={58},
-  number={4},
-  pages={328--346},
-  year={1950},
-  publisher={The University of Chicago Press}
-}
-
-@article{harsanyi1977rule,
-  title={Rule utilitarianism and decision theory},
-  author={Harsanyi, John C},
-  journal={Erkenntnis},
-  volume={11},
-  number={1},
-  pages={25--53},
-  year={1977},
-  publisher={Springer}
-}
-
-@book{pettigrew2019choosing,
-  title={Choosing for changing selves},
-  author={Pettigrew, Richard},
-  year={2019},
-  publisher={Oxford University Press}
-}
-
-@inproceedings{soares2015corrigibility,
-  title={Corrigibility},
-  author={Soares, Nate and Fallenstein, Benja and Armstrong, Stuart and Yudkowsky, Eliezer},
-  booktitle={Workshops at the twenty-ninth AAAI conference on artificial intelligence},
-  year={2015}
-}
-
-@book{russell2016artificial,
-  title={Artificial intelligence: a modern approach},
-  author={Russell, Stuart J and Norvig, Peter},
-  year={2016},
-  publisher={Pearson}
-}
-
-@inproceedings{ng2000algorithms,
-  title={Algorithms for inverse reinforcement learning.},
-  author={Ng, Andrew Y and Russell, Stuart and others},
-  booktitle = {Proceedings of the Seventeenth International Conference on Machine Learning},
-  pages = {663–-670},
-  numpages = {8},
-  series = {ICML '00},
-  year={2000}
-}
-
 @inproceedings{conitzer2024social,
   title={Social Choice Should Guide AI Alignment in Dealing with Diverse Human Feedback},
   booktitle = {International Conference on Machine Learning (ICML)},
@@ -1822,6 +1773,27 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   year = {2024}
 }
 
+@book{arnauld1861port,
+  title={The Port-Royal Logic},
+  author={Arnauld, Antoine},
+  year={1662},
+}
+
+@book{bentham1823hedonic,
+  title={An Introduction to the Principles of Morals and Legislation},
+  author={Bentham, Jeremy},
+  year={1823},
+}
+
+@article{ramsey2016truth,
+  title={Truth and probability},
+  author={Ramsey, Frank P},
+  journal={Readings in Formal Epistemology: Sourcebook},
+  pages={21--45},
+  year={2016},
+  publisher={Springer}
+}
+
 @article{hirschman1984against,
   title={Against parsimony: Three easy ways of complicating some categories of economic discourse},
   author={Hirschman, Albert O},
@@ -1843,10 +1815,44 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   publisher={Annual Reviews}
 }
 
+@article{thorndike1927law,
+  title={The law of effect},
+  author={Thorndike, Edward L},
+  journal={The American journal of psychology},
+  volume={39},
+  number={1/4},
+  pages={212--222},
+  year={1927},
+  publisher={JSTOR}
+}
+
+@book{skinner2019behavior,
+  title={The behavior of organisms: An experimental analysis},
+  author={Skinner, Burrhus Frederic},
+  year={2019},
+  publisher={BF Skinner Foundation}
+}
+
 @article{briggs2014normative,
   title={Normative theories of rational choice: Expected utility},
   author={Briggs, Rachael A},
   year={2014}
+}
+
+@techreport{widrow1960adaptive,
+  title={Adaptive switching circuits},
+  author={Widrow, Bernard and Hoff, Marcian E},
+  year={1960},
+  institution={Stanford Univ Ca Stanford Electronics Labs}
+}
+
+@inproceedings{singh2009rewards,
+  title={Where do rewards come from},
+  author={Singh, Satinder and Lewis, Richard L and Barto, Andrew G},
+  booktitle={Proceedings of the annual conference of the cognitive science society},
+  pages={2601--2606},
+  year={2009},
+  organization={Cognitive Science Society}
 }
 
 @article{mcclure2003computational,
@@ -2019,6 +2025,13 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   year={2022}
 }
 
+@article{von1947theory,
+  title={Theory of games and economic behavior, 2nd rev},
+  author={Von Neumann, John and Morgenstern, Oskar},
+  year={1947},
+  publisher={Princeton university press}
+}
+
 @inproceedings{pitis2019rethinking,
   title={Rethinking the discount factor in reinforcement learning: A decision theoretic approach},
   author={Pitis, Silviu},
@@ -2056,11 +2069,33 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   publisher={JSTOR}
 }
 
+@article{arrow1950difficulty,
+  title={A difficulty in the concept of social welfare},
+  author={Arrow, Kenneth J},
+  journal={Journal of political economy},
+  volume={58},
+  number={4},
+  pages={328--346},
+  year={1950},
+  publisher={The University of Chicago Press}
+}
+
 @book{maskin2014arrow,
   title={The Arrow impossibility theorem},
   author={Maskin, Eric and Sen, Amartya},
   year={2014},
   publisher={Columbia University Press}
+}
+
+@article{harsanyi1977rule,
+  title={Rule utilitarianism and decision theory},
+  author={Harsanyi, John C},
+  journal={Erkenntnis},
+  volume={11},
+  number={1},
+  pages={25--53},
+  year={1977},
+  publisher={Springer}
 }
 
 @article{hadfield2016cooperative,
@@ -2078,48 +2113,36 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   year={2020}
 }
 
+@inproceedings{soares2015corrigibility,
+  title={Corrigibility},
+  author={Soares, Nate and Fallenstein, Benja and Armstrong, Stuart and Yudkowsky, Eliezer},
+  booktitle={Workshops at the twenty-ninth AAAI conference on artificial intelligence},
+  year={2015}
+}
+
+@book{pettigrew2019choosing,
+  title={Choosing for changing selves},
+  author={Pettigrew, Richard},
+  year={2019},
+  publisher={Oxford University Press}
+}
+
 ### End chapter 10 ###
 
 ### First appearing in chapter 11 (Preference Data) ###
 
-@misc{bharadwaj2025flatteryflufffogdiagnosing,
-      title={Flattery, Fluff, and Fog: Diagnosing and Mitigating Idiosyncratic Biases in Preference Models}, 
-      author={Anirudh Bharadwaj and Chaitanya Malaviya and Nitish Joshi and Mark Yatskar},
-      year={2025},
-      eprint={2506.05339},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL},
-      url={https://arxiv.org/abs/2506.05339}, 
-}
-
-@inproceedings{zhang2024lists,
-  title={From lists to emojis: How format bias affects model alignment},
-  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
-  author={Zhang, Xuanchang and Xiong, Wei and Chen, Lichang and Zhou, Tianyi and Huang, Heng and Zhang, Tong},
-  year = {2025}
-}
-
-@inproceedings{kumar2025detecting,
-  title={Detecting Prefix Bias in LLM-based Reward Models},
-  booktitle = {ACM Conference on Fairness, Accountability, and Transparency (FAccT)},
-  author={Kumar, Ashwin and He, Yuzi and Markosyan, Aram H and Chern, Bobbie and Arrieta-Ibarra, Imanol},
-  year = {2025}
-}
-
-@inproceedings{bu2025beyond,
-  title={Beyond Excess and Deficiency: Adaptive Length Bias Mitigation in Reward Models for RLHF},
-  author={Bu, Yuyan and Huo, Liangyu and Jing, Yi and Yang, Qing},
-  booktitle={Findings of the Association for Computational Linguistics: NAACL 2025},
-  pages={3091--3098},
+@article{wang2025helpsteer3,
+  title={HelpSteer3-Preference: Open Human-Annotated Preference Data across Diverse Tasks and Languages},
+  author={Wang, Zhilin and Zeng, Jiaqi and Delalleau, Olivier and Shin, Hoo-Chang and Soares, Felipe and Bukharin, Alexander and Evans, Ellie and Dong, Yi and Kuchaiev, Oleksii},
+  journal={arXiv preprint arXiv:2505.11475},
   year={2025}
 }
 
-@inproceedings{sharma2023towards,
-  title={Towards Understanding Sycophancy in Language Models},
-  author={Mrinank Sharma and Meg Tong and Tomasz Korbak and David Duvenaud and Amanda Askell and Samuel R. Bowman and Esin DURMUS and Zac Hatfield-Dodds and Scott R Johnston and Shauna M Kravec and Timothy Maxwell and Sam McCandlish and Kamal Ndousse and Oliver Rausch and Nicholas Schiefer and Da Yan and Miranda Zhang and Ethan Perez},
-  booktitle={The Twelfth International Conference on Learning Representations},
-  year={2024},
-  url={https://openreview.net/forum?id=tvhaxkMKAn}
+@inproceedings{chiang2024chatbot,
+  title={Chatbot arena: An open platform for evaluating llms by human preference},
+  booktitle = {International Conference on Machine Learning (ICML)},
+  author={Chiang, Wei-Lin and Zheng, Lianmin and Sheng, Ying and Angelopoulos, Anastasios Nikolas and Li, Tianle and Li, Dacheng and Zhang, Hao and Zhu, Banghua and Jordan, Michael and Gonzalez, Joseph E and others},
+  year = {2024}
 }
 
 @article{likert1932technique,
@@ -2129,18 +2152,21 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   year={1932}
 }
 
-@inproceedings{wang2024helpsteer2p,
-  title={HelpSteer2-Preference: Complementing Ratings with Preferences},
-  booktitle = {International Conference on Learning Representations (ICLR)},
-  author={Wang, Zhilin and Bukharin, Alexander and Delalleau, Olivier and Egert, Daniel and Shen, Gerald and Zeng, Jiaqi and Kuchaiev, Oleksii and Dong, Yi},
-  year = {2025}
+@misc{zhou2023instructionfollowingevaluationlargelanguage,
+      title={Instruction-Following Evaluation for Large Language Models},
+      author={Jeffrey Zhou and Tianjian Lu and Swaroop Mishra and Siddhartha Brahma and Sujoy Basu and Yi Luan and Denny Zhou and Le Hou},
+      year={2023},
+      eprint={2311.07911},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2311.07911},
 }
 
-@article{malik2025rewardbench,
-  title={RewardBench 2: Advancing Reward Model Evaluation},
-  author={Malik, Saumya and Pyatkin, Valentina and Land, Sander and Morrison, Jacob and Smith, Noah A and Hajishirzi, Hannaneh and Lambert, Nathan},
-  journal={arXiv preprint arXiv:2506.01937},
-  year={2025}
+@article{ethayarajh2024kto,
+  title={Kto: Model alignment as prospect theoretic optimization},
+  author={Ethayarajh, Kawin and Xu, Winnie and Muennighoff, Niklas and Jurafsky, Dan and Kiela, Douwe},
+  journal={arXiv preprint arXiv:2402.01306},
+  year={2024}
 }
 
 @article{wu2024fine,
@@ -2158,18 +2184,44 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   year={2024}
 }
 
-@inproceedings{chiang2024chatbot,
-  title={Chatbot arena: An open platform for evaluating llms by human preference},
-  booktitle = {International Conference on Machine Learning (ICML)},
-  author={Chiang, Wei-Lin and Zheng, Lianmin and Sheng, Ying and Angelopoulos, Anastasios Nikolas and Li, Tianle and Li, Dacheng and Zhang, Hao and Zhu, Banghua and Jordan, Michael and Gonzalez, Joseph E and others},
-  year = {2024}
+@inproceedings{kumar2025detecting,
+  title={Detecting Prefix Bias in LLM-based Reward Models},
+  booktitle = {ACM Conference on Fairness, Accountability, and Transparency (FAccT)},
+  author={Kumar, Ashwin and He, Yuzi and Markosyan, Aram H and Chern, Bobbie and Arrieta-Ibarra, Imanol},
+  year = {2025}
 }
 
-@article{ethayarajh2024kto,
-  title={Kto: Model alignment as prospect theoretic optimization},
-  author={Ethayarajh, Kawin and Xu, Winnie and Muennighoff, Niklas and Jurafsky, Dan and Kiela, Douwe},
-  journal={arXiv preprint arXiv:2402.01306},
-  year={2024}
+@misc{bharadwaj2025flatteryflufffogdiagnosing,
+      title={Flattery, Fluff, and Fog: Diagnosing and Mitigating Idiosyncratic Biases in Preference Models},
+      author={Anirudh Bharadwaj and Chaitanya Malaviya and Nitish Joshi and Mark Yatskar},
+      year={2025},
+      eprint={2506.05339},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2506.05339},
+}
+
+@inproceedings{sharma2023towards,
+  title={Towards Understanding Sycophancy in Language Models},
+  author={Mrinank Sharma and Meg Tong and Tomasz Korbak and David Duvenaud and Amanda Askell and Samuel R. Bowman and Esin DURMUS and Zac Hatfield-Dodds and Scott R Johnston and Shauna M Kravec and Timothy Maxwell and Sam McCandlish and Kamal Ndousse and Oliver Rausch and Nicholas Schiefer and Da Yan and Miranda Zhang and Ethan Perez},
+  booktitle={The Twelfth International Conference on Learning Representations},
+  year={2024},
+  url={https://openreview.net/forum?id=tvhaxkMKAn}
+}
+
+@inproceedings{bu2025beyond,
+  title={Beyond Excess and Deficiency: Adaptive Length Bias Mitigation in Reward Models for RLHF},
+  author={Bu, Yuyan and Huo, Liangyu and Jing, Yi and Yang, Qing},
+  booktitle={Findings of the Association for Computational Linguistics: NAACL 2025},
+  pages={3091--3098},
+  year={2025}
+}
+
+@inproceedings{zhang2024lists,
+  title={From lists to emojis: How format bias affects model alignment},
+  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
+  author={Zhang, Xuanchang and Xiong, Wei and Chen, Lichang and Zhou, Tianyi and Huang, Heng and Zhang, Tong},
+  year = {2025}
 }
 
 @misc{openai2024modelspec,
@@ -2181,26 +2233,103 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   note         = {Accessed: 2025-02-14}
 }
 
-@misc{zhou2023instructionfollowingevaluationlargelanguage,
-      title={Instruction-Following Evaluation for Large Language Models},
-      author={Jeffrey Zhou and Tianjian Lu and Swaroop Mishra and Siddhartha Brahma and Sujoy Basu and Yi Luan and Denny Zhou and Le Hou},
-      year={2023},
-      eprint={2311.07911},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL},
-      url={https://arxiv.org/abs/2311.07911},
-}
-
 ### End chapter 11 ###
 
 ### First appearing in chapter 12 (Synthetic Data) ###
 
-@inproceedings{gu2024minillm,
-  title={{MiniLLM}: Knowledge Distillation of Large Language Models},
-  author={Gu, Yuxian and Dong, Li and Wei, Furu and Huang, Minlie},
-  booktitle={The Twelfth International Conference on Learning Representations},
+@article{shumailov2024ai,
+  title={AI models collapse when trained on recursively generated data},
+  author={Shumailov, Ilia and Shumaylov, Zakhar and Zhao, Yiren and Papernot, Nicolas and Anderson, Ross and Gal, Yarin},
+  journal={Nature},
+  volume={631},
+  number={8022},
+  pages={755--759},
   year={2024},
-  url={https://openreview.net/forum?id=5h0qf7IBZZ}
+  publisher={Nature Publishing Group UK London}
+}
+
+@article{gerstgrasser2024model,
+  title={Is model collapse inevitable? breaking the curse of recursion by accumulating real and synthetic data},
+  author={Gerstgrasser, Matthias and Schaeffer, Rylan and Dey, Apratim and Rafailov, Rafael and Sleight, Henry and Hughes, John and Korbak, Tomasz and Agrawal, Rajashree and Pai, Dhruv and Gromov, Andrey and others},
+  journal={arXiv preprint arXiv:2404.01413},
+  year={2024}
+}
+
+@inproceedings{feng2024beyond,
+  title={Beyond model collapse: Scaling up with synthesized data requires reinforcement},
+  author={Feng, Yunzhen and Dohmatob, Elvis and Yang, Pu and Charton, Francois and Kempe, Julia},
+  booktitle={ICML 2024 Workshop on Theoretical Foundations of Foundation Models},
+  year={2024}
+}
+
+@inproceedings{wang2022self,
+  title={Self-instruct: Aligning language models with self-generated instructions},
+  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
+  author={Wang, Yizhong and Kordi, Yeganeh and Mishra, Swaroop and Liu, Alisa and Smith, Noah A and Khashabi, Daniel and Hajishirzi, Hannaneh},
+  year = {2023}
+}
+
+@misc{numina_math_7b,
+  author = {Edward Beeching and Shengyi Costa Huang and Albert Jiang and Jia Li and Benjamin Lipkin and Zihan Qina and Kashif Rasul and Ziju Shen and Roman Soletskyi and Lewis Tunstall},
+  title = {NuminaMath 7B TIR},
+  year = {2024},
+  publisher = {Numina & Hugging Face},
+  journal = {Hugging Face repository},
+  howpublished = {\url{https://huggingface.co/AI-MO/NuminaMath-7B-TIR}}
+}
+
+@inproceedings{li2024superfiltering,
+  title={Superfiltering: Weak-to-strong data filtering for fast instruction-tuning},
+  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
+  author={Li, Ming and Zhang, Yong and He, Shwai and Li, Zhitao and Zhao, Hongyu and Wang, Jianzong and Cheng, Ning and Zhou, Tianyi},
+  year = {2024}
+}
+
+@article{hinton2015distilling,
+  title={Distilling the knowledge in a neural network},
+  author={Hinton, Geoffrey and Vinyals, Oriol and Dean, Jeff},
+  journal={arXiv preprint arXiv:1503.02531},
+  year={2015}
+}
+
+@article{shridhar2023distilling,
+  title={Distilling reasoning capabilities into smaller language models},
+  author={Shridhar, Kumar and Stolfo, Alessandro and Sachan, Mrinmaya},
+  journal={Findings of the Association for Computational Linguistics: ACL 2023},
+  pages={7059--7073},
+  year={2023},
+  publisher={Association for Computational Linguistics}
+}
+
+@inproceedings{hsieh2023distilling,
+  title={Distilling Step-by-Step! Outperforming Larger Language Models with Less Training Data and Smaller Model Sizes},
+  author={Hsieh, Cheng-Yu and Li, Chun-Liang and Yeh, Chih-kuan and Nakhost, Hootan and Fujii, Yasuhisa and Ratner, Alex and Krishna, Ranjay and Lee, Chen-Yu and Pfister, Tomas},
+  booktitle={Findings of the Association for Computational Linguistics: ACL 2023},
+  year={2023},
+  url={https://aclanthology.org/2023.findings-acl.507/},
+  doi={10.18653/v1/2023.findings-acl.507},
+  pages={8003--8017}
+}
+
+@misc{glm5team2026glm5,
+  title={{GLM}-5: From Vibe Coding to Agentic Engineering},
+  author={{GLM-5 Team} and Zeng, Aohan and Lv, Xin and Hou, Zhenyu and Du, Zhengxiao and Zheng, Qinkai and others},
+  year={2026},
+  month=feb,
+  eprint={2602.15763},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG},
+  doi={10.48550/arXiv.2602.15763},
+  url={https://arxiv.org/abs/2602.15763}
+}
+
+@techreport{deepseekai2026deepseekv4,
+  title={DeepSeek-V4: Towards Highly Efficient Million-Token Context Intelligence},
+  author={{DeepSeek-AI}},
+  institution={DeepSeek-AI},
+  year={2026},
+  type={Technical Report},
+  url={https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/DeepSeek_V4.pdf}
 }
 
 @inproceedings{kim-rush-2016-sequence,
@@ -2214,17 +2343,6 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   url={https://aclanthology.org/D16-1139/},
   doi={10.18653/v1/D16-1139},
   pages={1317--1327}
-}
-
-@article{lu2025onpolicy,
-  author={Lu, Kevin and {Thinking Machines Lab}},
-  title={On-Policy Distillation},
-  journal={Thinking Machines Lab: Connectionism},
-  year={2025},
-  month=oct,
-  note={Published October 27, 2025. \url{https://thinkingmachines.ai/blog/on-policy-distillation}},
-  doi={10.64434/tml.20251026},
-  url={https://thinkingmachines.ai/blog/on-policy-distillation}
 }
 
 @misc{sanh2019distilbert,
@@ -2250,16 +2368,80 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   note={Findings of EMNLP 2020}
 }
 
-@misc{glm5team2026glm5,
-  title={{GLM}-5: From Vibe Coding to Agentic Engineering},
-  author={{GLM-5 Team} and Zeng, Aohan and Lv, Xin and Hou, Zhenyu and Du, Zhengxiao and Zheng, Qinkai and others},
+@inproceedings{arora-etal-2022-exposure,
+    title = "Why Exposure Bias Matters: An Imitation Learning Perspective of Error Accumulation in Language Generation",
+    author = "Arora, Kushal  and
+      El Asri, Layla  and
+      Bahuleyan, Hareesh  and
+      Cheung, Jackie Chi Kit",
+    editor = "Muresan, Smaranda  and
+      Nakov, Preslav  and
+      Villavicencio, Aline",
+    booktitle = "Findings of the Association for Computational Linguistics: ACL 2022",
+    month = may,
+    year = "2022",
+    address = "Dublin, Ireland",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2022.findings-acl.58/",
+    doi = "10.18653/v1/2022.findings-acl.58",
+    pages = "700--710",
+    abstract = "Current language generation models suffer from issues such as repetition, incoherence, and hallucinations. An often-repeated hypothesis for this brittleness of generation models is that it is caused by the training and the generation procedure mismatch, also referred to as exposure bias. In this paper, we verify this hypothesis by analyzing exposure bias from an imitation learning perspective. We show that exposure bias leads to an accumulation of errors during generation, analyze why perplexity fails to capture this accumulation of errors, and empirically show that this accumulation results in poor generation quality."
+}
+
+@misc{song2026surveyonpolicydistillationlarge,
+  title={A Survey of On-Policy Distillation for Large Language Models},
+  author={Song, Mingyang and Zheng, Mao},
   year={2026},
-  month=feb,
-  eprint={2602.15763},
+  eprint={2604.00626},
   archivePrefix={arXiv},
   primaryClass={cs.LG},
-  doi={10.48550/arXiv.2602.15763},
-  url={https://arxiv.org/abs/2602.15763}
+  url={https://arxiv.org/abs/2604.00626}
+}
+
+@inproceedings{gu2024minillm,
+  title={{MiniLLM}: Knowledge Distillation of Large Language Models},
+  author={Gu, Yuxian and Dong, Li and Wei, Furu and Huang, Minlie},
+  booktitle={The Twelfth International Conference on Learning Representations},
+  year={2024},
+  url={https://openreview.net/forum?id=5h0qf7IBZZ}
+}
+
+@inproceedings{agarwal2024policy,
+  title={On-policy distillation of language models: Learning from self-generated mistakes},
+  author={Agarwal, Rishabh and Vieillard, Nino and Zhou, Yongchao and Stanczyk, Piotr and Ramos Garea, Sabela and Geist, Matthieu and Bachem, Olivier},
+  booktitle={The Twelfth International Conference on Learning Representations},
+  year={2024},
+  url={https://openreview.net/forum?id=3zKtaqxLhW}
+}
+
+@inproceedings{ross2011reduction,
+  title={A Reduction of Imitation Learning and Structured Prediction to No-Regret Online Learning},
+  author={Ross, Stephane and Gordon, Geoffrey and Bagnell, Drew},
+  booktitle={Proceedings of the Fourteenth International Conference on Artificial Intelligence and Statistics},
+  pages={627--635},
+  year={2011},
+  editor={Gordon, Geoffrey and Dunson, David and Dudik, Miroslav},
+  volume={15},
+  series={Proceedings of Machine Learning Research},
+  address={Fort Lauderdale, FL, USA},
+  month={11--13 Apr},
+  publisher={PMLR},
+  eprint={1011.0686},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG},
+  doi={10.48550/arXiv.1011.0686},
+  url={https://proceedings.mlr.press/v15/ross11a.html}
+}
+
+@article{lu2025onpolicy,
+  author={Lu, Kevin and {Thinking Machines Lab}},
+  title={On-Policy Distillation},
+  journal={Thinking Machines Lab: Connectionism},
+  year={2025},
+  month=oct,
+  note={Published October 27, 2025. \url{https://thinkingmachines.ai/blog/on-policy-distillation}},
+  doi={10.64434/tml.20251026},
+  url={https://thinkingmachines.ai/blog/on-policy-distillation}
 }
 
 @misc{zhao2026selfdistilled,
@@ -2273,40 +2455,15 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   url={https://arxiv.org/abs/2601.18734}
 }
 
-@techreport{deepseekai2026deepseekv4,
-  title={DeepSeek-V4: Towards Highly Efficient Million-Token Context Intelligence},
-  author={{DeepSeek-AI}},
-  institution={DeepSeek-AI},
-  year={2026},
-  type={Technical Report},
-  url={https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/DeepSeek_V4.pdf}
-}
-
-@inproceedings{wang2024helpsteer,
-  title={Helpsteer: Multi-attribute helpfulness dataset for steerlm},
-  author={Wang, Zhilin and Dong, Yi and Zeng, Jiaqi and Adams, Virginia and Sreedhar, Makesh Narsimhan and Egert, Daniel and Delalleau, Olivier and Scowcroft, Jane and Kant, Neel and Swope, Aidan and others},
-  booktitle={Proceedings of the 2024 Conference of the North American Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers)},
-  pages={3371--3384},
-  year={2024}
-}
-
-@article{wang2025helpsteer3,
-  title={HelpSteer3-Preference: Open Human-Annotated Preference Data across Diverse Tasks and Languages},
-  author={Wang, Zhilin and Zeng, Jiaqi and Delalleau, Olivier and Shin, Hoo-Chang and Soares, Felipe and Bukharin, Alexander and Evans, Ellie and Dong, Yi and Kuchaiev, Oleksii},
-  journal={arXiv preprint arXiv:2505.11475},
-  year={2025}
-}
-
-@article{liu2025inference,
-  title={Inference-Time Scaling for Generalist Reward Modeling},
-  author={Liu, Zijun and Wang, Peiyi and Xu, Runxin and Ma, Shirong and Ruan, Chong and Li, Peng and Liu, Yang and Wu, Yu},
-  journal={arXiv preprint arXiv:2504.02495},
-  year={2025}
+@article{lee2023rlaif,
+  title={Rlaif: Scaling reinforcement learning from human feedback with ai feedback},
+  author={Lee, Harrison and Phatale, Samrat and Mansoor, Hassan and Lu, Kellie Ren and Mesnard, Thomas and Ferret, Johan and Bishop, Colton and Hall, Ethan and Carbune, Victor and Rastogi, Abhinav},
+  year={2023}
 }
 
 @inproceedings{sharma2024critical,
       title={A Critical Evaluation of AI Feedback for Aligning Large Language Models},
-  booktitle = {Advances in Neural Information Processing Systems (NeurIPS)}, 
+  booktitle = {Advances in Neural Information Processing Systems (NeurIPS)},
       author={Archit Sharma and Sedrick Keh and Eric Mitchell and Chelsea Finn and Kushal Arora and Thomas Kollar},
       year = {2024},
       archivePrefix={arXiv},
@@ -2314,19 +2471,12 @@ url={https://openreview.net/forum?id=a147pIS2Co}
 }
 
 @misc{castricato2024suppressing,
-      title={Suppressing Pink Elephants with Direct Principle Feedback}, 
+      title={Suppressing Pink Elephants with Direct Principle Feedback},
       author={Louis Castricato and Nathan Lile and Suraj Anand and Hailey Schoelkopf and Siddharth Verma and Stella Biderman},
       year={2024},
       eprint={2402.07896},
       archivePrefix={arXiv},
       primaryClass={cs.CL}
-}
-
-@article{franken2024self,
-  title={Self-supervised alignment with mutual information: Learning to follow principles without preference labels},
-  author={Fr{\"a}nken, Jan-Philipp and Zelikman, Eric and Rafailov, Rafael and Gandhi, Kanishk and Gerstenberg, Tobias and Goodman, Noah},
-  journal={Advances in Neural Information Processing Systems},
-  year={2024}
 }
 
 @inproceedings{yuan2025selfrewardinglanguagemodels,
@@ -2337,93 +2487,6 @@ url={https://openreview.net/forum?id=a147pIS2Co}
       archivePrefix={arXiv},
       primaryClass={cs.CL},
       url={https://arxiv.org/abs/2401.10020},
-}
-
-@article{bercovich2025llamanemotron,
-  title={Llama‑Nemotron: Efficient Reasoning Models},
-  author={Bercovich, Akhiad and Levy, Itay and Golan, Izik and others},
-  journal={arXiv preprint arXiv:2505.00949},
-  year={2025}
-}
-
-@article{wang2025nemotron,
-  title={Nemotron-Cascade: Scaling Cascaded Reinforcement Learning for General-Purpose Reasoning Models},
-  author={Wang, Boxin and Lee, Chankyu and Lee, Nayeon and Lin, Sheng-Chieh and Dai, Wenliang and Chen, Yang and Chen, Yangyi and Yang, Zhuolin and Liu, Zihan and Shoeybi, Mohammad and others},
-  journal={arXiv preprint arXiv:2512.13607},
-  year={2025}
-}
-
-@techreport{nvidia2025nemotron3nano,
-  title       = {Nemotron 3 Nano: Open, Efficient Mixture-of-Experts Hybrid Mamba-Transformer Model for Agentic Reasoning},
-  author      = {{NVIDIA}},
-  institution = {NVIDIA},
-  type        = {Technical Report},
-  year        = {2025},
-  month       = {December},
-  note        = {Dated 2025-12-15},
-  url         = {https://research.nvidia.com/labs/nemotron/files/NVIDIA-Nemotron-3-Nano-Technical-Report.pdf}
-}
-
-@article{kalra2025verdict,
-  title={Verdict: A Library for Scaling Judge-Time Compute},
-  author={Kalra, Nimit and Tang, Leonard},
-  journal={arXiv preprint arXiv:2502.18018},
-  year={2025}
-}
-
-@inproceedings{zhao2025sample,
-  title={Sample, scrutinize and scale: Effective inference-time search by scaling verification},
-  booktitle = {International Conference on Machine Learning (ICML)},
-  author={Zhao, Eric and Awasthi, Pranjal and Gollapudi, Sreenivas},
-  year = {2025}
-}
-
-@article{madaan2023self,
-  title={Self-refine: Iterative refinement with self-feedback},
-  author={Madaan, Aman and Tandon, Niket and Gupta, Prakhar and Hallinan, Skyler and Gao, Luyu and Wiegreffe, Sarah and Alon, Uri and Dziri, Nouha and Prabhumoye, Shrimai and Yang, Yiming and others},
-  journal={Advances in Neural Information Processing Systems},
-  year={2023}
-}
-
-@article{pace2024west,
-  title={West-of-n: Synthetic preference generation for improved reward modeling},
-  author={Pace, Aliz{\'e}e and Mallinson, Jonathan and Malmi, Eric and Krause, Sebastian and Severyn, Aliaksei},
-  journal={arXiv preprint arXiv:2401.12086},
-  year={2024}
-}
-
-@article{wu2024meta,
-  title={Meta-rewarding language models: Self-improving alignment with llm-as-a-meta-judge},
-  author={Wu, Tianhao and Yuan, Weizhe and Golovneva, Olga and Xu, Jing and Tian, Yuandong and Jiao, Jiantao and Weston, Jason and Sukhbaatar, Sainbayar},
-  journal={arXiv preprint arXiv:2407.19594},
-  year={2024}
-}
-
-@inproceedings{wang2023large,
-  title={Large language models are not fair evaluators},
-  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
-  author={Wang, Peiyi and Li, Lei and Chen, Liang and Cai, Zefan and Zhu, Dawei and Lin, Binghuai and Cao, Yunbo and Liu, Qi and Liu, Tianyu and Sui, Zhifang},
-  year = {2024}
-}
-
-@article{panickssery2024llm,
-  title={Llm evaluators recognize and favor their own generations},
-  author={Panickssery, Arjun and Bowman, Samuel and Feng, Shi},
-  journal={Advances in Neural Information Processing Systems},
-  year={2024}
-}
-
-@article{brown2024large,
-  title={Large language monkeys: Scaling inference compute with repeated sampling},
-  author={Brown, Bradley and Juravsky, Jordan and Ehrlich, Ryan and Clark, Ronald and Le, Quoc V and R{\'e}, Christopher and Mirhoseini, Azalia},
-  journal={arXiv preprint arXiv:2407.21787},
-  year={2024}
-}
-
-@article{lee2023rlaif,
-  title={Rlaif: Scaling reinforcement learning from human feedback with ai feedback},
-  author={Lee, Harrison and Phatale, Samrat and Mansoor, Hassan and Lu, Kellie Ren and Mesnard, Thomas and Ferret, Johan and Bishop, Colton and Hall, Ethan and Carbune, Victor and Rastogi, Abhinav},
-  year={2023}
 }
 
 @article{miranda2024hybrid,
@@ -2462,59 +2525,26 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   note = {Presented at ICML 2025}
 }
 
-@article{guan2024deliberative,
-  title={Deliberative alignment: Reasoning enables safer language models},
-  author={Guan, Melody Y and Joglekar, Manas and Wallace, Eric and Jain, Saachi and Barak, Boaz and Heylar, Alec and Dias, Rachel and Vallone, Andrea and Ren, Hongyu and Wei, Jason and others},
-  journal={arXiv preprint arXiv:2412.16339},
+@inproceedings{wang2024helpsteer,
+  title={Helpsteer: Multi-attribute helpfulness dataset for steerlm},
+  author={Wang, Zhilin and Dong, Yi and Zeng, Jiaqi and Adams, Virginia and Sreedhar, Makesh Narsimhan and Egert, Daniel and Delalleau, Olivier and Scowcroft, Jane and Kant, Neel and Swope, Aidan and others},
+  booktitle={Proceedings of the 2024 Conference of the North American Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 1: Long Papers)},
+  pages={3371--3384},
   year={2024}
 }
 
-@misc{ganguli2023,
-  title        = {Collective Constitutional {AI}: {A}ligning a Language Model with Public Input},
-  author       = {Ganguli, D. and others},
-  year         = 2023,
-  howpublished = {Anthropic},
-  note         = {\url{https://www.anthropic.com/index/collective-constitutional-ai-aligning-a-language-model-with-public-input}, retrieved 2024-01-31}
+@article{wang2025nemotron,
+  title={Nemotron-Cascade: Scaling Cascaded Reinforcement Learning for General-Purpose Reasoning Models},
+  author={Wang, Boxin and Lee, Chankyu and Lee, Nayeon and Lin, Sheng-Chieh and Dai, Wenliang and Chen, Yang and Chen, Yangyi and Yang, Zhuolin and Liu, Zihan and Shoeybi, Mohammad and others},
+  journal={arXiv preprint arXiv:2512.13607},
+  year={2025}
 }
 
-@online{Anthropic2023ClaudesConstitution,
-  author = {Anthropic},
-  title = {Claude’s Constitution},
-  year = {2023},
-  url = {https://www.anthropic.com/news/claudes-constitution},
-  note = {Accessed: 2024-02-07},
-  urldate = {2024-02-07}
-}
-
-@article{lambert2024self,
-  title={Self-directed synthetic dialogues and revisions technical report},
-  author={Lambert, Nathan and Schoelkopf, Hailey and Gokaslan, Aaron and Soldaini, Luca and Pyatkin, Valentina and Castricato, Louis},
-  journal={arXiv preprint arXiv:2407.18421},
-  year={2024}
-}
-
-@inproceedings{sun2023principledriven,
-title={Principle-Driven Self-Alignment of Language Models from Scratch with Minimal Human Supervision},
-author={Zhiqing Sun and Yikang Shen and Qinhong Zhou and Hongxin Zhang and Zhenfang Chen and David Daniel Cox and Yiming Yang and Chuang Gan},
-booktitle={Thirty-seventh Conference on Neural Information Processing Systems},
-year={2023},
-url={https://openreview.net/forum?id=p40XRfBX96}
-}
-
-@inproceedings{sun2024salmon,
-title={{SALMON}: Self-Alignment with Principle-Following Reward Models},
-author={Sun, Zhiqing and Shen, Yikang and Zhang, Hongxin and Zhou, Qinhong and Chen, Zhenfang and Cox, David and Yang, Yiming and Gan, Chuang},
-booktitle={The Twelfth International Conference on Learning Representations},
-year={2024},
-url={https://openreview.net/forum?id=xJbsmB8UMx}
-}
-
-@article{Huang2024cai,
-  author = {Huang, Shengyi and Tunstall, Lewis and Beeching, Edward and von Werra, Leandro and Sanseviero, Omar and Rasul, Kashif and Wolf, Thomas},
-  title = {Constitutional AI Recipe},
-  journal = {Hugging Face Blog},
-  year = {2024},
-  note = {\url{https://huggingface.co/blog/constitutional_ai}},
+@inproceedings{wang2023large,
+  title={Large language models are not fair evaluators},
+  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
+  author={Wang, Peiyi and Li, Lei and Chen, Liang and Cai, Zefan and Zhu, Dawei and Lin, Binghuai and Cao, Yunbo and Liu, Qi and Liu, Tianyu and Sui, Zhifang},
+  year = {2024}
 }
 
 @article{wang2023shepherd,
@@ -2522,6 +2552,20 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   author={Wang, Tianlu and Yu, Ping and Tan, Xiaoqing Ellen and O'Brien, Sean and Pasunuru, Ramakanth and Dwivedi-Yu, Jane and Golovneva, Olga and Zettlemoyer, Luke and Fazel-Zarandi, Maryam and Celikyilmaz, Asli},
   journal={arXiv preprint arXiv:2308.04592},
   year={2023}
+}
+
+@inproceedings{ke2023critiquellm,
+  title={CritiqueLLM: Towards an informative critique generation model for evaluation of large language model generation},
+  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
+  author={Ke, Pei and Wen, Bosi and Feng, Zhuoer and Liu, Xiao and Lei, Xuanyu and Cheng, Jiale and Wang, Shengyuan and Zeng, Aohan and Dong, Yuxiao and Wang, Hongning and others},
+  year = {2024}
+}
+
+@inproceedings{li2023generative,
+  title={Generative Judge for Evaluating Alignment},
+  booktitle = {International Conference on Learning Representations (ICLR)},
+  author={Li, Junlong and Sun, Shichao and Yuan, Weizhe and Fan, Run-Ze and Zhao, Hai and Liu, Pengfei},
+  year = {2024}
 }
 
 @inproceedings{kim2024prometheus,
@@ -2539,18 +2583,101 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   year={2024}
 }
 
-@inproceedings{ke2023critiquellm,
-  title={CritiqueLLM: Towards an informative critique generation model for evaluation of large language model generation},
-  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
-  author={Ke, Pei and Wen, Bosi and Feng, Zhuoer and Liu, Xiao and Lei, Xuanyu and Cheng, Jiale and Wang, Shengyuan and Zeng, Aohan and Dong, Yuxiao and Wang, Hongning and others},
-  year = {2024}
+@inproceedings{zhao2025sample,
+  title={Sample, scrutinize and scale: Effective inference-time search by scaling verification},
+  booktitle = {International Conference on Machine Learning (ICML)},
+  author={Zhao, Eric and Awasthi, Pranjal and Gollapudi, Sreenivas},
+  year = {2025}
 }
 
-@inproceedings{li2023generative,
-  title={Generative Judge for Evaluating Alignment},
-  booktitle = {International Conference on Learning Representations (ICLR)},
-  author={Li, Junlong and Sun, Shichao and Yuan, Weizhe and Fan, Run-Ze and Zhao, Hai and Liu, Pengfei},
-  year = {2024}
+@article{kalra2025verdict,
+  title={Verdict: A Library for Scaling Judge-Time Compute},
+  author={Kalra, Nimit and Tang, Leonard},
+  journal={arXiv preprint arXiv:2502.18018},
+  year={2025}
+}
+
+@article{madaan2023self,
+  title={Self-refine: Iterative refinement with self-feedback},
+  author={Madaan, Aman and Tandon, Niket and Gupta, Prakhar and Hallinan, Skyler and Gao, Luyu and Wiegreffe, Sarah and Alon, Uri and Dziri, Nouha and Prabhumoye, Shrimai and Yang, Yiming and others},
+  journal={Advances in Neural Information Processing Systems},
+  year={2023}
+}
+
+@article{pace2024west,
+  title={West-of-n: Synthetic preference generation for improved reward modeling},
+  author={Pace, Aliz{\'e}e and Mallinson, Jonathan and Malmi, Eric and Krause, Sebastian and Severyn, Aliaksei},
+  journal={arXiv preprint arXiv:2401.12086},
+  year={2024}
+}
+
+@article{wu2024meta,
+  title={Meta-rewarding language models: Self-improving alignment with llm-as-a-meta-judge},
+  author={Wu, Tianhao and Yuan, Weizhe and Golovneva, Olga and Xu, Jing and Tian, Yuandong and Jiao, Jiantao and Weston, Jason and Sukhbaatar, Sainbayar},
+  journal={arXiv preprint arXiv:2407.19594},
+  year={2024}
+}
+
+@inproceedings{sun2024salmon,
+title={{SALMON}: Self-Alignment with Principle-Following Reward Models},
+author={Sun, Zhiqing and Shen, Yikang and Zhang, Hongxin and Zhou, Qinhong and Chen, Zhenfang and Cox, David and Yang, Yiming and Gan, Chuang},
+booktitle={The Twelfth International Conference on Learning Representations},
+year={2024},
+url={https://openreview.net/forum?id=xJbsmB8UMx}
+}
+
+@article{guan2024deliberative,
+  title={Deliberative alignment: Reasoning enables safer language models},
+  author={Guan, Melody Y and Joglekar, Manas and Wallace, Eric and Jain, Saachi and Barak, Boaz and Heylar, Alec and Dias, Rachel and Vallone, Andrea and Ren, Hongyu and Wei, Jason and others},
+  journal={arXiv preprint arXiv:2412.16339},
+  year={2024}
+}
+
+@online{Anthropic2023ClaudesConstitution,
+  author = {Anthropic},
+  title = {Claude’s Constitution},
+  year = {2023},
+  url = {https://www.anthropic.com/news/claudes-constitution},
+  note = {Accessed: 2024-02-07},
+  urldate = {2024-02-07}
+}
+
+@misc{ganguli2023,
+  title        = {Collective Constitutional {AI}: {A}ligning a Language Model with Public Input},
+  author       = {Ganguli, D. and others},
+  year         = 2023,
+  howpublished = {Anthropic},
+  note         = {\url{https://www.anthropic.com/index/collective-constitutional-ai-aligning-a-language-model-with-public-input}, retrieved 2024-01-31}
+}
+
+@article{Huang2024cai,
+  author = {Huang, Shengyi and Tunstall, Lewis and Beeching, Edward and von Werra, Leandro and Sanseviero, Omar and Rasul, Kashif and Wolf, Thomas},
+  title = {Constitutional AI Recipe},
+  journal = {Hugging Face Blog},
+  year = {2024},
+  note = {\url{https://huggingface.co/blog/constitutional_ai}},
+}
+
+@article{lambert2024self,
+  title={Self-directed synthetic dialogues and revisions technical report},
+  author={Lambert, Nathan and Schoelkopf, Hailey and Gokaslan, Aaron and Soldaini, Luca and Pyatkin, Valentina and Castricato, Louis},
+  journal={arXiv preprint arXiv:2407.18421},
+  year={2024}
+}
+
+@inproceedings{sun2023principledriven,
+title={Principle-Driven Self-Alignment of Language Models from Scratch with Minimal Human Supervision},
+author={Zhiqing Sun and Yikang Shen and Qinhong Zhou and Hongxin Zhang and Zhenfang Chen and David Daniel Cox and Yiming Yang and Chuang Gan},
+booktitle={Thirty-seventh Conference on Neural Information Processing Systems},
+year={2023},
+url={https://openreview.net/forum?id=p40XRfBX96}
+}
+
+@article{franken2024self,
+  title={Self-supervised alignment with mutual information: Learning to follow principles without preference labels},
+  author={Fr{\"a}nken, Jan-Philipp and Zelikman, Eric and Rafailov, Rafael and Gandhi, Kanishk and Gerstenberg, Tobias and Goodman, Noah},
+  journal={Advances in Neural Information Processing Systems},
+  year={2024}
 }
 
 @misc{gunjal2025rubrics,
@@ -2575,17 +2702,6 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   url           = {https://arxiv.org/abs/2507.18624}
 }
 
-@misc{he2025advancedif,
-  title         = {AdvancedIF: Rubric-Based Benchmarking and Reinforcement Learning for Advancing LLM Instruction Following},
-  author        = {Yun He and Wenzhe Li and Hejia Zhang and Songlin Li and Karishma Mandyam and Sopan Khosla and Yuanhao Xiong and Nanshu Wang and Xiaoliang Peng and Beibin Li and Shengjie Bi and Shishir G. Patil and Qi Qi and Shengyu Feng and Julian Katz-Samuels and Richard Yuanzhe Pang and Sujan Gonugondla and Hunter Lang and Yue Yu and Yundi Qian and Maryam Fazel-Zarandi and Licheng Yu and Amine Benhalloum and Hany Awadalla and Manaal Faruqui},
-  year          = {2025},
-  eprint        = {2511.10507},
-  archivePrefix = {arXiv},
-  primaryClass  = {cs.CL},
-  doi           = {10.48550/arXiv.2511.10507},
-  url           = {https://arxiv.org/abs/2511.10507}
-}
-
 @misc{rezaei2025onlinerubrics,
   title         = {Online Rubrics Elicitation from Pairwise Comparisons},
   author        = {MohammadHossein Rezaei and Robert Vacareanu and Zihao Wang and Clinton Wang and Bing Liu and Yunzhong He and Afra Feyza Aky{\"u}rek},
@@ -2608,6 +2724,17 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   url           = {https://arxiv.org/abs/2510.07743}
 }
 
+@misc{he2025advancedif,
+  title         = {AdvancedIF: Rubric-Based Benchmarking and Reinforcement Learning for Advancing LLM Instruction Following},
+  author        = {Yun He and Wenzhe Li and Hejia Zhang and Songlin Li and Karishma Mandyam and Sopan Khosla and Yuanhao Xiong and Nanshu Wang and Xiaoliang Peng and Beibin Li and Shengjie Bi and Shishir G. Patil and Qi Qi and Shengyu Feng and Julian Katz-Samuels and Richard Yuanzhe Pang and Sujan Gonugondla and Hunter Lang and Yue Yu and Yundi Qian and Maryam Fazel-Zarandi and Licheng Yu and Amine Benhalloum and Hany Awadalla and Manaal Faruqui},
+  year          = {2025},
+  eprint        = {2511.10507},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.CL},
+  doi           = {10.48550/arXiv.2511.10507},
+  url           = {https://arxiv.org/abs/2511.10507}
+}
+
 @misc{shao2025drtulu,
   title         = {DR Tulu: Reinforcement Learning with Evolving Rubrics for Deep Research},
   author        = {Rulin Shao and Akari Asai and Shannon Zejiang Shen and Hamish Ivison and Varsha Kishore and Jingming Zhuo and Xinran Zhao and Molly Park and Samuel G. Finlayson and David Sontag and Tyler Murray and Sewon Min and Pradeep Dasigi and Luca Soldaini and Faeze Brahman and Wen-tau Yih and Tongshuang Wu and Luke Zettlemoyer and Yoon Kim and Hannaneh Hajishirzi and Pang Wei Koh},
@@ -2617,17 +2744,6 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   primaryClass  = {cs.CL},
   doi           = {10.48550/arXiv.2511.19399},
   url           = {https://arxiv.org/abs/2511.19399}
-}
-
-@misc{huang2025rubricanchors,
-  title         = {Reinforcement Learning with Rubric Anchors},
-  author        = {Zenan Huang and Yihong Zhuang and Guoshan Lu and Zeyu Qin and Haokai Xu and Tianyu Zhao and Ru Peng and Jiaqi Hu and Zhanming Shen and Xiaomeng Hu and Xijun Gu and Peiyi Tu and Jiaxin Liu and Wenyu Chen and Yuzhuo Fu and Zhiting Fan and Yanmei Gu and Yuanyuan Wang and Zhengkai Yang and Jianguo Li and Junbo Zhao},
-  year          = {2025},
-  eprint        = {2508.12790},
-  archivePrefix = {arXiv},
-  primaryClass  = {cs.AI},
-  doi           = {10.48550/arXiv.2508.12790},
-  url           = {https://arxiv.org/abs/2508.12790}
 }
 
 @misc{sharma2025researchrubrics,
@@ -2652,21 +2768,9 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   url           = {https://arxiv.org/abs/2506.01241}
 }
 
-@inproceedings{geng2025the,
-  title={The Delta Learning Hypothesis: Preference Tuning on Weak Data can Yield Strong Gains},
-  author={Scott Geng and Hamish Ivison and Chun-Liang Li and Maarten Sap and Jerry Li and Ranjay Krishna and Pang Wei Koh},
-  booktitle={Second Conference on Language Modeling},
-  year={2025},
-  url={https://openreview.net/forum?id=9rwtezthwo}
-}
+### End chapter 12 ###
 
-
-@inproceedings{kwon2023efficient,
-  title={Efficient Memory Management for Large Language Model Serving with PagedAttention},
-  author={Woosuk Kwon and Zhuohan Li and Siyuan Zhuang and Ying Sheng and Lianmin Zheng and Cody Hao Yu and Joseph E. Gonzalez and Hao Zhang and Ion Stoica},
-  booktitle={Proceedings of the ACM SIGOPS 29th Symposium on Operating Systems Principles},
-  year={2023}
-}
+### First appearing in chapter 13 (Tools) ###
 
 @inproceedings{reed2015neural,
   title={Neural programmer-interpreters},
@@ -2716,16 +2820,34 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   year = {2024}
 }
 
-@inproceedings{qin2023toollm,
-  title         = {ToolLLM: Facilitating Large Language Models to Master 16000+ Real-world APIs},
-  booktitle = {International Conference on Learning Representations (ICLR)},
-  author        = {Qin, Yujia and Liang, Shihao and Ye, Yining and Zhu, Kunlun and Yan, Lan and Lu, Yaxi and Lin, Yankai and Cong, Xin and Tang, Xiangru and Qian, Bill and Zhao, Sihan and Hong, Lauren and Tian, Runchu and Xie, Ruobing and Zhou, Jie and Gerstein, Mark and Li, Dahai and Liu, Zhiyuan and Sun, Maosong},
-  year = {2024},
-  month         = jul,
-  archivePrefix = {arXiv},
-  primaryClass  = {cs.AI},
-  doi           = {10.48550/arXiv.2307.16789},
-  url           = {https://arxiv.org/abs/2307.16789}
+@Misc{anthropic_mcp_2024,
+  title        = {Model Context Protocol (MCP)},
+  author       = {{Anthropic}},
+  howpublished = {\url{https://modelcontextprotocol.io/}},
+  year         = {2024},
+  month        = nov # "~25",
+  note         = {Open‑source protocol for connecting LLMs to external tools and data},
+}
+
+@article{bran2023chemcrow,
+  title={Chemcrow: Augmenting large-language models with chemistry tools},
+  author={Bran, Andres M and Cox, Sam and Schilter, Oliver and Baldassari, Carlo and White, Andrew D and Schwaller, Philippe},
+  journal={arXiv preprint arXiv:2304.05376},
+  year={2023}
+}
+
+@inproceedings{li2024mmedagent,
+  title={Mmedagent: Learning to use medical tools with multi-modal agent},
+  booktitle = {Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  author={Li, Binxu and Yan, Tiankai and Pan, Yuanting and Luo, Jie and Ji, Ruiyang and Ding, Jiayuan and Xu, Zhe and Liu, Shilong and Dong, Haoyu and Lin, Zihao and others},
+  year = {2024}
+}
+
+@article{zhang2024codeagent,
+  title={Codeagent: Enhancing code generation with tool-integrated agent systems for real-world repo-level coding challenges},
+  author={Zhang, Kechi and Li, Jia and Li, Ge and Shi, Xianjie and Jin, Zhi},
+  journal={arXiv preprint arXiv:2401.07339},
+  year={2024}
 }
 
 @misc{yao2024taubench,
@@ -2740,6 +2862,18 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   url           = {https://arxiv.org/abs/2406.12045}
 }
 
+@inproceedings{qin2023toollm,
+  title         = {ToolLLM: Facilitating Large Language Models to Master 16000+ Real-world APIs},
+  booktitle = {International Conference on Learning Representations (ICLR)},
+  author        = {Qin, Yujia and Liang, Shihao and Ye, Yining and Zhu, Kunlun and Yan, Lan and Lu, Yaxi and Lin, Yankai and Cong, Xin and Tang, Xiangru and Qian, Bill and Zhao, Sihan and Hong, Lauren and Tian, Runchu and Xie, Ruobing and Zhou, Jie and Gerstein, Mark and Li, Dahai and Liu, Zhiyuan and Sun, Maosong},
+  year = {2024},
+  month         = jul,
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.AI},
+  doi           = {10.48550/arXiv.2307.16789},
+  url           = {https://arxiv.org/abs/2307.16789}
+}
+
 @inproceedings{yao2023react,
   title={React: Synergizing reasoning and acting in language models},
   author={Yao, Shunyu and Zhao, Jeffrey and Yu, Dian and Du, Nan and Shafran, Izhak and Narasimhan, Karthik and Cao, Yuan},
@@ -2747,64 +2881,150 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   year={2023}
 }
 
-@article{bran2023chemcrow,
-  title={Chemcrow: Augmenting large-language models with chemistry tools},
-  author={Bran, Andres M and Cox, Sam and Schilter, Oliver and Baldassari, Carlo and White, Andrew D and Schwaller, Philippe},
-  journal={arXiv preprint arXiv:2304.05376},
-  year={2023}
-}
-
-@article{zhang2024codeagent,
-  title={Codeagent: Enhancing code generation with tool-integrated agent systems for real-world repo-level coding challenges},
-  author={Zhang, Kechi and Li, Jia and Li, Ge and Shi, Xianjie and Jin, Zhi},
-  journal={arXiv preprint arXiv:2401.07339},
-  year={2024}
-}
-
-@inproceedings{li2024mmedagent,
-  title={Mmedagent: Learning to use medical tools with multi-modal agent},
-  booktitle = {Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  author={Li, Binxu and Yan, Tiankai and Pan, Yuanting and Luo, Jie and Ji, Ruiyang and Ding, Jiayuan and Xu, Zhe and Liu, Shilong and Dong, Haoyu and Lin, Zihao and others},
-  year = {2024}
-}
-
-@Misc{anthropic_mcp_2024,
-  title        = {Model Context Protocol (MCP)},
-  author       = {{Anthropic}},
-  howpublished = {\url{https://modelcontextprotocol.io/}},
-  year         = {2024},
-  month        = nov # "~25",
-  note         = {Open‑source protocol for connecting LLMs to external tools and data},
-}
-
-### End chapter 12 ###
-
-### First appearing in chapter 13 (Tools) ###
-
 ### End chapter 13 ###
 
 ### First appearing in chapter 14 (Over-optimization) ###
 
-@article{wu2025reasoning,
-  title={Reasoning or memorization? unreliable results of reinforcement learning due to data contamination},
-  author={Wu, Mingqi and Zhang, Zhihao and Dong, Qiaole and Xi, Zhiheng and Zhao, Jun and Jin, Senjie and Fan, Xiaoran and Zhou, Yuhao and Lv, Huijie and Zhang, Ming and others},
-  journal={arXiv preprint arXiv:2507.10532},
-  year={2025}
+@misc{schulman2023proxy,
+  author       = {John Schulman},
+  title        = {Proxy Objectives in Reinforcement Learning from Human Feedback},
+  howpublished = {Invited talk at the International Conference on Machine Learning (ICML)},
+  year         = 2023,
+  url          = {https://icml.cc/virtual/2023/invited-talk/21549}
 }
 
-@article{singh2024evaluation,
-  title={Evaluation data contamination in LLMs: how do we measure it and (when) does it matter?},
-  author={Singh, Aaditya K and Kocyigit, Muhammed Yusuf and Poulton, Andrew and Esiobu, David and Lomeli, Maria and Szilvasy, Gergely and Hupkes, Dieuwke},
-  journal={arXiv preprint arXiv:2411.03923},
+@article{zhang2018study,
+  title={A study on overfitting in deep reinforcement learning},
+  author={Zhang, Chiyuan and Vinyals, Oriol and Munos, Remi and Bengio, Samy},
+  journal={arXiv preprint arXiv:1804.06893},
+  year={2018}
+}
+
+@book{goodhart1984problems,
+  title={Problems of monetary management: the UK experience},
+  author={Goodhart, Charles AE and Goodhart, CAE},
+  year={1984},
+  publisher={Springer}
+}
+
+@article{hoskin1996awful,
+  title={The ‘awful idea of accountability’: inscribing people into the measurement of objects},
+  author={Hoskin, Keith},
+  journal={Accountability: Power, ethos and the technologies of managing},
+  volume={265},
+  year={1996},
+  publisher={International Thomson Business Press London}
+}
+
+@inproceedings{lu2011learning,
+  title={Learning Mallows models with pairwise preferences},
+  author={Lu, Tyler and Boutilier, Craig},
+  booktitle={Proceedings of the 28th international conference on machine learning (icml-11)},
+  pages={145--152},
+  year={2011}
+}
+
+@inproceedings{han2024wildguard,
+  title={Wildguard: Open one-stop moderation tools for safety risks, jailbreaks, and refusals of llms},
+  booktitle = {Advances in Neural Information Processing Systems (NeurIPS)},
+  author={Han, Seungju and Rao, Kavel and Ettinger, Allyson and Jiang, Liwei and Lin, Bill Yuchen and Lambert, Nathan and Choi, Yejin and Dziri, Nouha},
+  year = {2024}
+}
+
+@article{inan2023llama,
+  title={Llama guard: Llm-based input-output safeguard for human-ai conversations},
+  author={Inan, Hakan and Upasani, Kartikeya and Chi, Jianfeng and Rungta, Rashi and Iyer, Krithika and Mao, Yuning and Tontchev, Michael and Hu, Qing and Fuller, Brian and Testuggine, Davide and others},
+  journal={arXiv preprint arXiv:2312.06674},
+  year={2023}
+}
+
+@inproceedings{rottger2023xstest,
+  title={Xstest: A test suite for identifying exaggerated safety behaviours in large language models},
+  booktitle = {Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  author={R{\"o}ttger, Paul and Kirk, Hannah Rose and Vidgen, Bertie and Attanasio, Giuseppe and Bianchi, Federico and Hovy, Dirk},
+  year = {2024}
+}
+
+@inproceedings{coste2023reward,
+  title={Reward model ensembles help mitigate overoptimization},
+  booktitle = {International Conference on Learning Representations (ICLR)},
+  author={Coste, Thomas and Anwar, Usman and Kirk, Robert and Krueger, David},
+  year = {2024}
+}
+
+@inproceedings{moskovitz2023confronting,
+  title={Confronting reward model overoptimization with constrained RLHF},
+  booktitle = {International Conference on Learning Representations (ICLR)},
+  author={Moskovitz, Ted and Singh, Aaditya K and Strouse, DJ and Sandholm, Tuomas and Salakhutdinov, Ruslan and Dragan, Anca D and McAleer, Stephen},
+  year = {2024}
+}
+
+@article{rafailov2024scaling,
+  title={Scaling laws for reward model overoptimization in direct alignment algorithms},
+  author={Rafailov, Rafael and Chittepu, Yaswanth and Park, Ryan and Sikchi, Harshit Sushil and Hejna, Joey and Knox, Brad and Finn, Chelsea and Niekum, Scott},
+  journal={Advances in Neural Information Processing Systems},
+  volume={37},
+  pages={126207--126242},
   year={2024}
 }
 
-@inproceedings{huang2025math,
-  title={MATH-Perturb: Benchmarking LLMs' Math Reasoning Abilities against Hard Perturbations},
-  booktitle = {International Conference on Machine Learning (ICML)},
-  author={Huang, Kaixuan and Guo, Jiacheng and Li, Zihao and Ji, Xiang and Ge, Jiawei and Li, Wenzhe and Guo, Yingqing and Cai, Tianle and Yuan, Hui and Wang, Runzhe and others},
-  year = {2025}
+@article{zhuang2020consequences,
+  title={Consequences of misaligned AI},
+  author={Zhuang, Simon and Hadfield-Menell, Dylan},
+  journal={Advances in Neural Information Processing Systems},
+  volume={33},
+  pages={15763--15773},
+  year={2020}
 }
+
+### End chapter 14 ###
+
+### First appearing in chapter 15 (Regularization) ###
+
+@inproceedings{jaques2017sequence,
+  title={Sequence tutor: Conservative fine-tuning of sequence generation models with kl-control},
+  author={Jaques, Natasha and Gu, Shixiang and Bahdanau, Dzmitry and Hern{\'a}ndez-Lobato, Jos{\'e} Miguel and Turner, Richard E and Eck, Douglas},
+  booktitle={International Conference on Machine Learning},
+  pages={1645--1654},
+  year={2017},
+  organization={PMLR}
+}
+
+@inproceedings{jaques2020human,
+  title={Human-centric dialog training via offline reinforcement learning},
+  booktitle = {Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+  author={Jaques, Natasha and Shen, Judy Hanwen and Ghandeharioun, Asma and Ferguson, Craig and Lapedriza, Agata and Jones, Noah and Gu, Shixiang Shane and Picard, Rosalind},
+  year = {2020}
+}
+
+@misc{chen2025retainingdoingroleonpolicy,
+  title={Retaining by Doing: The Role of On-Policy Data in Mitigating Forgetting},
+  author={Howard Chen and Noam Razin and Karthik Narasimhan and Danqi Chen},
+  year={2025},
+  eprint={2510.18874},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG},
+  url={https://arxiv.org/abs/2510.18874},
+}
+
+@inproceedings{shenfeld2026rls,
+title={{RL}'s Razor: Why Online Reinforcement Learning Forgets Less},
+author={Idan Shenfeld and Jyothish Pari and Pulkit Agrawal},
+booktitle={The Fourteenth International Conference on Learning Representations},
+year={2026},
+url={https://openreview.net/forum?id=7HNRYT4V44}
+}
+
+@inproceedings{pang2024iterative,
+  title={Iterative reasoning preference optimization},
+  booktitle = {Advances in Neural Information Processing Systems (NeurIPS)},
+  author={Pang, Richard Yuanzhe and Yuan, Weizhe and Cho, Kyunghyun and He, He and Sukhbaatar, Sainbayar and Weston, Jason},
+  year = {2024}
+}
+
+### End chapter 15 ###
+
+### First appearing in chapter 16 (Evaluation) ###
 
 @inproceedings{hendrycks2020measuring,
   title={Measuring massive multitask language understanding},
@@ -2827,6 +3047,27 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   year = {2022}
 }
 
+@inproceedings{suzgun2022challenging,
+  title={Challenging BIG-Bench Tasks and Whether Chain-of-Thought Can Solve Them},
+  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
+  author={Suzgun, Mirac and Scales, Nathan and Sch{\"a}rli, Nathanael and Gehrmann, Sebastian and Tay, Yi and Chung, Hyung Won and Chowdhery, Aakanksha and Le, Quoc V and Chi, Ed H and Zhou, Denny and and Wei, Jason},
+  year = {2023}
+}
+
+@inproceedings{dua2019drop,
+  title={DROP: A reading comprehension benchmark requiring discrete reasoning over paragraphs},
+  booktitle = {Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
+  author={Dua, Dheeru and Wang, Yizhong and Dasigi, Pradeep and Stanovsky, Gabriel and Singh, Sameer and Gardner, Matt},
+  year = {2019}
+}
+
+@article{hendrycksmath2021,
+  title={Measuring Mathematical Problem Solving With the MATH Dataset},
+  author={Dan Hendrycks and Collin Burns and Saurav Kadavath and Akul Arora and Steven Basart and Eric Tang and Dawn Song and Jacob Steinhardt},
+  journal={NeurIPS},
+  year={2021}
+}
+
 @article{chen2021codex,
   title={Evaluating Large Language Models Trained on Code},
   author={Mark Chen and Jerry Tworek and Heewoo Jun and Qiming Yuan and Henrique Ponde de Oliveira Pinto and Jared Kaplan and Harri Edwards and Yuri Burda and Nicholas Joseph and Greg Brockman and Alex Ray and Raul Puri and Gretchen Krueger and Michael Petrov and Heidy Khlaaf and Girish Sastry and Pamela Mishkin and Brooke Chan and Scott Gray and Nick Ryder and Mikhail Pavlov and Alethea Power and Lukasz Kaiser and Mohammad Bavarian and Clemens Winter and Philippe Tillet and Felipe Petroski Such and Dave Cummings and Matthias Plappert and Fotios Chantzis and Elizabeth Barnes and Ariel Herbert-Voss and William Hebgen Guss and Alex Nichol and Alex Paino and Nikolas Tezak and Jie Tang and Igor Babuschkin and Suchir Balaji and Shantanu Jain and William Saunders and Christopher Hesse and Andrew N. Carr and Jan Leike and Josh Achiam and Vedant Misra and Evan Morikawa and Alec Radford and Matthew Knight and Miles Brundage and Mira Murati and Katie Mayer and Peter Welinder and Bob McGrew and Dario Amodei and Sam McCandlish and Ilya Sutskever and Wojciech Zaremba},
@@ -2842,35 +3083,6 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   booktitle = {Thirty-seventh Conference on Neural Information Processing Systems},
   year = {2023},
   url = {https://openreview.net/forum?id=1qvx610Cu7},
-}
-
-@article{hendrycksmath2021,
-  title={Measuring Mathematical Problem Solving With the MATH Dataset},
-  author={Dan Hendrycks and Collin Burns and Saurav Kadavath and Akul Arora and Steven Basart and Eric Tang and Dawn Song and Jacob Steinhardt},
-  journal={NeurIPS},
-  year={2021}
-}
-
-@inproceedings{suzgun2022challenging,
-  title={Challenging BIG-Bench Tasks and Whether Chain-of-Thought Can Solve Them},
-  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
-  author={Suzgun, Mirac and Scales, Nathan and Sch{\"a}rli, Nathanael and Gehrmann, Sebastian and Tay, Yi and Chung, Hyung Won and Chowdhery, Aakanksha and Le, Quoc V and Chi, Ed H and Zhou, Denny and and Wei, Jason},
-  year = {2023}
-}
-
-@inproceedings{dua2019drop,
-  title={DROP: A reading comprehension benchmark requiring discrete reasoning over paragraphs},
-  booktitle = {Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  author={Dua, Dheeru and Wang, Yizhong and Dasigi, Pradeep and Stanovsky, Gabriel and Singh, Sameer and Gardner, Matt},
-  year = {2019}
-}
-
-@misc{scale2024seal,
-  author       = {Scale AI},
-  title        = {SEAL LLM Leaderboards: Expert-Driven Private Evaluations},
-  year         = {2024},
-  url          = {https://scale.com/leaderboard},
-  note         = {Accessed: 2025-04-10}
 }
 
 @article{rein2023gpqa,
@@ -2901,6 +3113,21 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   year={2024}
 }
 
+@misc{scale2024seal,
+  author       = {Scale AI},
+  title        = {SEAL LLM Leaderboards: Expert-Driven Private Evaluations},
+  year         = {2024},
+  url          = {https://scale.com/leaderboard},
+  note         = {Accessed: 2025-04-10}
+}
+
+@article{schulhoff2024prompt,
+  title={The prompt report: A systematic survey of prompting techniques},
+  author={Schulhoff, Sander and Ilie, Michael and Balepur, Nishant and Kahadze, Konstantine and Liu, Amanda and Si, Chenglei and Li, Yinheng and Gupta, Aayush and Han, HyoJung and Schulhoff, Sevien and others},
+  journal={arXiv preprint arXiv:2406.06608},
+  year={2024}
+}
+
 @inproceedings{robinson2023leveraging,
   title={Leveraging Large Language Models for Multiple Choice Question Answering},
   author={Robinson, Joshua and Rytting, Christopher Michael and Wingate, David},
@@ -2909,13 +3136,13 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   url={https://openreview.net/forum?id=upQ4o-ygvJ}
 }
 
-
-
-@article{schulhoff2024prompt,
-  title={The prompt report: A systematic survey of prompting techniques},
-  author={Schulhoff, Sander and Ilie, Michael and Balepur, Nishant and Kahadze, Konstantine and Liu, Amanda and Si, Chenglei and Li, Yinheng and Gupta, Aayush and Han, HyoJung and Schulhoff, Sevien and others},
-  journal={arXiv preprint arXiv:2406.06608},
-  year={2024}
+@article{wei2022chain,
+  title={Chain-of-thought prompting elicits reasoning in large language models},
+  author={Wei, Jason and Wang, Xuezhi and Schuurmans, Dale and Bosma, Maarten and Xia, Fei and Chi, Ed and Le, Quoc V and Zhou, Denny and others},
+  journal={Advances in neural information processing systems},
+  volume={35},
+  pages={24824--24837},
+  year={2022}
 }
 
 @article{kojima2022large,
@@ -2927,6 +3154,29 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   year={2022}
 }
 
+@article{li2024numinamath,
+  title={Numinamath: The largest public dataset in ai4maths with 860k pairs of competition math problems and solutions},
+  author={Li, Jia and Beeching, Edward and Tunstall, Lewis and Lipkin, Ben and Soletskyi, Roman and Huang, Shengyi and Rasul, Kashif and Yu, Longhui and Jiang, Albert Q and Shen, Ziju and others},
+  journal={Hugging Face repository},
+  volume={13},
+  pages={9},
+  year={2024}
+}
+
+@inproceedings{yu2023metamath,
+  title={Metamath: Bootstrap your own mathematical questions for large language models},
+  booktitle = {International Conference on Learning Representations (ICLR)},
+  author={Yu, Longhui and Jiang, Weisen and Shi, Han and Yu, Jincheng and Liu, Zhengying and Zhang, Yu and Kwok, James T and Li, Zhenguo and Weller, Adrian and Liu, Weiyang},
+  year = {2024}
+}
+
+@article{achiam2023gpt,
+  title={Gpt-4 technical report},
+  author={Achiam, Josh and Adler, Steven and Agarwal, Sandhini and Ahmad, Lama and Akkaya, Ilge and Aleman, Florencia Leoni and Almeida, Diogo and Altenschmidt, Janko and Altman, Sam and Anadkat, Shyamal and others},
+  journal={arXiv preprint arXiv:2303.08774},
+  year={2023}
+}
+
 @misc{openai2024swebench,
   title        = {Introducing SWE-bench Verified},
   author       = {{OpenAI}},
@@ -2936,11 +3186,39 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   note         = {Accessed: 2025-04-12}
 }
 
+@article{singh2024evaluation,
+  title={Evaluation data contamination in LLMs: how do we measure it and (when) does it matter?},
+  author={Singh, Aaditya K and Kocyigit, Muhammed Yusuf and Poulton, Andrew and Esiobu, David and Lomeli, Maria and Szilvasy, Gergely and Hupkes, Dieuwke},
+  journal={arXiv preprint arXiv:2411.03923},
+  year={2024}
+}
+
+@article{wu2025reasoning,
+  title={Reasoning or memorization? unreliable results of reinforcement learning due to data contamination},
+  author={Wu, Mingqi and Zhang, Zhihao and Dong, Qiaole and Xi, Zhiheng and Zhao, Jun and Jin, Senjie and Fan, Xiaoran and Zhou, Yuhao and Lv, Huijie and Zhang, Ming and others},
+  journal={arXiv preprint arXiv:2507.10532},
+  year={2025}
+}
+
+@inproceedings{huang2025math,
+  title={MATH-Perturb: Benchmarking LLMs' Math Reasoning Abilities against Hard Perturbations},
+  booktitle = {International Conference on Machine Learning (ICML)},
+  author={Huang, Kaixuan and Guo, Jiacheng and Li, Zihao and Ji, Xiang and Ge, Jiawei and Li, Wenzhe and Guo, Yingqing and Cai, Tianle and Yuan, Hui and Wang, Runzhe and others},
+  year = {2025}
+}
+
 @misc{inspectAI2024,
   author       = {{UK AI Safety Institute}},
   title        = {{Inspect AI: Framework for Large Language Model Evaluations}},
   year         = {2024},
   howpublished = {\url{https://github.com/UKGovernmentBEIS/inspect_ai}}
+}
+
+@misc{fourrier2023lighteval,
+  author       = {Fourrier, Clementine and Habib, Nathan and Kydlicek, Hynek and Wolf, Thomas and Tunstall, Lewis},
+  title        = {{LightEval: A lightweight framework for LLM evaluation}},
+  year         = {2023},
+  howpublished = {\url{https://github.com/huggingface/lighteval}}
 }
 
 @misc{open-llm-leaderboard-v2,
@@ -2951,13 +3229,6 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   howpublished = "\url{https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard}",
 }
 
-@misc{fourrier2023lighteval,
-  author       = {Fourrier, Clementine and Habib, Nathan and Kydlicek, Hynek and Wolf, Thomas and Tunstall, Lewis},
-  title        = {{LightEval: A lightweight framework for LLM evaluation}},
-  year         = {2023},
-  howpublished = {\url{https://github.com/huggingface/lighteval}}
-}
-
 @misc{gao2023evalharness,
   author       = {Gao, Leo and Tow, Jonathan and Abbasi, Baber and Biderman, Stella and Black, Sid and DiPofi, Anthony and Foster, Charles and Golding, Laurence and Hsu, Jeffrey and Le Noac'h, Alain and Li, Haonan and McDonell, Kyle and Muennighoff, Niklas and Ociepa, Chris and Phang, Jason and Reynolds, Laria and Schoelkopf, Hailey and Skowron, Aviya and Sutawika, Lintang and Tang, Eric and Thite, Anish and Wang, Ben and Wang, Kevin and Zou, Andy},
   title        = {{A Framework for Few-Shot Language Model Evaluation}},
@@ -2965,6 +3236,14 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   publisher    = {Zenodo},
   doi          = {10.5281/zenodo.10256836},
   url          = {https://zenodo.org/record/10256836}
+}
+
+@inproceedings{gpt-neox-20b,
+  title={{GPT-NeoX-20B}: An Open-Source Autoregressive Language Model},
+  author={Black, Sid and Biderman, Stella and Hallahan, Eric and Anthony, Quentin and Gao, Leo and Golding, Laurence and He, Horace and Leahy, Connor and McDonell, Kyle and Phang, Jason and Pieler, Michael and Prashanth, USVSN Sai and Purohit, Shivanshu and Reynolds, Laria and Tow, Jonathan and Wang, Ben and Weinbach, Samuel},
+  booktitle={Proceedings of the ACL Workshop on Challenges \& Perspectives in Creating Large Language Models},
+  url={https://arxiv.org/abs/2204.06745},
+  year={2022}
 }
 
 @inproceedings{gu2024olmes,
@@ -2991,183 +3270,15 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   note         = {Accessed 2024-05-29}
 }
 
-@article{achiam2023gpt,
-  title={Gpt-4 technical report},
-  author={Achiam, Josh and Adler, Steven and Agarwal, Sandhini and Ahmad, Lama and Akkaya, Ilge and Aleman, Florencia Leoni and Almeida, Diogo and Altenschmidt, Janko and Altman, Sam and Anadkat, Shyamal and others},
-  journal={arXiv preprint arXiv:2303.08774},
-  year={2023}
-}
-
-@inproceedings{gpt-neox-20b,
-  title={{GPT-NeoX-20B}: An Open-Source Autoregressive Language Model},
-  author={Black, Sid and Biderman, Stella and Hallahan, Eric and Anthony, Quentin and Gao, Leo and Golding, Laurence and He, Horace and Leahy, Connor and McDonell, Kyle and Phang, Jason and Pieler, Michael and Prashanth, USVSN Sai and Purohit, Shivanshu and Reynolds, Laria and Tow, Jonathan and Wang, Ben and Weinbach, Samuel},
-  booktitle={Proceedings of the ACL Workshop on Challenges \& Perspectives in Creating Large Language Models},
-  url={https://arxiv.org/abs/2204.06745},
-  year={2022}
-}
-
-@article{li2024numinamath,
-  title={Numinamath: The largest public dataset in ai4maths with 860k pairs of competition math problems and solutions},
-  author={Li, Jia and Beeching, Edward and Tunstall, Lewis and Lipkin, Ben and Soletskyi, Roman and Huang, Shengyi and Rasul, Kashif and Yu, Longhui and Jiang, Albert Q and Shen, Ziju and others},
-  journal={Hugging Face repository},
-  volume={13},
-  pages={9},
-  year={2024}
-}
-
-@inproceedings{yu2023metamath,
-  title={Metamath: Bootstrap your own mathematical questions for large language models},
-  booktitle = {International Conference on Learning Representations (ICLR)},
-  author={Yu, Longhui and Jiang, Weisen and Shi, Han and Yu, Jincheng and Liu, Zhengying and Zhang, Yu and Kwok, James T and Li, Zhenguo and Weller, Adrian and Liu, Weiyang},
-  year = {2024}
-}
-
-### End chapter 14 ###
-
-### First appearing in chapter 15 (Regularization) ###
-
-@inproceedings{jaques2020human,
-  title={Human-centric dialog training via offline reinforcement learning},
-  booktitle = {Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-  author={Jaques, Natasha and Shen, Judy Hanwen and Ghandeharioun, Asma and Ferguson, Craig and Lapedriza, Agata and Jones, Noah and Gu, Shixiang Shane and Picard, Rosalind},
-  year = {2020}
-}
-
-@inproceedings{jaques2017sequence,
-  title={Sequence tutor: Conservative fine-tuning of sequence generation models with kl-control},
-  author={Jaques, Natasha and Gu, Shixiang and Bahdanau, Dzmitry and Hern{\'a}ndez-Lobato, Jos{\'e} Miguel and Turner, Richard E and Eck, Douglas},
-  booktitle={International Conference on Machine Learning},
-  pages={1645--1654},
-  year={2017},
-  organization={PMLR}
-}
-
-@inproceedings{pang2024iterative,
-  title={Iterative reasoning preference optimization},
-  booktitle = {Advances in Neural Information Processing Systems (NeurIPS)},
-  author={Pang, Richard Yuanzhe and Yuan, Weizhe and Cho, Kyunghyun and He, He and Sukhbaatar, Sainbayar and Weston, Jason},
-  year = {2024}
-}
-
-@inproceedings{gao2024rebel,
-  title={Rebel: Reinforcement learning via regressing relative rewards},
-  booktitle = {Advances in Neural Information Processing Systems (NeurIPS)},
-  author={Gao, Zhaolin and Chang, Jonathan D and Zhan, Wenhao and Oertell, Owen and Swamy, Gokul and Brantley, Kiant{\'e} and Joachims, Thorsten and Bagnell, J Andrew and Lee, Jason D and Sun, Wen},
-  year = {2024}
-}
-
-@misc{schulman2016klapprox,
-  author = {Schulman, John},
-  title = {Approximating KL-divergence},
-  year = {2016},
-  howpublished = {\url{http://joschu.net/blog/kl-approx.html}},
-  note = {Accessed: 2024-10-01}
-}
-
-### End chapter 15 ###
-
-### First appearing in chapter 16 (Evaluation) ###
-
-@inproceedings{wang2022self,
-  title={Self-instruct: Aligning language models with self-generated instructions},
-  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
-  author={Wang, Yizhong and Kordi, Yeganeh and Mishra, Swaroop and Liu, Alisa and Smith, Noah A and Khashabi, Daniel and Hajishirzi, Hannaneh},
-  year = {2023}
-}
-
-@misc{numina_math_7b,
-  author = {Edward Beeching and Shengyi Costa Huang and Albert Jiang and Jia Li and Benjamin Lipkin and Zihan Qina and Kashif Rasul and Ziju Shen and Roman Soletskyi and Lewis Tunstall},
-  title = {NuminaMath 7B TIR},
-  year = {2024},
-  publisher = {Numina & Hugging Face},
-  journal = {Hugging Face repository},
-  howpublished = {\url{https://huggingface.co/AI-MO/NuminaMath-7B-TIR}}
-}
-
-@article{shridhar2023distilling,
-  title={Distilling reasoning capabilities into smaller language models},
-  author={Shridhar, Kumar and Stolfo, Alessandro and Sachan, Mrinmaya},
-  journal={Findings of the Association for Computational Linguistics: ACL 2023},
-  pages={7059--7073},
-  year={2023},
-  publisher={Association for Computational Linguistics}
-}
-
-@inproceedings{hsieh2023distilling,
-  title={Distilling Step-by-Step! Outperforming Larger Language Models with Less Training Data and Smaller Model Sizes},
-  author={Hsieh, Cheng-Yu and Li, Chun-Liang and Yeh, Chih-kuan and Nakhost, Hootan and Fujii, Yasuhisa and Ratner, Alex and Krishna, Ranjay and Lee, Chen-Yu and Pfister, Tomas},
-  booktitle={Findings of the Association for Computational Linguistics: ACL 2023},
-  year={2023},
-  url={https://aclanthology.org/2023.findings-acl.507/},
-  doi={10.18653/v1/2023.findings-acl.507},
-  pages={8003--8017}
-}
-
-@article{gerstgrasser2024model,
-  title={Is model collapse inevitable? breaking the curse of recursion by accumulating real and synthetic data},
-  author={Gerstgrasser, Matthias and Schaeffer, Rylan and Dey, Apratim and Rafailov, Rafael and Sleight, Henry and Hughes, John and Korbak, Tomasz and Agrawal, Rajashree and Pai, Dhruv and Gromov, Andrey and others},
-  journal={arXiv preprint arXiv:2404.01413},
-  year={2024}
-}
-
-@inproceedings{feng2024beyond,
-  title={Beyond model collapse: Scaling up with synthesized data requires reinforcement},
-  author={Feng, Yunzhen and Dohmatob, Elvis and Yang, Pu and Charton, Francois and Kempe, Julia},
-  booktitle={ICML 2024 Workshop on Theoretical Foundations of Foundation Models},
-  year={2024}
-}
-
-@article{shumailov2024ai,
-  title={AI models collapse when trained on recursively generated data},
-  author={Shumailov, Ilia and Shumaylov, Zakhar and Zhao, Yiren and Papernot, Nicolas and Anderson, Ross and Gal, Yarin},
-  journal={Nature},
-  volume={631},
-  number={8022},
-  pages={755--759},
-  year={2024},
-  publisher={Nature Publishing Group UK London}
-}
-
-@inproceedings{li2024superfiltering,
-  title={Superfiltering: Weak-to-strong data filtering for fast instruction-tuning},
-  booktitle = {Annual Meeting of the Association for Computational Linguistics (ACL)},
-  author={Li, Ming and Zhang, Yong and He, Shwai and Li, Zhitao and Zhao, Hongyu and Wang, Jianzong and Cheng, Ning and Zhou, Tianyi},
-  year = {2024}
-}
-
 ### End chapter 16 ###
 
 ### First appearing in chapter 17 (Product & Character) ###
-
-@inproceedings{wang2023openchat,
-  title={Openchat: Advancing open-source language models with mixed-quality data},
-  booktitle = {International Conference on Learning Representations (ICLR)},
-  author={Wang, Guan and Cheng, Sijie and Zhan, Xianyuan and Li, Xiangang and Song, Sen and Liu, Yang},
-  year = {2024}
-}
-
-@article{qwen,
-  title={Qwen Technical Report},
-  author={Jinze Bai and Shuai Bai and Yunfei Chu and Zeyu Cui and Kai Dang and Xiaodong Deng and Yang Fan and Wenbin Ge and Yu Han and Fei Huang and Binyuan Hui and Luo Ji and Mei Li and Junyang Lin and Runji Lin and Dayiheng Liu and Gao Liu and Chengqiang Lu and Keming Lu and Jianxin Ma and Rui Men and Xingzhang Ren and Xuancheng Ren and Chuanqi Tan and Sinan Tan and Jianhong Tu and Peng Wang and Shijie Wang and Wei Wang and Shengguang Wu and Benfeng Xu and Jin Xu and An Yang and Hao Yang and Jian Yang and Shusheng Yang and Yang Yao and Bowen Yu and Hongyi Yuan and Zheng Yuan and Jianwei Zhang and Xingxuan Zhang and Yichang Zhang and Zhenru Zhang and Chang Zhou and Jingren Zhou and Xiaohuan Zhou and Tianhang Zhu},
-  journal={arXiv preprint arXiv:2309.16609},
-  year={2023}
-}
-
 
 @article{maiya2025open,
   title={Open Character Training: Shaping the Persona of AI Assistants through Constitutional AI},
   author={Maiya, Sharan and Bartsch, Henning and Lambert, Nathan and Hubinger, Evan},
   journal={arXiv preprint arXiv:2511.01689},
   year={2025}
-}
-
-@misc{anthropic2024claude,
-  author       = {{Anthropic}},
-  title        = {Claude’s Character},
-  year         = {2024},
-  month        = {June},
-  url          = {https://www.anthropic.com/research/claude-character},
-  note         = {Accessed: 2025-04-16}
 }
 
 @article{turner2023activation,
@@ -3188,14 +3299,28 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   url={https://arxiv.org/abs/2507.21509}
 }
 
-@misc{feng2026persona,
-  title={PERSONA: Algebraic Personality Composition in Language Models},
-  author={Zhaoyang Feng and Yiwei Li and Tianqing Fang and Dongyao Li and Zhiwei He and Jun Yan and Wenjie Li},
-  year={2026},
-  eprint={2502.13131},
-  archivePrefix={arXiv},
-  primaryClass={cs.CL},
-  url={https://arxiv.org/abs/2502.13131}
+@misc{anthropic2024claude,
+  author       = {{Anthropic}},
+  title        = {Claude’s Character},
+  year         = {2024},
+  month        = {June},
+  url          = {https://www.anthropic.com/research/claude-character},
+  note         = {Accessed: 2025-04-16}
+}
+
+@article{mikolov2013efficient,
+  title={Efficient estimation of word representations in vector space},
+  author={Mikolov, Tomas and Chen, Kai and Corrado, Greg and Dean, Jeffrey},
+  journal={arXiv preprint arXiv:1301.3781},
+  year={2013}
+}
+
+@inproceedings{zou2024representation,
+  title={Representation Engineering: A Top-Down Approach to {AI} Transparency},
+  author={Zou, Andy and Phan, Long and Chen, Sarah and Campbell, James and Guo, Phillip and Ren, Richard and Pan, Alexander and Yin, Xuwang and Mazeika, Mantas and Dombrowski, Ann-Kathrin and Goel, Shashwat and Li, Nathaniel and Byun, Michael J and Wang, Zifan and Mallen, Alex and Basart, Steven and Koyejo, Sanmi and Song, Dawn and Fredrikson, Matt and Kolter, J Zico and Hendrycks, Dan},
+  booktitle={Proceedings of the 62nd Annual Meeting of the Association for Computational Linguistics},
+  year={2024},
+  url={https://aclanthology.org/2024.acl-long.828/}
 }
 
 @misc{bas2026actuallysteermultibehaviorstudy,
@@ -3206,6 +3331,40 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   archivePrefix={arXiv},
   primaryClass={cs.AI},
   url={https://arxiv.org/abs/2511.18284}
+}
+
+@misc{feng2026persona,
+  title={PERSONA: Algebraic Personality Composition in Language Models},
+  author={Zhaoyang Feng and Yiwei Li and Tianqing Fang and Dongyao Li and Zhiwei He and Jun Yan and Wenjie Li},
+  year={2026},
+  eprint={2502.13131},
+  archivePrefix={arXiv},
+  primaryClass={cs.CL},
+  url={https://arxiv.org/abs/2502.13131}
+}
+
+@article{lu2026assistant,
+  title={The Assistant Axis: Situating and Stabilizing the Default Persona of Language Models},
+  author={Colin Lu and James Gallagher and Joanna Michala and Karina Fish and Jack Lindsey},
+  year={2026},
+  journal={arXiv preprint arXiv:2601.10387},
+  url={https://arxiv.org/abs/2601.10387}
+}
+
+@inproceedings{ye2026personality,
+  title={Your Language Model Secretly Contains Personality Subnetworks},
+  author={Ruimeng Ye and Zihan Wang and Zinan Ling and Yang Xiao and Manling Li and Xiaolong Ma and Bo Hui},
+  booktitle={The Fourteenth International Conference on Learning Representations},
+  year={2026},
+  url={https://openreview.net/forum?id=zzo3Sy3NSX}
+}
+
+@inproceedings{frankle2019lottery,
+  title={The Lottery Ticket Hypothesis: Finding Sparse, Trainable Neural Networks},
+  author={Jonathan Frankle and Michael Carbin},
+  booktitle={International Conference on Learning Representations},
+  year={2019},
+  url={https://openreview.net/forum?id=rJl-b3RcF7}
 }
 
 @misc{anthropic2025souldoc,
@@ -3251,219 +3410,33 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   year={2024}
 }
 
-@inproceedings{agarwal2024policy,
-  title={On-policy distillation of language models: Learning from self-generated mistakes},
-  author={Agarwal, Rishabh and Vieillard, Nino and Zhou, Yongchao and Stanczyk, Piotr and Ramos Garea, Sabela and Geist, Matthieu and Bachem, Olivier},
-  booktitle={The Twelfth International Conference on Learning Representations},
-  year={2024},
-  url={https://openreview.net/forum?id=3zKtaqxLhW}
-}
-
-@inproceedings{arora-etal-2022-exposure,
-    title = "Why Exposure Bias Matters: An Imitation Learning Perspective of Error Accumulation in Language Generation",
-    author = "Arora, Kushal  and
-      El Asri, Layla  and
-      Bahuleyan, Hareesh  and
-      Cheung, Jackie Chi Kit",
-    editor = "Muresan, Smaranda  and
-      Nakov, Preslav  and
-      Villavicencio, Aline",
-    booktitle = "Findings of the Association for Computational Linguistics: ACL 2022",
-    month = may,
-    year = "2022",
-    address = "Dublin, Ireland",
-    publisher = "Association for Computational Linguistics",
-    url = "https://aclanthology.org/2022.findings-acl.58/",
-    doi = "10.18653/v1/2022.findings-acl.58",
-    pages = "700--710",
-    abstract = "Current language generation models suffer from issues such as repetition, incoherence, and hallucinations. An often-repeated hypothesis for this brittleness of generation models is that it is caused by the training and the generation procedure mismatch, also referred to as exposure bias. In this paper, we verify this hypothesis by analyzing exposure bias from an imitation learning perspective. We show that exposure bias leads to an accumulation of errors during generation, analyze why perplexity fails to capture this accumulation of errors, and empirically show that this accumulation results in poor generation quality."
-}
-
-@misc{song2026surveyonpolicydistillationlarge,
-  title={A Survey of On-Policy Distillation for Large Language Models},
-  author={Song, Mingyang and Zheng, Mao},
-  year={2026},
-  eprint={2604.00626},
-  archivePrefix={arXiv},
-  primaryClass={cs.LG},
-  url={https://arxiv.org/abs/2604.00626}
-}
-
-@article{hinton2015distilling,
-  title={Distilling the knowledge in a neural network},
-  author={Hinton, Geoffrey and Vinyals, Oriol and Dean, Jeff},
-  journal={arXiv preprint arXiv:1503.02531},
-  year={2015}
-}
-
-@article{wei2022chain,
-  title={Chain-of-thought prompting elicits reasoning in large language models},
-  author={Wei, Jason and Wang, Xuezhi and Schuurmans, Dale and Bosma, Maarten and Xia, Fei and Chi, Ed and Le, Quoc V and Zhou, Denny and others},
-  journal={Advances in neural information processing systems},
-  volume={35},
-  pages={24824--24837},
-  year={2022}
-}
-
 ### End appendix A ###
 
 ### First appearing in appendix B (Style & Information) ###
 
-@article{zhang2018study,
-  title={A study on overfitting in deep reinforcement learning},
-  author={Zhang, Chiyuan and Vinyals, Oriol and Munos, Remi and Bengio, Samy},
-  journal={arXiv preprint arXiv:1804.06893},
-  year={2018}
-}
-
-@article{hoskin1996awful,
-  title={The ‘awful idea of accountability’: inscribing people into the measurement of objects},
-  author={Hoskin, Keith},
-  journal={Accountability: Power, ethos and the technologies of managing},
-  volume={265},
-  year={1996},
-  publisher={International Thomson Business Press London}
-}
-
-@inproceedings{coste2023reward,
-  title={Reward model ensembles help mitigate overoptimization},
-  booktitle = {International Conference on Learning Representations (ICLR)},
-  author={Coste, Thomas and Anwar, Usman and Kirk, Robert and Krueger, David},
-  year = {2024}
-}
-
-@inproceedings{moskovitz2023confronting,
-  title={Confronting reward model overoptimization with constrained RLHF},
-  booktitle = {International Conference on Learning Representations (ICLR)},
-  author={Moskovitz, Ted and Singh, Aaditya K and Strouse, DJ and Sandholm, Tuomas and Salakhutdinov, Ruslan and Dragan, Anca D and McAleer, Stephen},
-  year = {2024}
-}
-
-@article{rafailov2024scaling,
-  title={Scaling laws for reward model overoptimization in direct alignment algorithms},
-  author={Rafailov, Rafael and Chittepu, Yaswanth and Park, Ryan and Sikchi, Harshit Sushil and Hejna, Joey and Knox, Brad and Finn, Chelsea and Niekum, Scott},
-  journal={Advances in Neural Information Processing Systems},
-  volume={37},
-  pages={126207--126242},
-  year={2024}
-}
-
-@inproceedings{rottger2023xstest,
-  title={Xstest: A test suite for identifying exaggerated safety behaviours in large language models},
-  booktitle = {Conference of the North American Chapter of the Association for Computational Linguistics (NAACL)},
-  author={R{\"o}ttger, Paul and Kirk, Hannah Rose and Vidgen, Bertie and Attanasio, Giuseppe and Bianchi, Federico and Hovy, Dirk},
-  year = {2024}
-}
-
-@inproceedings{han2024wildguard,
-  title={Wildguard: Open one-stop moderation tools for safety risks, jailbreaks, and refusals of llms},
-  booktitle = {Advances in Neural Information Processing Systems (NeurIPS)},
-  author={Han, Seungju and Rao, Kavel and Ettinger, Allyson and Jiang, Liwei and Lin, Bill Yuchen and Lambert, Nathan and Choi, Yejin and Dziri, Nouha},
-  year = {2024}
-}
-
-@article{inan2023llama,
-  title={Llama guard: Llm-based input-output safeguard for human-ai conversations},
-  author={Inan, Hakan and Upasani, Kartikeya and Chi, Jianfeng and Rungta, Rashi and Iyer, Krithika and Mao, Yuning and Tontchev, Michael and Hu, Qing and Fuller, Brian and Testuggine, Davide and others},
-  journal={arXiv preprint arXiv:2312.06674},
+@article{qwen,
+  title={Qwen Technical Report},
+  author={Jinze Bai and Shuai Bai and Yunfei Chu and Zeyu Cui and Kai Dang and Xiaodong Deng and Yang Fan and Wenbin Ge and Yu Han and Fei Huang and Binyuan Hui and Luo Ji and Mei Li and Junyang Lin and Runji Lin and Dayiheng Liu and Gao Liu and Chengqiang Lu and Keming Lu and Jianxin Ma and Rui Men and Xingzhang Ren and Xuancheng Ren and Chuanqi Tan and Sinan Tan and Jianhong Tu and Peng Wang and Shijie Wang and Wei Wang and Shengguang Wu and Benfeng Xu and Jin Xu and An Yang and Hao Yang and Jian Yang and Shusheng Yang and Yang Yao and Bowen Yu and Hongyi Yuan and Zheng Yuan and Jianwei Zhang and Xingxuan Zhang and Yichang Zhang and Zhenru Zhang and Chang Zhou and Jingren Zhou and Xiaohuan Zhou and Tianhang Zhu},
+  journal={arXiv preprint arXiv:2309.16609},
   year={2023}
 }
 
-@inproceedings{lu2011learning,
-  title={Learning Mallows models with pairwise preferences},
-  author={Lu, Tyler and Boutilier, Craig},
-  booktitle={Proceedings of the 28th international conference on machine learning (icml-11)},
-  pages={145--152},
-  year={2011}
-}
-
-@misc{schulman2023proxy,
-  author       = {John Schulman},
-  title        = {Proxy Objectives in Reinforcement Learning from Human Feedback},
-  howpublished = {Invited talk at the International Conference on Machine Learning (ICML)},
-  year         = 2023,
-  url          = {https://icml.cc/virtual/2023/invited-talk/21549}
-}
-
-@book{goodhart1984problems,
-  title={Problems of monetary management: the UK experience},
-  author={Goodhart, Charles AE and Goodhart, CAE},
-  year={1984},
-  publisher={Springer}
-}
-
-@article{zhuang2020consequences,
-  title={Consequences of misaligned AI},
-  author={Zhuang, Simon and Hadfield-Menell, Dylan},
-  journal={Advances in Neural Information Processing Systems},
-  volume={33},
-  pages={15763--15773},
-  year={2020}
+@inproceedings{wang2023openchat,
+  title={Openchat: Advancing open-source language models with mixed-quality data},
+  booktitle = {International Conference on Learning Representations (ICLR)},
+  author={Wang, Guan and Cheng, Sijie and Zhan, Xianyuan and Li, Xiangang and Song, Sen and Liu, Yang},
+  year = {2024}
 }
 
 ### End appendix B ###
 
-### Begin Extra Appendix Citations ###
+### First appearing in appendix C (Practical Issues) ###
+
 @article{yadav2024matters,
   title={What Matters for Model Merging at Scale?},
   author={Yadav, Prateek and Vu, Tu and Lai, Jonathan and Chronopoulou, Alexandra and Faruqui, Manaal and Bansal, Mohit and Munkhdalai, Tsendsuren},
   journal={arXiv preprint arXiv:2410.03617},
   year={2024}
 }
-@misc{deepseekai2025deepseekv3technicalreport,
-      title={DeepSeek-V3 Technical Report},
-      author={DeepSeek-AI and Aixin Liu and Bei Feng and Bing Xue and Bingxuan Wang and Bochao Wu and Chengda Lu and Chenggang Zhao and Chengqi Deng and Chenyu Zhang and Chong Ruan and Damai Dai and Daya Guo and Dejian Yang and Deli Chen and Dongjie Ji and Erhang Li and Fangyun Lin and Fucong Dai and Fuli Luo and Guangbo Hao and Guanting Chen and Guowei Li and H. Zhang and Han Bao and Hanwei Xu and Haocheng Wang and Haowei Zhang and Honghui Ding and Huajian Xin and Huazuo Gao and Hui Li and Hui Qu and J. L. Cai and Jian Liang and Jianzhong Guo and Jiaqi Ni and Jiashi Li and Jiawei Wang and Jin Chen and Jingchang Chen and Jingyang Yuan and Junjie Qiu and Junlong Li and Junxiao Song and Kai Dong and Kai Hu and Kaige Gao and Kang Guan and Kexin Huang and Kuai Yu and Lean Wang and Lecong Zhang and Lei Xu and Leyi Xia and Liang Zhao and Litong Wang and Liyue Zhang and Meng Li and Miaojun Wang and Mingchuan Zhang and Minghua Zhang and Minghui Tang and Mingming Li and Ning Tian and Panpan Huang and Peiyi Wang and Peng Zhang and Qiancheng Wang and Qihao Zhu and Qinyu Chen and Qiushi Du and R. J. Chen and R. L. Jin and Ruiqi Ge and Ruisong Zhang and Ruizhe Pan and Runji Wang and Runxin Xu and Ruoyu Zhang and Ruyi Chen and S. S. Li and Shanghao Lu and Shangyan Zhou and Shanhuang Chen and Shaoqing Wu and Shengfeng Ye and Shengfeng Ye and Shirong Ma and Shiyu Wang and Shuang Zhou and Shuiping Yu and Shunfeng Zhou and Shuting Pan and T. Wang and Tao Yun and Tian Pei and Tianyu Sun and W. L. Xiao and Wangding Zeng and Wanjia Zhao and Wei An and Wen Liu and Wenfeng Liang and Wenjun Gao and Wenqin Yu and Wentao Zhang and X. Q. Li and Xiangyue Jin and Xianzu Wang and Xiao Bi and Xiaodong Liu and Xiaohan Wang and Xiaojin Shen and Xiaokang Chen and Xiaokang Zhang and Xiaosha Chen and Xiaotao Nie and Xiaowen Sun and Xiaoxiang Wang and Xin Cheng and Xin Liu and Xin Xie and Xingchao Liu and Xingkai Yu and Xinnan Song and Xinxia Shan and Xinyi Zhou and Xinyu Yang and Xinyuan Li and Xuecheng Su and Xuheng Lin and Y. K. Li and Y. Q. Wang and Y. X. Wei and Y. X. Zhu and Yang Zhang and Yanhong Xu and Yanhong Xu and Yanping Huang and Yao Li and Yao Zhao and Yaofeng Sun and Yaohui Li and Yaohui Wang and Yi Yu and Yi Zheng and Yichao Zhang and Yifan Shi and Yiliang Xiong and Ying He and Ying Tang and Yishi Piao and Yisong Wang and Yixuan Tan and Yiyang Ma and Yiyuan Liu and Yongqiang Guo and Yu Wu and Yuan Ou and Yuchen Zhu and Yuduan Wang and Yue Gong and Yuheng Zou and Yujia He and Yukun Zha and Yunfan Xiong and Yunxian Ma and Yuting Yan and Yuxiang Luo and Yuxiang You and Yuxuan Liu and Yuyang Zhou and Z. F. Wu and Z. Z. Ren and Zehui Ren and Zhangli Sha and Zhe Fu and Zhean Xu and Zhen Huang and Zhen Zhang and Zhenda Xie and Zhengyan Zhang and Zhewen Hao and Zhibin Gou and Zhicheng Ma and Zhigang Yan and Zhihong Shao and Zhipeng Xu and Zhiyu Wu and Zhongyu Zhang and Zhuoshu Li and Zihui Gu and Zijia Zhu and Zijun Liu and Zilin Li and Ziwei Xie and Ziyang Song and Ziyi Gao and Zizheng Pan},
-      year={2025},
-      eprint={2412.19437},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL},
-      url={https://arxiv.org/abs/2412.19437},
-}
-@inproceedings{ye2026personality,
-  title={Your Language Model Secretly Contains Personality Subnetworks},
-  author={Ruimeng Ye and Zihan Wang and Zinan Ling and Yang Xiao and Manling Li and Xiaolong Ma and Bo Hui},
-  booktitle={The Fourteenth International Conference on Learning Representations},
-  year={2026},
-  url={https://openreview.net/forum?id=zzo3Sy3NSX}
-}
 
-@inproceedings{frankle2019lottery,
-  title={The Lottery Ticket Hypothesis: Finding Sparse, Trainable Neural Networks},
-  author={Jonathan Frankle and Michael Carbin},
-  booktitle={International Conference on Learning Representations},
-  year={2019},
-  url={https://openreview.net/forum?id=rJl-b3RcF7}
-}
-
-@article{lu2026assistant,
-  title={The Assistant Axis: Situating and Stabilizing the Default Persona of Language Models},
-  author={Colin Lu and James Gallagher and Joanna Michala and Karina Fish and Jack Lindsey},
-  year={2026},
-  journal={arXiv preprint arXiv:2601.10387},
-  url={https://arxiv.org/abs/2601.10387}
-}
-
-@article{dai2023safe,
-  title={Safe RLHF: Safe Reinforcement Learning from Human Feedback},
-  author={Josef Dai and Xuehai Pan and Ruiyang Sun and Jiaming Ji and Xinbo Xu and Mickel Liu and Yizhou Wang and Yaodong Yang},
-  year={2023},
-  journal={arXiv preprint arXiv:2310.12773},
-  url={https://arxiv.org/abs/2310.12773}
-}
-
-@article{mikolov2013efficient,
-  title={Efficient estimation of word representations in vector space},
-  author={Mikolov, Tomas and Chen, Kai and Corrado, Greg and Dean, Jeffrey},
-  journal={arXiv preprint arXiv:1301.3781},
-  year={2013}
-}
-
-@inproceedings{zou2024representation,
-  title={Representation Engineering: A Top-Down Approach to {AI} Transparency},
-  author={Zou, Andy and Phan, Long and Chen, Sarah and Campbell, James and Guo, Phillip and Ren, Richard and Pan, Alexander and Yin, Xuwang and Mazeika, Mantas and Dombrowski, Ann-Kathrin and Goel, Shashwat and Li, Nathaniel and Byun, Michael J and Wang, Zifan and Mallen, Alex and Basart, Steven and Koyejo, Sanmi and Song, Dawn and Fredrikson, Matt and Kolter, J Zico and Hendrycks, Dan},
-  booktitle={Proceedings of the 62nd Annual Meeting of the Association for Computational Linguistics},
-  year={2024},
-  url={https://aclanthology.org/2024.acl-long.828/}
-}
-
-### End Extra Appendix Citations ###
+### End appendix C ###

--- a/book/scripts/check_bib_integrity.py
+++ b/book/scripts/check_bib_integrity.py
@@ -18,7 +18,10 @@ from pathlib import Path
 
 
 BIB_ENTRY_START_RE = re.compile(r"@\w+\s*\{\s*([^,\s]+)\s*,")
-CITATION_RE = re.compile(r"(?<![\w:-])-?@([A-Za-z0-9_-]+(?::[A-Za-z0-9_-]+)?)")
+CITATION_RE = re.compile(
+    r"(?<![\w:-])-?@(?:\{([^}\n]+)\}|"
+    r"([A-Za-z0-9_](?:[A-Za-z0-9_]|[:.#$%&\-+?<>~/](?=[A-Za-z0-9_]))*))"
+)
 FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
 SECTION_HEADER_RE = re.compile(
     r"^### First appearing in (chapter \d+|appendix [A-Z]) .+ ###$"
@@ -239,10 +242,8 @@ def extract_citations(content: str) -> list[tuple[str, int]]:
     citations: list[tuple[str, int]] = []
     content = strip_fenced_code(content)
     for match in CITATION_RE.finditer(content):
-        key = match.group(1)
+        key = match.group(1) or match.group(2)
         if key.startswith(CROSS_REF_PREFIXES):
-            continue
-        if ":" in key:
             continue
         line = content.count("\n", 0, match.start()) + 1
         citations.append((key, line))

--- a/book/scripts/check_bib_integrity.py
+++ b/book/scripts/check_bib_integrity.py
@@ -1,121 +1,473 @@
 #!/usr/bin/env python3
-"""Check bib.bib for duplicate keys and unused entries."""
+"""Check and optionally normalize the book bibliography.
 
+The bibliography is grouped by the chapter where each key first appears. By
+default this script only reports duplicate keys, missing citations, unused
+entries, and order drift. Pass --fix to rewrite bib.bib by removing unused
+entries and sorting the remaining entries by first citation appearance.
+"""
+
+from __future__ import annotations
+
+import argparse
 import re
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
 from pathlib import Path
-from collections import Counter
 
-def extract_bib_entry(content: str, key: str, start_line: int) -> str:
-    """Extract the full bib entry starting from a given line."""
-    lines = content.split('\n')
-    entry_lines = []
-    brace_count = 0
-    started = False
 
-    for i, line in enumerate(lines[start_line - 1:], start_line):
-        if not started:
-            if re.match(rf'^@\w+\{{{re.escape(key)},', line):
-                started = True
-                brace_count += line.count('{') - line.count('}')
-                entry_lines.append(line)
-        else:
-            brace_count += line.count('{') - line.count('}')
-            entry_lines.append(line)
-            if brace_count <= 0:
-                break
+BIB_ENTRY_START_RE = re.compile(r"@\w+\s*\{\s*([^,\s]+)\s*,")
+CITATION_RE = re.compile(r"(?<![\w:-])-?@([A-Za-z0-9_-]+(?::[A-Za-z0-9_-]+)?)")
+FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
+SECTION_HEADER_RE = re.compile(
+    r"^### First appearing in (chapter \d+|appendix [A-Z]) .+ ###$"
+)
+SECTION_END_RE = re.compile(r"^### End (chapter \d+|appendix [A-Z]) ###$")
+CROSS_REF_PREFIXES = (
+    "chap:",
+    "def:",
+    "eq:",
+    "fig:",
+    "lst:",
+    "sec:",
+    "tbl:",
+    "thm:",
+)
 
-    return '\n'.join(entry_lines)
 
-def main():
-    bib_path = Path("book/chapters/bib.bib")
-    chapters_dir = Path("book/chapters")
+@dataclass(frozen=True)
+class BibEntry:
+    key: str
+    line: int
+    text: str
 
-    # Extract all bib keys with line numbers
-    bib_content = bib_path.read_text()
-    key_pattern = re.compile(r'^@\w+\{([^,]+),', re.MULTILINE)
 
-    keys_with_lines = []
-    for i, line in enumerate(bib_content.split('\n'), 1):
-        match = re.match(r'^@\w+\{([^,]+),', line)
-        if match:
-            keys_with_lines.append((match.group(1), i))
+@dataclass(frozen=True)
+class Section:
+    id: str
+    header: str
+    end: str
+    path: Path
 
-    all_keys = [k for k, _ in keys_with_lines]
 
-    # Find duplicates
+@dataclass(frozen=True)
+class CitationLocation:
+    key: str
+    section_id: str
+    chapter_path: Path
+    line: int
+    order: int
+
+
+@dataclass
+class BibReport:
+    entries: list[BibEntry]
+    duplicates: dict[str, int]
+    duplicate_lines: dict[str, list[int]]
+    citations: list[CitationLocation]
+    first_locations: dict[str, CitationLocation]
+    missing_keys: set[str]
+    unused_keys: set[str]
+    expected_order: list[str]
+    current_used_order: list[str]
+
+    @property
+    def has_order_drift(self) -> bool:
+        return self.expected_order != self.current_used_order
+
+    @property
+    def has_problems(self) -> bool:
+        return bool(
+            self.duplicates
+            or self.missing_keys
+            or self.unused_keys
+            or self.has_order_drift
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--bib-file",
+        type=Path,
+        default=Path("book/chapters/bib.bib"),
+        help="Path to the BibTeX file to check.",
+    )
+    parser.add_argument(
+        "--chapters-dir",
+        type=Path,
+        default=Path("book/chapters"),
+        help="Directory containing book chapter markdown files.",
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Remove unused entries and sort bib.bib by first citation appearance.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit with a non-zero status if any issues remain.",
+    )
+    return parser.parse_args()
+
+
+def parse_bib_entries(content: str) -> list[BibEntry]:
+    entries: list[BibEntry] = []
+    for match in BIB_ENTRY_START_RE.finditer(content):
+        start = match.start()
+        brace_count = 0
+        end = None
+        for index in range(start, len(content)):
+            char = content[index]
+            if char == "{":
+                brace_count += 1
+            elif char == "}":
+                brace_count -= 1
+                if brace_count == 0:
+                    end = index + 1
+                    break
+
+        if end is None:
+            raise ValueError(f"Could not find end of entry for key {match.group(1)}")
+
+        line = content.count("\n", 0, start) + 1
+        entries.append(BibEntry(key=match.group(1), line=line, text=content[start:end]))
+
+    return entries
+
+
+def extract_page_title(path: Path) -> str:
+    content = path.read_text()
+    frontmatter = re.search(r"^---\n(.*?)\n---", content, re.DOTALL | re.MULTILINE)
+    if frontmatter:
+        title = re.search(r'^page-title:\s*"?([^"\n]+)"?\s*$', frontmatter.group(1), re.MULTILINE)
+        if title:
+            value = title.group(1).strip()
+            value = re.sub(r"^Appendix [A-Z]:\s*", "", value)
+            return value
+
+    heading = re.search(r"^#\s+(.+)$", content, re.MULTILINE)
+    if heading:
+        return heading.group(1).strip()
+
+    return path.stem.replace("-", " ").title()
+
+
+def section_id_from_marker(marker: str) -> str:
+    if marker.startswith("chapter "):
+        return "chapter-" + marker.removeprefix("chapter ")
+    return "appendix-" + marker.removeprefix("appendix ")
+
+
+def existing_section_lines(content: str) -> tuple[dict[str, str], dict[str, str]]:
+    headers: dict[str, str] = {}
+    ends: dict[str, str] = {}
+    for line in content.splitlines():
+        header = SECTION_HEADER_RE.match(line)
+        if header:
+            headers[section_id_from_marker(header.group(1))] = line
+            continue
+
+        end = SECTION_END_RE.match(line)
+        if end:
+            ends[section_id_from_marker(end.group(1))] = line
+
+    return headers, ends
+
+
+def chapter_files(chapters_dir: Path) -> list[Path]:
+    files = []
+    for path in sorted(chapters_dir.glob("*.md")):
+        if path.name in {"README.md", "appendix-00-references.md"}:
+            continue
+        files.append(path)
+    return files
+
+
+def section_for_path(
+    path: Path,
+    existing_headers: dict[str, str],
+    existing_ends: dict[str, str],
+) -> Section | None:
+    chapter = re.match(r"^(\d+)-", path.name)
+    if chapter:
+        number = str(int(chapter.group(1)))
+        section_id = f"chapter-{number}"
+        title = extract_page_title(path)
+        return Section(
+            id=section_id,
+            header=existing_headers.get(
+                section_id, f"### First appearing in chapter {number} ({title}) ###"
+            ),
+            end=existing_ends.get(section_id, f"### End chapter {number} ###"),
+            path=path,
+        )
+
+    appendix = re.match(r"^appendix-([a-z])-", path.name)
+    if appendix:
+        letter = appendix.group(1).upper()
+        section_id = f"appendix-{letter}"
+        title = extract_page_title(path)
+        return Section(
+            id=section_id,
+            header=existing_headers.get(
+                section_id, f"### First appearing in appendix {letter} ({title}) ###"
+            ),
+            end=existing_ends.get(section_id, f"### End appendix {letter} ###"),
+            path=path,
+        )
+
+    return None
+
+
+def book_sections(chapters_dir: Path, bib_content: str) -> list[Section]:
+    existing_headers, existing_ends = existing_section_lines(bib_content)
+    sections = [
+        section_for_path(path, existing_headers, existing_ends)
+        for path in chapter_files(chapters_dir)
+    ]
+    return [section for section in sections if section is not None]
+
+
+def strip_fenced_code(content: str) -> str:
+    return FENCED_CODE_RE.sub(lambda match: "\n" * match.group(0).count("\n"), content)
+
+
+def extract_citations(content: str) -> list[tuple[str, int]]:
+    citations: list[tuple[str, int]] = []
+    content = strip_fenced_code(content)
+    for match in CITATION_RE.finditer(content):
+        key = match.group(1)
+        if key.startswith(CROSS_REF_PREFIXES):
+            continue
+        if ":" in key:
+            continue
+        line = content.count("\n", 0, match.start()) + 1
+        citations.append((key, line))
+    return citations
+
+
+def collect_citations(sections: list[Section]) -> list[CitationLocation]:
+    locations: list[CitationLocation] = []
+    order = 0
+    for section in sections:
+        content = section.path.read_text()
+        for key, line in extract_citations(content):
+            locations.append(
+                CitationLocation(
+                    key=key,
+                    section_id=section.id,
+                    chapter_path=section.path,
+                    line=line,
+                    order=order,
+                )
+            )
+            order += 1
+    return locations
+
+
+def analyze_bib(bib_content: str, chapters_dir: Path) -> BibReport:
+    entries = parse_bib_entries(bib_content)
+    key_counts = Counter(entry.key for entry in entries)
+    duplicates = {key: count for key, count in key_counts.items() if count > 1}
+
+    duplicate_lines: dict[str, list[int]] = defaultdict(list)
+    for entry in entries:
+        if entry.key in duplicates:
+            duplicate_lines[entry.key].append(entry.line)
+
+    sections = book_sections(chapters_dir, bib_content)
+    citations = collect_citations(sections)
+
+    first_locations: dict[str, CitationLocation] = {}
+    for citation in citations:
+        first_locations.setdefault(citation.key, citation)
+
+    unique_bib_keys = set(key_counts)
+    cited_keys = set(first_locations)
+    missing_keys = cited_keys - unique_bib_keys
+    unused_keys = unique_bib_keys - cited_keys
+
+    expected_order = [
+        citation.key
+        for citation in sorted(first_locations.values(), key=lambda item: item.order)
+        if citation.key in unique_bib_keys
+    ]
+    current_used_order = [entry.key for entry in entries if entry.key in cited_keys]
+
+    return BibReport(
+        entries=entries,
+        duplicates=duplicates,
+        duplicate_lines=dict(duplicate_lines),
+        citations=citations,
+        first_locations=first_locations,
+        missing_keys=missing_keys,
+        unused_keys=unused_keys,
+        expected_order=expected_order,
+        current_used_order=current_used_order,
+    )
+
+
+def print_duplicate_report(report: BibReport, entries_by_key: dict[str, BibEntry]) -> None:
     print("=" * 70)
-    print("DUPLICATE KEYS (with full entries for comparison)")
+    print("DUPLICATE KEYS")
     print("=" * 70)
-    key_counts = Counter(all_keys)
-    duplicates = {k: v for k, v in key_counts.items() if v > 1}
-
-    if duplicates:
-        for key, count in sorted(duplicates.items()):
-            lines = [line for k, line in keys_with_lines if k == key]
-            print(f"\n>>> {key}: appears {count} times at lines {lines}")
-            print("-" * 70)
-            for line_num in lines:
-                entry = extract_bib_entry(bib_content, key, line_num)
-                print(f"[Line {line_num}]")
-                print(entry)
-                print()
-    else:
+    if not report.duplicates:
         print("  No duplicates found!")
+        return
 
-    # Read all markdown files and find citations
+    for key, count in sorted(report.duplicates.items()):
+        lines = report.duplicate_lines[key]
+        print(f"  {key}: appears {count} times at lines {lines}")
+        if key in entries_by_key:
+            print(entries_by_key[key].text)
+
+
+def print_unused_report(report: BibReport) -> None:
     print("\n" + "=" * 70)
     print("UNUSED BIB ENTRIES")
     print("=" * 70)
+    print(
+        f"\nFound {len(report.unused_keys)} unused entries out of "
+        f"{len(set(entry.key for entry in report.entries))} total:\n"
+    )
+    if not report.unused_keys:
+        print("  No unused entries found!")
+        return
 
-    all_citations = set()
-    md_files = list(chapters_dir.glob("*.md"))
+    unused_entries = [entry for entry in report.entries if entry.key in report.unused_keys]
+    for entry in unused_entries:
+        print(f"  Line {entry.line:4d}: {entry.key}")
 
-    for md_file in md_files:
-        content = md_file.read_text()
-        # Match [@key] or [@key1; @key2] or [@key1;@key2] patterns
-        citations = re.findall(r'\[@([^\]@;]+?)(?:[;\s]|(?=\]))', content)
-        all_citations.update(citations)
-        # Also match multi-citations like [@key1; @key2]
-        multi_cites = re.findall(r'\[([^\]]+)\]', content)
-        for mc in multi_cites:
-            if '@' in mc:
-                # Extract all @key references
-                refs = re.findall(r'@([^;\s\]]+)', mc)
-                all_citations.update(refs)
 
-    unique_keys = set(all_keys)
-    unused_keys = unique_keys - all_citations
+def print_missing_report(report: BibReport) -> None:
+    print("\n" + "=" * 70)
+    print("MISSING BIB ENTRIES")
+    print("=" * 70)
+    if not report.missing_keys:
+        print("  No missing entries found!")
+        return
 
-    # Sort unused keys and show with line numbers
-    unused_with_lines = []
-    for key in unused_keys:
-        for k, line in keys_with_lines:
-            if k == key:
-                unused_with_lines.append((key, line))
-                break
+    for key in sorted(report.missing_keys):
+        location = report.first_locations[key]
+        print(f"  {key}: {location.chapter_path}:{location.line}")
 
-    unused_with_lines.sort(key=lambda x: x[1])
 
-    print(f"\nFound {len(unused_keys)} unused entries out of {len(unique_keys)} total:\n")
-    for key, line in unused_with_lines:
-        print(f"  Line {line:4d}: {key}")
+def print_order_report(report: BibReport) -> None:
+    print("\n" + "=" * 70)
+    print("FIRST-APPEARANCE ORDER")
+    print("=" * 70)
+    if not report.has_order_drift:
+        print("  Bibliography entries already match first citation order.")
+        return
 
-    # Summary
+    print("  Bibliography entries are not in first citation order.")
+    print("  First mismatches:")
+    mismatch_count = 0
+    for index, (expected, current) in enumerate(
+        zip(report.expected_order, report.current_used_order), start=1
+    ):
+        if expected == current:
+            continue
+        expected_loc = report.first_locations[expected]
+        current_loc = report.first_locations.get(current)
+        current_detail = ""
+        if current_loc:
+            current_detail = f" first used in {current_loc.chapter_path.name}:{current_loc.line}"
+        print(
+            f"  {index:4d}: expected {expected} "
+            f"({expected_loc.chapter_path.name}:{expected_loc.line}), "
+            f"found {current}{current_detail}"
+        )
+        mismatch_count += 1
+        if mismatch_count >= 20:
+            break
+
+
+def print_summary(report: BibReport) -> None:
     print("\n" + "=" * 70)
     print("SUMMARY")
     print("=" * 70)
-    print(f"  Total bib entries: {len(all_keys)}")
+    unique_keys = set(entry.key for entry in report.entries)
+    print(f"  Total bib entries: {len(report.entries)}")
     print(f"  Unique bib keys: {len(unique_keys)}")
-    print(f"  Duplicate keys: {len(duplicates)}")
-    print(f"  Citations found in markdown: {len(all_citations)}")
-    print(f"  Unused entries: {len(unused_keys)}")
+    print(f"  Duplicate keys: {len(report.duplicates)}")
+    print(f"  Citations found in markdown: {len(set(report.first_locations))}")
+    print(f"  Missing entries: {len(report.missing_keys)}")
+    print(f"  Unused entries: {len(report.unused_keys)}")
+    print(f"  First-appearance order drift: {report.has_order_drift}")
 
-    # Show citations that don't exist in bib (potential typos)
-    missing = all_citations - unique_keys
-    if missing:
-        print(f"\n  WARNING: {len(missing)} citations reference non-existent keys:")
-        for key in sorted(missing):
-            print(f"    - {key}")
+
+def print_report(report: BibReport) -> None:
+    first_entries_by_key: dict[str, BibEntry] = {}
+    for entry in report.entries:
+        first_entries_by_key.setdefault(entry.key, entry)
+
+    print_duplicate_report(report, first_entries_by_key)
+    print_unused_report(report)
+    print_missing_report(report)
+    print_order_report(report)
+    print_summary(report)
+
+
+def build_clean_bib(bib_content: str, chapters_dir: Path, report: BibReport) -> str:
+    if report.duplicates:
+        duplicate_list = ", ".join(sorted(report.duplicates))
+        raise ValueError(f"Refusing to rewrite bib with duplicate keys: {duplicate_list}")
+
+    entries_by_key = {entry.key: entry for entry in report.entries}
+    sections = book_sections(chapters_dir, bib_content)
+    entries_by_section: dict[str, list[BibEntry]] = defaultdict(list)
+
+    for key in report.expected_order:
+        location = report.first_locations[key]
+        entries_by_section[location.section_id].append(entries_by_key[key])
+
+    chunks: list[str] = []
+    for section in sections:
+        entries = entries_by_section.get(section.id, [])
+        if not entries:
+            continue
+
+        chunks.append(section.header)
+        chunks.extend(entry.text.rstrip() for entry in entries)
+        chunks.append(section.end)
+
+    return "\n\n".join(chunks).rstrip() + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+
+    bib_content = args.bib_file.read_text()
+    report = analyze_bib(bib_content, args.chapters_dir)
+    print_report(report)
+
+    if args.fix:
+        print("\n" + "=" * 70)
+        print("APPLYING FIXES")
+        print("=" * 70)
+        new_content = build_clean_bib(bib_content, args.chapters_dir, report)
+        if new_content == bib_content:
+            print("  No changes needed.")
+        else:
+            args.bib_file.write_text(new_content)
+            removed = len(report.unused_keys)
+            print(f"  Rewrote {args.bib_file}")
+            print(f"  Removed {removed} unused entries.")
+            print("  Sorted entries by first citation appearance.")
+            bib_content = new_content
+            report = analyze_bib(bib_content, args.chapters_dir)
+            print("\nPost-fix verification:")
+            print_summary(report)
+
+    if args.strict and report.has_problems:
+        return 1
+
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Extend `book/scripts/check_bib_integrity.py` so bibliography checks can also fix unused entries and first-appearance ordering.
- Re-run the web bibliography cleanup for `book/chapters/bib.bib`, removing three unused entries and sorting the remaining 406 entries by first citation appearance.
- Move previously extra appendix citations into their actual first-appearance chapter or appendix sections.

## Validation

- `uv run python book/scripts/check_bib_integrity.py --strict`
- `uv run python -m py_compile book/scripts/check_bib_integrity.py`
- `git diff --check`

## Notes

- Attempted `make html`, but the local environment is missing `pandoc` (`/bin/sh: pandoc: command not found`), so the full web build could not run here.