### PR TITLE
[codex] Polish nav resource links

### DIFF
--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -279,7 +279,7 @@
       <p class="meta">Introduction and overview of what you'll learn</p>
     </div>
     <div class="talk-actions">
-      <a href="https://www.youtube.com/watch?v=jQPiH-KB4B0&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y" class="btn btn-watch" target="_blank">
+      <a href="https://www.youtube.com/watch?v=jQPiH-KB4B0&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y" class="btn btn-watch" target="_blank" rel="noopener noreferrer">
         <svg width="14" height="14"><use href="#icon-watch"/></svg>
         Watch
       </a>
@@ -310,10 +310,10 @@
           <p class="meta">Chapters 1-3 &middot; Foundations of RLHF and post-training</p>
         </div>
         <div class="talk-actions">
-          <a href="https://www.youtube.com/watch?v=o6l6tJQgUg4&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=2" class="btn btn-watch" target="_blank"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
+          <a href="https://www.youtube.com/watch?v=o6l6tJQgUg4&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=2" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
           <a href="/teach/course/lec1-chap1-3/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
-          <a href="/teach/course/lec1-chap1-3/" class="btn" target="_blank"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
-          <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec1-chap1-3.md?plain=1" class="btn btn-source" target="_blank"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
+          <a href="/teach/course/lec1-chap1-3/" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
+          <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec1-chap1-3.md?plain=1" class="btn btn-source" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
         </div>
       </div>
       <div class="course-entry" id="lecture-2-ift-rm-rs">
@@ -322,10 +322,10 @@
           <p class="meta">Chapters 4, 5, 9 &middot; Beginning the core optimization methods section</p>
         </div>
         <div class="talk-actions">
-          <a href="https://www.youtube.com/watch?v=4gIwiSPmQkU&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=3" class="btn btn-watch" target="_blank"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
+          <a href="https://www.youtube.com/watch?v=4gIwiSPmQkU&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=3" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
           <a href="/teach/course/lec2-chap4-5-9/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
-          <a href="/teach/course/lec2-chap4-5-9/" class="btn" target="_blank"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
-          <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec2-chap4-5-9.md?plain=1" class="btn btn-source" target="_blank"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
+          <a href="/teach/course/lec2-chap4-5-9/" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
+          <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec2-chap4-5-9.md?plain=1" class="btn btn-source" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
         </div>
       </div>
       <div class="course-entry" id="lecture-3-rl-theory">
@@ -334,10 +334,10 @@
           <p class="meta">Chapter 6, Part 1 &middot; Policy gradients math, intuitions, and theory</p>
         </div>
         <div class="talk-actions">
-          <a href="https://www.youtube.com/watch?v=K_Sj_-1BUMM&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=4" class="btn btn-watch" target="_blank"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
+          <a href="https://www.youtube.com/watch?v=K_Sj_-1BUMM&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=4" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
           <a href="/teach/course/lec3-chap6-p1/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
-          <a href="/teach/course/lec3-chap6-p1/" class="btn" target="_blank"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
-          <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec3-chap6-p1.md?plain=1" class="btn btn-source" target="_blank"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
+          <a href="/teach/course/lec3-chap6-p1/" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
+          <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec3-chap6-p1.md?plain=1" class="btn btn-source" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
         </div>
       </div>
       <div class="course-entry" id="lecture-4-rl-implementation">
@@ -346,10 +346,10 @@
           <p class="meta">Chapter 6, Part 2 &middot; Code, loss aggregation, async training, and practical engineering</p>
         </div>
         <div class="talk-actions">
-          <a href="https://www.youtube.com/watch?v=i-AIMpZHgeg&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=5" class="btn btn-watch" target="_blank"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
+          <a href="https://www.youtube.com/watch?v=i-AIMpZHgeg&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=5" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
           <a href="/teach/course/lec4-chap6-p2/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
-          <a href="/teach/course/lec4-chap6-p2/" class="btn" target="_blank"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
-          <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec4-chap6-p2.md?plain=1" class="btn btn-source" target="_blank"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
+          <a href="/teach/course/lec4-chap6-p2/" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
+          <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec4-chap6-p2.md?plain=1" class="btn btn-source" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
         </div>
       </div>
     </div>
@@ -372,8 +372,8 @@
         <div class="talk-actions">
           <span class="tag">Invited Talk</span>
           <a href="/teach/SALA-2026/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
-          <a href="/teach/SALA-2026/" class="btn" target="_blank"><svg width="14" height="14"><use href="#icon-slides"/></svg> Full Screen</a>
-          <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/SALA-2026/talk.md?plain=1" class="btn btn-source" target="_blank"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
+          <a href="/teach/SALA-2026/" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-slides"/></svg> Full Screen</a>
+          <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/SALA-2026/talk.md?plain=1" class="btn btn-source" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
         </div>
       </div>
     </div>

