### PR TITLE
[codex] Lock mobile chapter overflow

### DIFF
--- a/book/templates/style.css
+++ b/book/templates/style.css
@@ -9,6 +9,7 @@
 html {
     font-size: 100%;
     overflow-y: scroll;
+    overflow-x: hidden;
     -webkit-text-size-adjust: 100%;
     -ms-text-size-adjust: 100%;
 }
@@ -21,6 +22,7 @@ body {
     padding: 1em;
     margin: auto;
     max-width: 42em;
+    overflow-x: hidden;
     background: #fefefe;
 }
 
@@ -318,7 +320,8 @@ td {
     vertical-align: top;
 }
 
-.table-scroll {
+.table-scroll,
+.table-wrap {
     max-width: 100%;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
@@ -333,24 +336,23 @@ td {
     width: max-content;
 }
 
-.table-wrap {
-    margin: 1.5em auto 2em;
-}
-
 .table-wrap table {
     margin: 0 auto;
 }
 
-.table-scroll::-webkit-scrollbar {
+.table-scroll::-webkit-scrollbar,
+.table-wrap::-webkit-scrollbar {
     height: 8px;
 }
 
-.table-scroll::-webkit-scrollbar-thumb {
+.table-scroll::-webkit-scrollbar-thumb,
+.table-wrap::-webkit-scrollbar-thumb {
     background-color: rgba(0, 0, 0, 0.2);
     border-radius: 4px;
 }
 
-.table-scroll::-webkit-scrollbar-track {
+.table-scroll::-webkit-scrollbar-track,
+.table-wrap::-webkit-scrollbar-track {
     background: rgba(0, 0, 0, 0.05);
 }
 


### PR DESCRIPTION
## Summary

- Prevent the page root/body from horizontally scrolling on mobile.
- Make Pandoc/crossref `.table-wrap` elements behave like the existing `.table-scroll` containers so wide numbered tables scroll internally instead of expanding the page.
- Share scrollbar styling between generated table wrappers and JS-wrapped tables.

## Root Cause

Numbered tables generated by Pandoc/crossref are wrapped in `.table-wrap`. The existing `table-scroll.js` intentionally skips tables inside `.table-wrap`, but the CSS for `.table-wrap` did not set horizontal overflow handling. Wide tables, especially the reasoning-model table in Chapter 7, therefore expanded the document width on mobile. Some code/math internals can also report wider scroll bounds, so the page root/body now explicitly locks horizontal overflow while dedicated code/math/table containers keep their own scrolling behavior.

## Validation

- `make html`
- Headless Chromium mobile scan at 320px, 360px, and 390px across all generated chapter pages: every page stayed at `scrollX = 0` after forcing `window.scrollTo(9999, 0)`.
- Verified Chapter 7 `.table-wrap` remains internally scrollable at 390px (`clientWidth = 362`, `scrollWidth = 460`, `scrollLeft` moved to `98`).
- Visual mobile check of `/c/07-reasoning.html#tbl:reasoning_list` through a local preview server.