### PR TITLE
[codex] Add reader experiment exercises and agent docs

### DIFF
--- a/.claude/skills/run-rlhf-code-experiment/SKILL.md
+++ b/.claude/skills/run-rlhf-code-experiment/SKILL.md
@@ -25,8 +25,10 @@ Use this skill when the user wants to run, adapt, compare, or document an experi
    - Direct alignment: use `--max_samples` or copy a YAML with a smaller sample count.
    - Policy gradients: copy a YAML and reduce `data.size` before changing algorithm logic.
    - Rejection sampling: reduce `max_train_samples`, `max_test_samples`, or `num_completions_per_prompt` in a copied YAML.
-5. Run one training job at a time unless GPU memory has been checked.
-6. If W&B is not desired, set `WANDB_MODE=disabled` or use the module's no-W&B flag when available.
+5. For any long training, preprocessing, evaluation, or sweep command, launch the command in the background rather than the foreground. In Claude Code, use the background-run option for the shell command, then start a monitor for it.
+6. Watch the monitor until the run has produced initial logs or failed. The Claude Code status bar should show a background task and monitor (for example, `[1 background task] [1 monitor]`). Keep checking the monitor periodically for loss, metrics, W&B URLs, OOMs, dataset download errors, and stalled output.
+7. Run one training job at a time unless GPU memory has been checked.
+8. If W&B is not desired, set `WANDB_MODE=disabled` or use the module's no-W&B flag when available.
 
 ## What To Report
 

--- a/.claude/skills/run-rlhf-code-experiment/SKILL.md
+++ b/.claude/skills/run-rlhf-code-experiment/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: run-rlhf-code-experiment
+description: Plan, run, and report a small RLHF Book code experiment.
+allowed-tools: Bash(uv:*), Bash(git:*), Read, Edit
+---
+
+# Run RLHF Code Experiment
+
+Use this skill when the user wants to run, adapt, compare, or document an experiment from `code/`.
+
+## Pick The Starting Point
+
+- Policy gradients / RL / GRPO / PPO: read `code/policy_gradients/README.md`.
+- Reward models / ORM / PRM / Bradley-Terry RM: read `code/reward_models/README.md`.
+- DPO / IPO / SimPO / ORPO / KTO / APO: read `code/direct_alignment/README.md`.
+- Rejection sampling / best-of-N / GSM8K filtering: read `code/rejection_sampling/README.md`.
+
+## Run Protocol
+
+1. Work from the repository root unless a command explicitly says `cd code/`.
+2. Install or refresh dependencies with `cd code/ && uv sync` only when needed.
+3. Use `uv run python`, never bare `python`.
+4. Start with a short run:
+   - Reward models: lower `--samples` and `--epochs`.
+   - Direct alignment: use `--max_samples` or copy a YAML with a smaller sample count.
+   - Policy gradients: copy a YAML and reduce `data.size` before changing algorithm logic.
+   - Rejection sampling: reduce `max_train_samples`, `max_test_samples`, or `num_completions_per_prompt` in a copied YAML.
+5. Run one training job at a time unless GPU memory has been checked.
+6. If W&B is not desired, set `WANDB_MODE=disabled` or use the module's no-W&B flag when available.
+
+## What To Report
+
+Report enough detail for another reader to reproduce the result:
+
+- Exact command.
+- Model, dataset, seed, and config file.
+- Config values changed from the checked-in defaults.
+- Final metrics and any observed failure mode.
+- W&B run URL if logging was enabled.
+- Follow-up sweep worth trying next.
+
+## Comparison Rules
+
+- For policy gradients, compare `avg_correctness`, `avg_format`, `avg_binary`, loss, and whether sampled groups contain reward contrast.
+- For reward models, compare reward margins or correctness scores on held-out examples, not just training loss.
+- For direct alignment, compare `accuracy`, `margins`, `chosen_rewards`, `rejected_rewards`, and sample generations. IPO loss scale is not directly comparable to DPO loss scale.
+- For rejection sampling, always compare each reward-selected run to its matched random baseline.
+
+## Documentation Rule
+
+If the run exposes a new setup requirement, failure mode, or useful workflow shortcut, update the relevant README, `code/CLAUDE.md`, or this skill before finishing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,11 @@ uv run python -c "import matplotlib"
 python book/scripts/some_script.py
 ```
 
+## Agent Skills
+
+The repo includes Claude Code skills under `.claude/skills/`.
+For code experiments, use `.claude/skills/run-rlhf-code-experiment/SKILL.md`; it maps reader goals to the maintained examples under `code/` and specifies what metrics to report.
+
 ## Directory Structure
 
 ```