--- a/book/templates/footer.html
+++ b/book/templates/footer.html
@@ -1,18 +1,18 @@
 <footer style="padding: 20px; text-align: center; margin-top: 2em;">
   <div style="display: flex; justify-content: center; gap: 20px; align-items: center;">
-    <a href="https://github.com/natolambert/rlhf-book" target="_blank">
+    <a href="https://github.com/natolambert/rlhf-book" target="_blank" rel="noopener noreferrer">
       <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" style="width: 40px; height: 40px;">
     </a>
-    <a href="https://arxiv.org/abs/2504.12501" target="_blank">
+    <a href="https://arxiv.org/abs/2504.12501" target="_blank" rel="noopener noreferrer">
       <img src="/assets/arxiv.svg" alt="arXiv" style="width: 40px; height: 40px;">
     </a>
-    <a href="https://www.manning.com/books/the-rlhf-book" target="_blank">
+    <a href="https://www.manning.com/books/the-rlhf-book" target="_blank" rel="noopener noreferrer">
       <img src="/assets/manning.svg" alt="Manning" style="width: 40px; height: 40px;">
     </a>
-    <a href="https://amzn.to/4cwCDJQ" target="_blank">
+    <a href="https://amzn.to/4cwCDJQ" target="_blank" rel="noopener noreferrer">
       <img src="/assets/amazon.svg" alt="Amazon" style="width: 40px; height: 40px;">
     </a>
-    <a href="https://discord.gg/yz5AwK4gBR" target="_blank">
+    <a href="https://discord.gg/yz5AwK4gBR" target="_blank" rel="noopener noreferrer">
       <img src="/assets/discord.svg" alt="Discord" style="width: 40px; height: 40px;">
     </a>
   </div>

--- a/book/templates/html.html
+++ b/book/templates/html.html
@@ -121,7 +121,7 @@ $endif$
       <h3 style="margin: 0 0 0.15em 0; font-size: 1.05em;">Welcome to the Course</h3>
       <p style="font-size: 0.88em; color: #666; margin: 0;">Video introduction and overview of the RLHF Book</p>
     </div>
-    <a href="https://www.youtube.com/watch?v=jQPiH-KB4B0&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y" target="_blank" style="display: inline-flex; align-items: center; gap: 0.4em; font-size: 0.85em; padding: 0.35em 0.7em; border-radius: 0.3em; border: 1px solid #c0392b; background: rgba(192,57,43,0.1); color: #c0392b; text-decoration: none; white-space: nowrap;">
+    <a href="https://www.youtube.com/watch?v=jQPiH-KB4B0&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y" target="_blank" rel="noopener noreferrer" style="display: inline-flex; align-items: center; gap: 0.4em; font-size: 0.85em; padding: 0.35em 0.7em; border-radius: 0.3em; border: 1px solid #c0392b; background: rgba(192,57,43,0.1); color: #c0392b; text-decoration: none; white-space: nowrap;">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3"/></svg>
       Watch
     </a>