--- a/book/chapters/05-reward-models.md
+++ b/book/chapters/05-reward-models.md
@@ -541,3 +541,36 @@ Examples of new benchmarks include:
 - **Multimodal:** MJ-Bench [@chen2024mj], Multimodal RewardBench [@yasunaga2025multimodal], VL RewardBench [@li2024vlrewardbench], or VLRMBench [@ruan2025vlrmbench].
 
 To understand progress on *training* reward models, one can reference new reward model training methods, with aspect-conditioned models [@wang2024interpretable], high-quality human datasets [@wang2024helpsteer2] [@wang2024helpsteer2p], scaling experiments [@adler2024nemotron], extensive experimentation [@touvron2023llama], or debiasing data [@park2024offsetbias].
+
+## Suggested Experiments
+
+The companion code repository includes small reward model training scripts in `code/reward_models/`.
+These are intended as learning exercises rather than tuned reference recipes.
+Start from a clean `code/` environment with `uv sync`, then run one experiment at a time.
+
+1. **Train a Bradley-Terry preference reward model on UltraFeedback.**
+   Run:
+
+   ```bash
+   cd code/
+   uv run python -m reward_models.train_preference_rm --samples 2000 --epochs 1
+   ```
+
+   Watch whether the reward margin between chosen and rejected responses grows in the demo and W&B logs.
+   Then vary `--samples`, `--lr`, and `--model-id` to see when the signal becomes noisy or unstable.
+
+2. **Compare outcome and process supervision.**
+   Run the GSM8K outcome reward model and the PRM800K process reward model:
+
+   ```bash
+   cd code/
+   uv run python -m reward_models.train_orm --samples 400 --epochs 2
+   uv run python -m reward_models.train_prm --samples 500 --epochs 2
+   ```
+
+   Compare what each model can score after training: the ORM should distinguish correct and incorrect final answers, while the PRM should assign scores across intermediate reasoning steps.
+   This is the practical version of the distinction between sequence-level, outcome-level, and process-level supervision.
+
+3. **Add a small held-out reward model eval.**
+   A useful contribution is a 50- to 200-example evaluation for `reward_models/` that reports accuracy or preference-pair ordering without requiring a full training run.
+   Keep the evaluation small enough that it can be used while tuning hyperparameters.

--- a/book/chapters/06-policy-gradients.md
+++ b/book/chapters/06-policy-gradients.md
@@ -1331,3 +1331,40 @@ Examples for further reading include:
 - Some foundation models, such as Apple Intelligence Foundation Models [@gunter2024apple] or Kimi k1.5 reasoning model [@team2025kimi], have used variants of **Mirror Descent Policy Optimization (MDPO)** [@tomar2020mirror]. Research is still developing further on the fundamentals here [@zhang2025improving], but Mirror Descent is an optimization method rather than directly a policy gradient algorithm. What is important here is that it is substituted in very similarly to existing RL infrastructure.
 - **Decoupled Clip and Dynamic sAmpling Policy Optimization (DAPO)** proposes 4 modifications to GRPO to better suit reasoning language models, where long traces are needed and new, underutilized tokens need to be increased in probability [@yu2025dapo]. The changes are: 1, have two different clip hyperparameters, $\varepsilon_\text{low}$ and $\varepsilon_\text{high}$, so clipping on the positive side of the logratio can take bigger steps for better exploration; 2, dynamic sampling, which removes all samples with reward = 0 or reward = 1 for all samples in the batch (no learning signal); 3, use the per-token loss as discussed above in Implementation: GRPO; and 4, a soft penalty on samples that are too long to avoid trying to learn from truncated answers.
 - **Value-based Augmented Proximal Policy Optimization (VAPO)** [@yuan2025vapo] combines optimizations from DAPO (including clip-higher, token-level policy-gradient, and different length normalization) with insights from Value-Calibrated PPO [@yuan2025s] to pretrain the value function and length-adaptive GAE to show the promise of value-based methods relative to GRPO.
+
+## Suggested Experiments
+
+The companion implementation in `code/policy_gradients/` is designed for small, observable RL runs.
+The default configs train `Qwen/Qwen3-1.7B` on the `spell_backward` procedural task from `reasoning-gym`, which is a good first exercise because failures and partial progress are easy to inspect.
+
+1. **Run the word reversal task with GRPO.**
+
+   ```bash
+   cd code/
+   uv run python -m policy_gradients.train --config policy_gradients/configs/grpo.yaml
+   ```
+
+   Track `avg_correctness`, `avg_format`, and `avg_binary`.
+   The useful first question is whether each prompt group contains contrast: if all sampled completions are right or all are wrong, a group-relative update has little learning signal.
+
+2. **Compare group-relative and single-sample estimators.**
+   Run the matched starting configs:
+
+   ```bash
+   cd code/
+   uv run python -m policy_gradients.train --config policy_gradients/configs/reinforce.yaml
+   uv run python -m policy_gradients.train --config policy_gradients/configs/rloo.yaml
+   uv run python -m policy_gradients.train --config policy_gradients/configs/grpo.yaml
+   ```
+
+   Compare how quickly the correctness signal improves and how noisy the loss is.
+   RLOO and GRPO should make the role of within-prompt baselines much more concrete than the equations alone.
+
+3. **Sweep the contrast knobs.**
+   Copy `policy_gradients/configs/grpo.yaml` and vary `num_rollouts`, `temperature`, `data.size`, and `format_weight`.
+   Small `num_rollouts` reduces group contrast; very low temperature can collapse samples; very high temperature can generate too many malformed answers.
+   This is the simplest way to see why RLVR recipes often spend so much effort on sampling settings before touching the optimizer.
+
+4. **Move from toy rewards toward math.**
+   For GSM8K-style experiments, start with the `code/reward_models/train_orm.py` and `code/rejection_sampling/` examples before adding a new online RL environment.
+   A good contribution would be a small `reasoning-gym` or GSM8K policy-gradient config that runs on a sub-1B Qwen model and reports the same group-contrast diagnostics.

--- a/book/chapters/08-direct-alignment.md
+++ b/book/chapters/08-direct-alignment.md
@@ -324,3 +324,44 @@ Even with this performance delta, DAAs are still used extensively in leading mod
 DAAs provide a controlled environment where iterations on training data and other configurations can be made rapidly, and given that data is often far more important than algorithms, using DPO can be fine.
 
 With the emergence of reasoning models that are primarily trained with RL, further investment will return to using RL for preference-tuning, which in the long-term will improve the robustness of RL infrastructure and cement this margin between DAAs and RL for optimizing from human feedback.