--- a/book/templates/nav.js
+++ b/book/templates/nav.js
@@ -4,80 +4,81 @@ class NavigationDropdown extends HTMLElement {
 
       // Get the initial expanded state from the attribute, default to false
       const initialExpanded = this.getAttribute('expanded') === 'true';
+      const contentId = `navigation-dropdown-content-${NavigationDropdown.nextId++}`;
 
       this.innerHTML = `
         <div>
-          <button class="dropdown-button" aria-expanded="${initialExpanded}">
+          <button class="dropdown-button" aria-expanded="${initialExpanded}" aria-controls="${contentId}">
             <span><strong>Navigation</strong></span>
-            <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
               <path d="M19 9l-7 7-7-7" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
           </button>
 
-          <div class="dropdown-content${initialExpanded ? ' open' : ''}">
+          <div id="${contentId}" class="dropdown-content${initialExpanded ? ' open' : ''}">
     <nav class="chapter-nav">
       <div class="section">
         <h3>Links</h3>
         <ul>
-          <li><a href="https://rlhfbook.com">Home</a> / <a href="https://github.com/natolambert/rlhf-book">GitHub</a> / <a href="https://discord.gg/yz5AwK4gBR">Discord</a></li>
-          <li><a href="https://rlhfbook.com/book.pdf">PDF</a> / <a href="https://arxiv.org/abs/2504.12501">Arxiv</a> / <a href="https://rlhfbook.com/book.epub">EPUB</a> / <a href="https://rlhfbook.com/book.kindle.epub">Kindle</a></li>
+          <li><a href="/">Home</a> / <a href="https://github.com/natolambert/rlhf-book">GitHub</a> / <a href="https://discord.gg/yz5AwK4gBR">Discord</a></li>
+          <li><a href="/book.pdf">PDF</a> / <a href="https://arxiv.org/abs/2504.12501">arXiv</a> / <a href="/book.epub">EPUB</a> / <a href="/book.kindle.epub">Kindle</a></li>
           <li>Order: <a href="https://hubs.la/Q03TsMBq0">Manning</a>, <a href="https://amzn.to/4cwCDJQ">Amazon</a></li>
         </ul>
         <h3>Resources</h3>
         <ul>
-          <li><a href="https://rlhfbook.com/rl-cheatsheet">RL Cheatsheet</a></li>
-          <li><a href="https://rlhfbook.com/library">Compare Model Completions</a></li>
-          <li><a href="https://rlhfbook.com/course">Accompanying Course</a></li>
+          <li><a href="/rl-cheatsheet">RL Cheatsheet</a></li>
+          <li><a href="/library">Compare Model Completions</a></li>
+          <li><a href="/course">Accompanying Course</a></li>
         </ul>
       </div>
 
       <div class="section">
         <h3>Introductions</h3>
         <ol start="1">
-          <li><a href="https://rlhfbook.com/c/01-introduction">Introduction</a></li>
-          <li><a href="https://rlhfbook.com/c/02-related-works">A Tiny History of RLHF</a></li>
-          <li><a href="https://rlhfbook.com/c/03-training-overview">Training Overview</a></li>
+          <li><a href="/c/01-introduction">Introduction</a></li>
+          <li><a href="/c/02-related-works">A Tiny History of RLHF</a></li>
+          <li><a href="/c/03-training-overview">Training Overview</a></li>
         </ol>
       </div>
 
       <div class="section">
         <h3>Core Training Pipeline</h3>
         <ol start="4">
-          <li><a href="https://rlhfbook.com/c/04-instruction-tuning">Instruction Fine-Tuning</a></li>
-          <li><a href="https://rlhfbook.com/c/05-reward-models">Reward Modeling</a> [<a href="https://github.com/natolambert/rlhf-book/tree/main/code/reward_models">code</a>]</li>
-          <li><a href="https://rlhfbook.com/c/06-policy-gradients">Reinforcement Learning</a> [<a href="https://github.com/natolambert/rlhf-book/tree/main/code/policy_gradients">code</a>]</li>
-          <li><a href="https://rlhfbook.com/c/07-reasoning">Reasoning and Inference-Time Scaling</a></li>
-          <li><a href="https://rlhfbook.com/c/08-direct-alignment">Direct-Alignment Algorithms</a> [<a href="https://github.com/natolambert/rlhf-book/tree/main/code/direct_alignment">code</a>]</li>
-          <li><a href="https://rlhfbook.com/c/09-rejection-sampling">Rejection Sampling</a> [<a href="https://github.com/natolambert/rlhf-book/tree/main/code/rejection_sampling">code</a>]</li>
+          <li><a href="/c/04-instruction-tuning">Instruction Fine-Tuning</a></li>
+          <li><a href="/c/05-reward-models">Reward Modeling</a> [<a href="https://github.com/natolambert/rlhf-book/tree/main/code/reward_models">code</a>]</li>
+          <li><a href="/c/06-policy-gradients">Reinforcement Learning</a> [<a href="https://github.com/natolambert/rlhf-book/tree/main/code/policy_gradients">code</a>]</li>
+          <li><a href="/c/07-reasoning">Reasoning and Inference-Time Scaling</a></li>
+          <li><a href="/c/08-direct-alignment">Direct-Alignment Algorithms</a> [<a href="https://github.com/natolambert/rlhf-book/tree/main/code/direct_alignment">code</a>]</li>
+          <li><a href="/c/09-rejection-sampling">Rejection Sampling</a> [<a href="https://github.com/natolambert/rlhf-book/tree/main/code/rejection_sampling">code</a>]</li>
         </ol>
       </div>
 
       <div class="section">
         <h3>Data & Preferences</h3>
         <ol start="10">
-          <li><a href="https://rlhfbook.com/c/10-preferences">The Nature of Preferences</a></li>
-          <li><a href="https://rlhfbook.com/c/11-preference-data">Preference Data</a></li>
-          <li><a href="https://rlhfbook.com/c/12-synthetic-data">Synthetic Data</a></li>
+          <li><a href="/c/10-preferences">The Nature of Preferences</a></li>
+          <li><a href="/c/11-preference-data">Preference Data</a></li>
+          <li><a href="/c/12-synthetic-data">Synthetic Data</a></li>
         </ol>
       </div>
 
       <div class="section">
         <h3>Practical Considerations</h3>
         <ol start="13">
-          <li><a href="https://rlhfbook.com/c/13-tools">Tool Use and Function Calling</a></li>
-          <li><a href="https://rlhfbook.com/c/14-over-optimization">Over-Optimization</a></li>
-          <li><a href="https://rlhfbook.com/c/15-regularization">Regularization</a></li>
-          <li><a href="https://rlhfbook.com/c/16-evaluation">Evaluation</a></li>
-          <li><a href="https://rlhfbook.com/c/17-product">Model Character & Products</a></li>
+          <li><a href="/c/13-tools">Tool Use and Function Calling</a></li>
+          <li><a href="/c/14-over-optimization">Over-Optimization</a></li>
+          <li><a href="/c/15-regularization">Regularization</a></li>
+          <li><a href="/c/16-evaluation">Evaluation</a></li>
+          <li><a href="/c/17-product">Model Character & Products</a></li>
         </ol>
       </div>
 
       <div class="section">
         <h3>Appendices</h3>
         <ol type="A" style="padding-left: 0; list-style-position: inside;">
-          <li><a href="https://rlhfbook.com/c/appendix-a-definitions">Definitions</a></li>
-          <li><a href="https://rlhfbook.com/c/appendix-b-style">Beyond "Just Style"</a></li>
-          <li><a href="https://rlhfbook.com/c/appendix-c-practical">Practical Issues</a></li>
+          <li><a href="/c/appendix-a-definitions">Definitions</a></li>
+          <li><a href="/c/appendix-b-style">Beyond "Just Style"</a></li>
+          <li><a href="/c/appendix-c-practical">Practical Issues</a></li>
         </ol>
       </div>
     </nav>
@@ -91,6 +92,8 @@ class NavigationDropdown extends HTMLElement {
       if (searchEl && typeof PagefindUI !== 'undefined') {
         new PagefindUI({ element: searchEl, showImages: false });
       }
+
+      this.markCurrentPage();
 
       // Set up click handler
       const button = this.querySelector('.dropdown-button');
@@ -120,7 +123,21 @@ class NavigationDropdown extends HTMLElement {
         }
       }
     }
+
+    markCurrentPage() {
+      const normalizePath = (path) => path.replace(/\/index\.html$/, '/').replace(/\.html$/, '').replace(/\/$/, '') || '/';
+      const currentPath = normalizePath(window.location.pathname);
+
+      this.querySelectorAll('a[href^="/"]').forEach((link) => {
+        const linkPath = normalizePath(new URL(link.getAttribute('href'), window.location.origin).pathname);
+        if (linkPath === currentPath) {
+          link.setAttribute('aria-current', 'page');
+        }
+      });
+    }
 }
+
+NavigationDropdown.nextId = 0;
 
 // Only define the component once
 if (!customElements.get('navigation-dropdown')) {

--- a/book/templates/nav.js
+++ b/book/templates/nav.js
@@ -26,8 +26,8 @@ class NavigationDropdown extends HTMLElement {
         <h3>Resources</h3>
         <ul>
           <li><a href="https://rlhfbook.com/rl-cheatsheet">RL Cheatsheet</a></li>
-          <li><a href="https://rlhfbook.com/library">Completions Library</a></li>
-          <li><a href="https://rlhfbook.com/course">Course</a></li>
+          <li><a href="https://rlhfbook.com/library">Compare Model Completions</a></li>
+          <li><a href="https://rlhfbook.com/course">Accompanying Course</a></li>
         </ul>
       </div>
 

--- a/book/templates/style.css
+++ b/book/templates/style.css
@@ -534,6 +534,9 @@ thead {
     color: #0066cc;
     text-decoration: none;
   }
+  .section a[aria-current="page"] {
+    font-weight: bold;
+  }
   .section a:hover {
     text-decoration: underline;
   }


### PR DESCRIPTION
## Summary

Updates the Resources nav labels so the course link reads "Accompanying Course" and the completions library link reads "Compare Model Completions".

Also folds in a few small navigation cleanups:

- use root-relative URLs for internal nav links
- add `aria-controls` to the dropdown button and mark the current page with `aria-current="page"`
- add a light visual style for the current nav item
- add `rel="noopener noreferrer"` to new-tab links in shared/course templates
- normalize `arXiv` capitalization in the nav

## Impact

This keeps the shared nav friendlier in deploy previews/local previews, improves small accessibility details, and adds standard new-tab link hygiene. External URLs and page structure are otherwise unchanged.

## Validation

- `node --check book/templates/nav.js`
- `git diff --check`
- Confirmed no `target="_blank"` links in `book/templates` are missing `rel`
- Confirmed no `https://rlhfbook.com` or `Arxiv` strings remain in `book/templates/nav.js`