+
+## Suggested Experiments
+
+The companion code in `code/direct_alignment/` trains DPO and several related losses on preference data.
+This is the most accessible place to start experimenting with preference tuning because the setup is offline: no reward model server or rollout loop is required.
+
+1. **Train a small DPO run on UltraFeedback.**
+
+   ```bash
+   cd code/
+   uv run python -m direct_alignment.train --loss dpo --max_samples 1000
+   ```
+
+   Watch `loss`, `accuracy`, `margins`, `chosen_rewards`, and `rejected_rewards`.
+   The main sanity check is that the implicit reward margin should move in the desired direction without the model's sample generations collapsing.
+
+2. **Compare DPO, IPO, and length-normalized DPO.**
+
+   ```bash
+   cd code/
+   uv run python -m direct_alignment.train --config direct_alignment/configs/dpo.yaml
+   uv run python -m direct_alignment.train --config direct_alignment/configs/ipo.yaml
+   uv run python -m direct_alignment.train --config direct_alignment/configs/dpo_norm.yaml
+   ```
+
+   Compare the margin scale and the learning rate sensitivity.
+   IPO's loss is not on the same numeric scale as DPO, so read it through `accuracy` and margin behavior rather than raw loss alone.
+
+3. **Try the reference-free variants carefully.**
+   Run SimPO or ORPO from their configs, then inspect the generated samples that are logged during training.
+   These losses are more sensitive to log-probability scaling and learning rate, which makes them useful debugging exercises.
+
+   ```bash
+   cd code/
+   uv run python -m direct_alignment.train --config direct_alignment/configs/simpo.yaml
+   uv run python -m direct_alignment.train --config direct_alignment/configs/orpo.yaml
+   ```
+
+4. **Change the data before changing the loss.**
+   Keep the loss fixed and vary `--max_samples`, `--max_length`, or the preference dataset.
+   If the results move more than changing between DPO-like objectives, that is an empirical reminder of a central theme in preference tuning: data usually dominates small algorithmic differences.

--- a/book/chapters/09-rejection-sampling.md
+++ b/book/chapters/09-rejection-sampling.md
@@ -244,3 +244,44 @@ Using the argmax method, we select the best completion for the prompt:
 $$S(R) = \arg\max_{j \in [1,N]} r_j$$ {#eq:selection_function}
 
 Using the top-K method with $K=1$ reduces to the same method, which is common practice.
+
+## Suggested Experiments
+
+The companion implementation in `code/rejection_sampling/` runs a complete GSM8K rejection-sampling pipeline: generate rollouts, score them with a reward model, select a training subset, fine-tune, and evaluate exact-match accuracy.
+The four configs are arranged as matched treatment/control pairs, so readers can ask whether the reward model is actually helping.
+
+1. **Build the rollout cache once.**
+
+   ```bash
+   cd code/
+   uv run python -m rejection_sampling.preprocess \
+       --config rejection_sampling/configs/top_per_prompt.yaml
+   ```
+
+   This generates and scores completions for the shared GSM8K slice.
+   Subsequent training configs reuse the cache as long as the generation and scoring settings stay unchanged.
+
+2. **Compare reward selection against random controls.**
+
+   ```bash
+   cd code/
+   uv run python -m rejection_sampling.train \
+       --config rejection_sampling/configs/top_per_prompt.yaml
+   uv run python -m rejection_sampling.train \
+       --config rejection_sampling/configs/random_per_prompt.yaml
+   uv run python -m rejection_sampling.train \
+       --config rejection_sampling/configs/top_k_overall.yaml
+   uv run python -m rejection_sampling.train \
+       --config rejection_sampling/configs/random_k_overall.yaml
+   ```
+
+   Read results in matched pairs: `top_per_prompt` versus `random_per_prompt`, and `top_k_overall` versus `random_k_overall`.
+   If the reward-selected run does not beat its random baseline, the reward model or sampled completions are not giving useful signal on that slice.
+
+3. **Vary how much choice the reward model gets.**
+   Copy one config and change `num_completions_per_prompt`, `temperature`, `top_p`, and `selection.top_k`.
+   More completions can improve the best available sample, but only if the reward model can separate good and bad answers.
+
+4. **Try a smaller policy model.**
+   Set `model_name` to a smaller compatible instruct model, reduce `max_train_samples`, and rerun the same matched pairs.
+   This makes the experiment cheaper and highlights whether rejection sampling is rescuing weak generations or merely selecting among already-good ones.

--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,7 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
-- 2026-05-11: PR TBD documented reader experiment paths for the code examples and added agent guidance for running small RLHF Book experiments.
+- 2026-05-11: [PR #417](https://github.com/natolambert/rlhf-book/pull/417) documented reader experiment paths for the code examples and added agent guidance for running small RLHF Book experiments.
 - 2026-05-06: [PR #400](https://github.com/natolambert/rlhf-book/pull/400) added `dpo_norm` variant in direct-alignment that applies standard DPO with average response log-probs for both policy and reference model.
 - 2026-05-05: [PR #396](https://github.com/natolambert/rlhf-book/pull/396) added lightweight import and CLI smoke tests for the `code/` subpackages.
 

--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,7 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
-- 2026-05-11: [PR #417](https://github.com/natolambert/rlhf-book/pull/417) documented reader experiment paths for the code examples and added agent guidance for running small RLHF Book experiments.
+- 2026-05-11: [PR #417](https://github.com/natolambert/rlhf-book/pull/417) documented reader experiment paths for the code examples, added agent guidance for running small RLHF Book experiments, and expanded contributor notes for adding new modules.
 - 2026-05-06: [PR #400](https://github.com/natolambert/rlhf-book/pull/400) added `dpo_norm` variant in direct-alignment that applies standard DPO with average response log-probs for both policy and reference model.
 - 2026-05-05: [PR #396](https://github.com/natolambert/rlhf-book/pull/396) added lightweight import and CLI smoke tests for the `code/` subpackages.
 

--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,6 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
+- 2026-05-11: PR TBD documented reader experiment paths for the code examples and added agent guidance for running small RLHF Book experiments.
 - 2026-05-06: [PR #400](https://github.com/natolambert/rlhf-book/pull/400) added `dpo_norm` variant in direct-alignment that applies standard DPO with average response log-probs for both policy and reference model.
 - 2026-05-05: [PR #396](https://github.com/natolambert/rlhf-book/pull/396) added lightweight import and CLI smoke tests for the `code/` subpackages.
 

--- a/code/CLAUDE.md
+++ b/code/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Claude Code Notes
 
 - **Always run Python commands with `uv run python`** (not bare `python`/`python3`) so the project environment is used consistently
-- **Always run training commands in background** using `run_in_background: true` to avoid blocking
+- **Always run training commands in background** using `run_in_background: true` to avoid blocking or hitting interactive timeouts. Start a monitor for the background task and check it from the Claude Code status bar (e.g. `[1 background task] [1 monitor]`) until you see the first metrics or failure.
 - **Be careful with parallel jobs**: Only run one training job at a time unless you verify memory is available. Running too many can OOM the system.
 - **If using a DGX Spark**: ~120GB unified CPU/GPU memory — aim for <80GB usage to be safe. Flash Attention is not available on ARM64/Blackwell; the code automatically falls back to PyTorch SDPA.
 - **Before finalizing changes under `code/`**, run `uvx ruff@0.14.5 check .`, `uvx ruff@0.14.5 format --check .`, and `uv run --extra dev pytest` — all are enforced by CI on PRs that touch `code/` (see `.github/workflows/lint.yml`). Use `uvx ruff@0.14.5 check --fix .` and `uvx ruff@0.14.5 format .` to auto-fix. Pin the ruff version to match CI; unpinned `uvx ruff` can diverge.
@@ -46,9 +46,10 @@ When a user asks for a runnable experiment, start from the closest maintained ex
 
 1. Read the module README and config before running anything.
 2. Start with the smallest command that can show signal (`--max_samples`, `--samples`, or a copied small YAML).
-3. Run one training job at a time unless GPU memory has been checked.
-4. Record the exact command, model, dataset slice, seed, changed config values, final metrics, and W&B link if enabled.
-5. If a run fails and the fix changes future workflow knowledge, update this file or the relevant skill so the next agent can find it.
+3. Launch long-running training/eval commands in the background, then attach a monitor and keep checking it. Do not leave a silent background run without confirming that logs, W&B, or metrics are moving.
+4. Run one training job at a time unless GPU memory has been checked.
+5. Record the exact command, model, dataset slice, seed, changed config values, final metrics, and W&B link if enabled.
+6. If a run fails and the fix changes future workflow knowledge, update this file or the relevant skill so the next agent can find it.
 
 ## Changelog Process
 

--- a/code/CLAUDE.md
+++ b/code/CLAUDE.md
@@ -30,6 +30,26 @@ uv run python -m direct_alignment.train --config direct_alignment/configs/dpo.ya
 uv run python -m rejection_sampling.train --config rejection_sampling/configs/top_per_prompt.yaml
 ```
 
+## Task Map
+
+When a user asks for a runnable experiment, start from the closest maintained example:
+
+| User goal | Start here | Notes |
+|-----------|------------|-------|
+| "Run RL / GRPO / PPO" | `policy_gradients/README.md` and `policy_gradients/configs/*.yaml` | Default task is `spell_backward`; watch `avg_correctness`, `avg_format`, and group contrast. |
+| "Train a reward model" | `reward_models/README.md` | Preference RM uses UltraFeedback; ORM uses GSM8K; PRM uses PRM800K. These are experimental and need tuning. |
+| "Train DPO / IPO / SimPO / KTO" | `direct_alignment/README.md` and `direct_alignment/configs/*.yaml` | DPO/IPO/KTO/APO are validated; SimPO/ORPO are implemented but still marked noisy. |
+| "Try rejection sampling / best-of-N" | `rejection_sampling/README.md` and `rejection_sampling/configs/*.yaml` | Always compare each reward-selection config to its matched random baseline. |
+| "Use an agent skill" | `.claude/skills/run-rlhf-code-experiment/SKILL.md` | Use this for planning and reporting a small experiment run. |
+
+## Experiment Workflow
+
+1. Read the module README and config before running anything.
+2. Start with the smallest command that can show signal (`--max_samples`, `--samples`, or a copied small YAML).
+3. Run one training job at a time unless GPU memory has been checked.
+4. Record the exact command, model, dataset slice, seed, changed config values, final metrics, and W&B link if enabled.
+5. If a run fails and the fix changes future workflow knowledge, update this file or the relevant skill so the next agent can find it.
+
 ## Changelog Process
 
 - **CI enforces this**: a GitHub Actions check fails PRs that touch `code/` without modifying `code/CHANGELOG.md` (the file must be modified; the format below is convention, not enforced).

--- a/code/CONTRIBUTING.md
+++ b/code/CONTRIBUTING.md
@@ -25,17 +25,17 @@ When adding a new top-level code module, add its import path to `tests/test_impo
 
 Keep these tests lightweight: they should verify imports, entrypoint wiring, and tiny helper signatures only. They should not download datasets, load models, start training, or require GPUs.
 
-## Adding a New Module
+## Keeping Examples and Book Docs in Sync
 
-When adding a new top-level module under `code/`, update the surrounding repository metadata so readers, agents, and CI can find it:
+When changing a runnable example, config, metric, or recommended command under `policy_gradients/`, `direct_alignment/`, `reward_models/`, or `rejection_sampling/`, check the connected documentation before submitting:
 
-- `code/pyproject.toml`: add the package to `[tool.setuptools.packages.find].include`, add any new dependencies, and add a `[project.scripts]` entry if the module has a CLI.
-- `code/README.md`: add the module to the overview, quick-start commands, reader experiment path, and chapter mapping if it is user-facing.
-- `code/CLAUDE.md`: add the module to the task map and quick-start list so coding agents know where to start. `code/AGENTS.md` is a symlink to this file, so do not create a separate copy.
-- `code/<module>/README.md`: document the purpose, status, quick start, configs, expected metrics, memory notes, and reference runs if validated.
-- `code/<module>/configs/`: include at least one small, runnable config when the module uses YAML configs.
-- `code/tests/test_import_smoke.py`: add import coverage and CLI `--help` coverage for new entrypoints.
-- `code/CHANGELOG.md`: add one `## Unreleased` bullet for the PR.
-- Book chapter docs: if the module supports a chapter exercise, link it from the relevant chapter's "Suggested Experiments" section.
+- Update the module README if commands, configs, expected metrics, memory notes, status, or reference runs changed.
+- Update `code/README.md` if the reader experiment path, quick-start commands, or chapter mapping changed.
+- Update `code/CLAUDE.md` if agent-facing task guidance or run workflow changed. `code/AGENTS.md` is a symlink to this file, so do not create a separate copy.
+- Update the connected book chapter's "Suggested Experiments" section if the reader-facing exercise changed.
+- Update `code/tests/test_import_smoke.py` if imports or CLI entrypoints changed.
+- Add one `## Unreleased` bullet in `code/CHANGELOG.md`.
+
+New top-level modules are rare, but when adding one also update `code/pyproject.toml` package/script metadata and add a module README plus a small runnable config if the module uses YAML configs.
 
 For long-running examples, document how to launch the run in the background and monitor it. Agent-facing instructions should explicitly say to use a background task plus monitor rather than a foreground command that may time out.

--- a/code/CONTRIBUTING.md
+++ b/code/CONTRIBUTING.md
@@ -24,3 +24,18 @@ If you use Claude Code, run `/pre-submit-pr` and paste its output in your PR des
 When adding a new top-level code module, add its import path to `tests/test_import_smoke.py` so CI catches broken package wiring. If the module exposes a runnable CLI entrypoint, add that module to the CLI help smoke tests too.
 
 Keep these tests lightweight: they should verify imports, entrypoint wiring, and tiny helper signatures only. They should not download datasets, load models, start training, or require GPUs.
+
+## Adding a New Module
+
+When adding a new top-level module under `code/`, update the surrounding repository metadata so readers, agents, and CI can find it:
+
+- `code/pyproject.toml`: add the package to `[tool.setuptools.packages.find].include`, add any new dependencies, and add a `[project.scripts]` entry if the module has a CLI.
+- `code/README.md`: add the module to the overview, quick-start commands, reader experiment path, and chapter mapping if it is user-facing.
+- `code/CLAUDE.md`: add the module to the task map and quick-start list so coding agents know where to start. `code/AGENTS.md` is a symlink to this file, so do not create a separate copy.
+- `code/<module>/README.md`: document the purpose, status, quick start, configs, expected metrics, memory notes, and reference runs if validated.
+- `code/<module>/configs/`: include at least one small, runnable config when the module uses YAML configs.
+- `code/tests/test_import_smoke.py`: add import coverage and CLI `--help` coverage for new entrypoints.
+- `code/CHANGELOG.md`: add one `## Unreleased` bullet for the PR.
+- Book chapter docs: if the module supports a chapter exercise, link it from the relevant chapter's "Suggested Experiments" section.
+
+For long-running examples, document how to launch the run in the background and monitor it. Agent-facing instructions should explicitly say to use a background task plus monitor rather than a foreground command that may time out.

--- a/code/README.md
+++ b/code/README.md
@@ -19,6 +19,7 @@ uv sync
 
 Start with one short run, confirm that the learning signal is visible, then sweep one variable at a time.
 If you do not want W&B logging, set `WANDB_MODE=disabled` or use the module-specific no-W&B option when available.
+If you are running these with a coding assistant, launch long training/eval commands in the background and monitor them; foreground runs can time out before they produce useful metrics.
 
 | Chapter | Starting experiment | Command | What to inspect |
 |---------|---------------------|---------|-----------------|

--- a/code/README.md
+++ b/code/README.md
@@ -8,6 +8,35 @@ I primarily run experiments on a [DGX Spark](https://www.nvidia.com/en-us/produc
 
 *Note: There's an open PR [here](https://github.com/natolambert/rlhf-book/pull/328) exploring the idea of adding speedrun functionality to this repository — comment if you're interested in pushing this further or seeing it merged into main.*
 
+## Reader Experiment Path
+
+All commands below assume:
+
+```bash
+cd code/
+uv sync
+```
+
+Start with one short run, confirm that the learning signal is visible, then sweep one variable at a time.
+If you do not want W&B logging, set `WANDB_MODE=disabled` or use the module-specific no-W&B option when available.
+
+| Chapter | Starting experiment | Command | What to inspect |
+|---------|---------------------|---------|-----------------|
+| Chapter 5: Reward Models | Bradley-Terry RM on UltraFeedback | `uv run python -m reward_models.train_preference_rm --samples 2000 --epochs 1` | Chosen/rejected reward margin, training loss, demo scoring |
+| Chapter 5: Reward Models | ORM on GSM8K | `uv run python -m reward_models.train_orm --samples 400 --epochs 2` | Whether correct final answers score above perturbed answers |
+| Chapter 6: Policy Gradients | GRPO on `spell_backward` | `uv run python -m policy_gradients.train --config policy_gradients/configs/grpo.yaml` | `avg_correctness`, `avg_format`, `avg_binary`, and whether groups contain contrast |
+| Chapter 8: Direct Alignment | DPO on UltraFeedback | `uv run python -m direct_alignment.train --loss dpo --max_samples 1000` | `accuracy`, `margins`, `chosen_rewards`, `rejected_rewards`, sample generations |
+| Chapter 9: Rejection Sampling | GSM8K reward selection versus random controls | `uv run python -m rejection_sampling.train --config rejection_sampling/configs/top_per_prompt.yaml` | Final exact-match accuracy against the matched random baseline |
+
+Good first sweeps:
+
+- **Policy gradients**: copy `policy_gradients/configs/grpo.yaml` and vary `num_rollouts`, `temperature`, `format_weight`, and `data.size`.
+- **Direct alignment**: hold the dataset fixed and compare `dpo.yaml`, `ipo.yaml`, and `dpo_norm.yaml`; read IPO through margins/accuracy, not raw loss scale.
+- **Reward models**: vary `--samples`, `--lr`, and `--model-id` before changing the model architecture.
+- **Rejection sampling**: keep generation/scoring settings identical while comparing `top_*` configs to their `random_*` controls.
+
+The book chapters now include suggested exercises at the end of Chapters 5, 6, 8, and 9.
+
 ## Attribution
 
 This code is built on the excellent work of community contributors:


### PR DESCRIPTION
## Summary

Adds concrete reader-facing experiment suggestions to the web/book chapters that already have runnable companion code, and improves the code-library documentation so readers and coding agents can find the right starting points.

## Changes

- Added "Suggested Experiments" sections to Chapters 5, 6, 8, and 9.
- Added a reader experiment path to `code/README.md` mapping chapters to runnable commands and metrics to inspect.
- Added a task map and experiment workflow to `code/CLAUDE.md`.
- Added a `run-rlhf-code-experiment` Claude skill for planning, running, and reporting small code experiments.
- Added a root `CLAUDE.md` pointer to the new skill.

## Validation

- `git diff --check`
- `make nested_html`
- `uvx ruff@0.14.5 check .`
- `uvx ruff@0.14.5 format --check .`
- `uv run --extra dev pytest` (32 passed, 4 third-party warnings)

## Notes

`AGENTS.md` is already symlinked to `CLAUDE.md`, so this PR updates `CLAUDE.md` rather than adding a separate agent instructions file.