### PR TITLE
[codex] Fix minor code docs and checks

### DIFF
--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,6 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
+- 2026-05-12: [PR #419](https://github.com/natolambert/rlhf-book/pull/419) fixed minor code docs and comments, direct-alignment experiment script paths, rejection-sampling answer matching, policy-gradient loss exports, and PRM fallback rating handling.
 - 2026-05-11: [PR #417](https://github.com/natolambert/rlhf-book/pull/417) documented reader experiment paths for the code examples, added agent guidance for running small RLHF Book experiments, and expanded contributor notes for adding new modules.
 - 2026-05-06: [PR #400](https://github.com/natolambert/rlhf-book/pull/400) added `dpo_norm` variant in direct-alignment that applies standard DPO with average response log-probs for both policy and reference model.
 - 2026-05-05: [PR #396](https://github.com/natolambert/rlhf-book/pull/396) added lightweight import and CLI smoke tests for the `code/` subpackages.

--- a/code/CLAUDE.md
+++ b/code/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Claude Code Notes
 
 - **Always run Python commands with `uv run python`** (not bare `python`/`python3`) so the project environment is used consistently
-- **Always run training commands in background** using `run_in_background: true` to avoid blocking or hitting interactive timeouts. Start a monitor for the background task and check it from the Claude Code status bar (e.g. `[1 background task] [1 monitor]`) until you see the first metrics or failure.
+- **Always run training commands in the background** using `run_in_background: true` to avoid blocking or hitting interactive timeouts. Start a monitor for the background task and check it from the Claude Code status bar (e.g. `[1 background task] [1 monitor]`) until you see the first metrics or failure.
 - **Be careful with parallel jobs**: Only run one training job at a time unless you verify memory is available. Running too many can OOM the system.
 - **If using a DGX Spark**: ~120GB unified CPU/GPU memory — aim for <80GB usage to be safe. Flash Attention is not available on ARM64/Blackwell; the code automatically falls back to PyTorch SDPA.
 - **Before finalizing changes under `code/`**, run `uvx ruff@0.14.5 check .`, `uvx ruff@0.14.5 format --check .`, and `uv run --extra dev pytest` — all are enforced by CI on PRs that touch `code/` (see `.github/workflows/lint.yml`). Use `uvx ruff@0.14.5 check --fix .` and `uvx ruff@0.14.5 format .` to auto-fix. Pin the ruff version to match CI; unpinned `uvx ruff` can diverge.
@@ -100,7 +100,7 @@ Without LoRA (full fine-tune):
 - 1.7B model: ~10-15GB
 - 3B model: ~20-25GB
 
-With gradient checkpointing can reduce by ~30-40%.
+Gradient checkpointing can reduce memory use by ~30-40%.
 
 ## TODOs
 

--- a/code/direct_alignment/README.md
+++ b/code/direct_alignment/README.md
@@ -149,7 +149,7 @@ Other compatible datasets:
 **Note on DPO-Norm scale**: DPO-Norm uses per-token average log-ratios, so its logits
 are much smaller than summed DPO logits. A `beta` around `2.0` is a reasonable starting
 point (matching SimPO's range). It is directly supported by the SimPO author
-([GitHub #20](https://github.com/princeton-nlp/SimPO/issues/20)) and an AI2 open-instruct maintainer ([GitHub #237](https://github.com/allenai/open-instruct/pull/237))
+([GitHub #20](https://github.com/princeton-nlp/SimPO/issues/20)) and an AI2 open-instruct maintainer ([GitHub #237](https://github.com/allenai/open-instruct/pull/237)).
 
 ### In-Loop Generation Logging
 
@@ -349,6 +349,6 @@ These would be great contributions to make the implementations more complete:
 
 ## How This Was Made
 
-I used GPT 5.2 Pro to write a plan based on canonical implementations, and had Claude Code with Opus 4.5 write it, periodically getting feedback from Codex 5.2 xhigh, with manual tuning of the configs to make the configs have representative learning curves.
+I used GPT 5.2 Pro to write a plan based on canonical implementations, and had Claude Code with Opus 4.5 write it, periodically getting feedback from Codex 5.2 xhigh, with manual tuning to give the configs representative learning curves.
 
 Due to this, **community contributions are strongly encouraged**. I'm happy to test high-quality contributions on my Spark to continue making this a home for tinkerers interested in RLHF and post-training.

--- a/code/direct_alignment/config.py
+++ b/code/direct_alignment/config.py
@@ -85,7 +85,7 @@ class Config:
         if self.loss == "cdpo":
             self.label_smoothing = 0.1
         elif self.loss in ["simpo", "dpo_norm"]:
-            # SimPO and DPO-Norm typically uses higher beta
+            # SimPO and DPO-Norm typically use higher beta
             if self.beta == 0.1:  # Only override if default
                 self.beta = 2.0
 

--- a/code/direct_alignment/configs/apo_down.yaml
+++ b/code/direct_alignment/configs/apo_down.yaml
@@ -20,7 +20,7 @@ max_length: 2048
 
 # Training
 learning_rate: 5.0e-6  # Higher LR works better for this model
-num_epochs: 3  # ~700 steps total
+num_epochs: 3  # ~300 optimizer steps total
 batch_size: 8
 gradient_accumulation_steps: 8  # Effective batch size = 64
 warmup_ratio: 0.1

--- a/code/direct_alignment/configs/apo_zero.yaml
+++ b/code/direct_alignment/configs/apo_zero.yaml
@@ -20,7 +20,7 @@ max_length: 2048
 
 # Training
 learning_rate: 5.0e-6  # Higher LR works better for this model
-num_epochs: 3  # ~700 steps total
+num_epochs: 3  # ~300 optimizer steps total
 batch_size: 8
 gradient_accumulation_steps: 8  # Effective batch size = 64
 warmup_ratio: 0.1

--- a/code/direct_alignment/configs/dpo.yaml
+++ b/code/direct_alignment/configs/dpo.yaml
@@ -20,7 +20,7 @@ max_length: 2048
 
 # Training
 learning_rate: 5.0e-6  # Higher LR works better for this model
-num_epochs: 3  # ~700 steps total
+num_epochs: 3  # ~300 optimizer steps total
 batch_size: 8
 gradient_accumulation_steps: 8  # Effective batch size = 64
 warmup_ratio: 0.1

--- a/code/direct_alignment/configs/dpo_norm.yaml
+++ b/code/direct_alignment/configs/dpo_norm.yaml
@@ -21,7 +21,7 @@ max_length: 2048
 
 # Training
 learning_rate: 5.0e-6  # Higher LR works better for this model
-num_epochs: 3  # ~700 steps total
+num_epochs: 3  # ~300 optimizer steps total
 batch_size: 8
 gradient_accumulation_steps: 8  # Effective batch size = 64
 warmup_ratio: 0.1

--- a/code/direct_alignment/configs/ipo.yaml
+++ b/code/direct_alignment/configs/ipo.yaml
@@ -23,7 +23,7 @@ max_length: 2048
 
 # Training
 learning_rate: 5.0e-6
-num_epochs: 3  # ~700 steps total
+num_epochs: 3  # ~300 optimizer steps total
 batch_size: 8
 gradient_accumulation_steps: 8  # Effective batch size = 64
 warmup_ratio: 0.1

--- a/code/direct_alignment/configs/kto.yaml
+++ b/code/direct_alignment/configs/kto.yaml
@@ -23,7 +23,7 @@ max_length: 2048
 
 # Training
 learning_rate: 5.0e-6
-num_epochs: 3  # ~700 steps total
+num_epochs: 3  # ~300 optimizer steps total
 batch_size: 8
 gradient_accumulation_steps: 8  # Effective batch size = 64
 warmup_ratio: 0.1

--- a/code/direct_alignment/experiments/2026-02-08-orpo-simpo.md
+++ b/code/direct_alignment/experiments/2026-02-08-orpo-simpo.md
@@ -76,7 +76,7 @@ This is an experiment log for the ORPO/SimPO debugging and sweep work done in th
 ## Non-W&B / Aborted Probes
 
 - Several very short sanity probes were launched with `WANDB_MODE=disabled` while validating startup and crash behavior.
-- A few background launches exited early before trainer initialization due environment/sandbox behavior; this was worked around by running in foreground when needed and by explicit detached launches.
+- A few background launches exited early before trainer initialization due to environment/sandbox behavior; this was worked around by running in foreground when needed and by explicit detached launches.
 - Fixed-batch overfit sanity (non-W&B): both SimPO and ORPO can drive a single batch to `accuracy=1.0` and rapidly increasing margins at `lr=1e-5`, indicating gradient path / loss wiring is functional.
 
 ## Current Read

--- a/code/direct_alignment/experiments/2026-02-08-orpo-simpo/run_orpo_small.sh
+++ b/code/direct_alignment/experiments/2026-02-08-orpo-simpo/run_orpo_small.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")/../../.."
 
 ts="$(date +%Y%m%d-%H%M%S)"
 export WANDB_PROJECT="${WANDB_PROJECT:-rlhf-book}"

--- a/code/direct_alignment/experiments/2026-02-08-orpo-simpo/run_simpo_small.sh
+++ b/code/direct_alignment/experiments/2026-02-08-orpo-simpo/run_simpo_small.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")/../../.."
 
 ts="$(date +%Y%m%d-%H%M%S)"
 export WANDB_PROJECT="${WANDB_PROJECT:-rlhf-book}"

--- a/code/direct_alignment/loss.py
+++ b/code/direct_alignment/loss.py
@@ -608,7 +608,8 @@ def get_loss_function(loss_type: str, **kwargs) -> nn.Module:
     """Get loss function by name.
 
     Args:
-        loss_type: One of 'dpo', 'dpo_norm', 'cdpo', 'ipo', 'simpo', 'orpo', 'kto'
+        loss_type: One of 'dpo', 'dpo_norm', 'cdpo', 'ipo', 'simpo', 'orpo',
+            'kto', 'apo_zero', 'apo_down'
         **kwargs: Arguments passed to the loss function constructor
 
     Returns:

--- a/code/policy_gradients/__init__.py
+++ b/code/policy_gradients/__init__.py
@@ -8,7 +8,16 @@
 
 from .buffer import Experience, ReplayBuffer
 from .config import Config, load_config
-from .loss import CISPOLoss, GRPOLoss, GSPOLoss, PPOLoss, ReinforceLoss
+from .loss import (
+    CISPOLoss,
+    DAPOLoss,
+    GRPOLoss,
+    GSPOLoss,
+    MaxRLLoss,
+    PPOLoss,
+    ReinforceLoss,
+    SAPOLoss,
+)
 
 
 __all__ = [
@@ -21,4 +30,7 @@ __all__ = [
     "PPOLoss",
     "ReinforceLoss",
     "CISPOLoss",
+    "SAPOLoss",
+    "DAPOLoss",
+    "MaxRLLoss",
 ]

--- a/code/policy_gradients/config.py
+++ b/code/policy_gradients/config.py
@@ -30,16 +30,23 @@ class Config(BaseModel):
 
     Attributes:
         data: Dataset configuration
-        loss: Loss function (reinforce, rloo, ppo, grpo, drgrpo, gspo, cispo, sapo)
+        loss: Loss function (reinforce, rloo, ppo, grpo, drgrpo, gspo, cispo, sapo,
+            dapo, maxrl)
         model_name: HuggingFace model identifier
 
-        # Clipping (GRPO, DrGRPO, GSPO, CISPO, PPO)
+        # Clipping (GRPO, DrGRPO, GSPO, CISPO, PPO, DAPO)
         clip_eps_lo: Lower clipping bound for policy ratio
         clip_eps_hi: Upper clipping bound for policy ratio
 
         # SAPO-specific
         sapo_temp_pos: Sigmoid temperature for positive advantages
         sapo_temp_neg: Sigmoid temperature for negative advantages
+
+        # DAPO-specific
+        l_cache: Overlong penalty cache length
+        l_max: Overlong penalty maximum length
+        accuracy_min_reward: Minimum correctness reward for dynamic filtering
+        accuracy_max_reward: Maximum correctness reward for dynamic filtering
 
         # PPO-specific
         clip_eps_val: Clipping bound for value function

--- a/code/policy_gradients/configs/dapo.yaml
+++ b/code/policy_gradients/configs/dapo.yaml
@@ -15,7 +15,7 @@ clip_eps_lo: 0.2
 # Clip higher
 clip_eps_hi: 0.28
 
-# Optional KL penalty
+# Shared KL fields; DAPO loss ignores KL.
 beta: 0.0
 kl_estimator: kl3  # KL estimator: kl1, kl2, or kl3
 ref_model_device_id: 0

--- a/code/rejection_sampling/README.md
+++ b/code/rejection_sampling/README.md
@@ -7,11 +7,11 @@ Chapter 9 of [the RLHF Book](https://rlhfbook.com). See the parent
 [`code/README.md`](../README.md) for installation, configuration, and memory
 requirements. The pipeline:
 
-1. Generate `N` rollouts per GSM8k training prompt with `Qwen/Qwen3-1.7B`.
+1. Generate `N` rollouts per GSM8K training prompt with `Qwen/Qwen3-1.7B`.
 2. Score every rollout with `nvidia/AceMath-7B-RM`.
 3. Select a subset of (prompt, completion) pairs via one of four selection configs.
 4. SFT `Qwen/Qwen3-1.7B` on the selected subset.
-5. Evaluate exact-match accuracy on the GSM8k test split.
+5. Evaluate exact-match accuracy on the GSM8K test split.
 
 The two chapter selection strategies are each paired with a matched
 random-selection baseline at the same sample budget. Comparing

--- a/code/rejection_sampling/configs/random_per_prompt.yaml
+++ b/code/rejection_sampling/configs/random_per_prompt.yaml
@@ -3,7 +3,7 @@
 # top_per_prompt on dataset size and prompt coverage, so comparing the two
 # isolates whether reward-based filtering actually beats a coin flip.
 #
-# Generation params are identical across all three configs so they share a
+# Generation params are identical across all four configs so they share a
 # single rollout cache in rejection_sampling/output/rollouts/<hash>.jsonl.
 
 data:

--- a/code/rejection_sampling/configs/top_k_overall.yaml
+++ b/code/rejection_sampling/configs/top_k_overall.yaml
@@ -1,7 +1,7 @@
 # Rejection sampling with top-K overall selection.
 # See rejection_sampling/chapter.md (@eq:rs_topk_selection).
 #
-# Generation params are identical across all three configs so they share a
+# Generation params are identical across all four configs so they share a
 # single rollout cache in rejection_sampling/output/rollouts/<hash>.jsonl.
 
 data:

--- a/code/rejection_sampling/configs/top_per_prompt.yaml
+++ b/code/rejection_sampling/configs/top_per_prompt.yaml
@@ -1,7 +1,7 @@
 # Rejection sampling with top-per-prompt selection.
 # See rejection_sampling/chapter.md (@eq:rs_selection_per_prompt).
 #
-# Generation params are identical across all three configs so they share a
+# Generation params are identical across all four configs so they share a
 # single rollout cache in rejection_sampling/output/rollouts/<hash>.jsonl.
 
 data:

--- a/code/rejection_sampling/preprocess.py
+++ b/code/rejection_sampling/preprocess.py
@@ -261,7 +261,7 @@ def run(cfg: Config) -> Path:
         prompts, completions = _load_rollouts_intermediate(intermediate_path)
     else:
         prompts = load_gsm8k_prompts(cfg)
-        console.print(f"[dim]Loaded {len(prompts)} GSM8k prompts.[/dim]")
+        console.print(f"[dim]Loaded {len(prompts)} GSM8K prompts.[/dim]")
 
         model_device = torch.device(
             f"cuda:{cfg.model_device_id}" if torch.cuda.is_available() else "cpu"

--- a/code/rejection_sampling/train.py
+++ b/code/rejection_sampling/train.py
@@ -1,4 +1,4 @@
-# Stage 3: selection + SFT + GSM8k exact-match eval. Auto-runs preprocess on
+# Stage 3: selection + SFT + GSM8K exact-match eval. Auto-runs preprocess on
 # cache miss, so one command per config is enough:
 #   uv run python -m rejection_sampling.train --config configs/top_per_prompt.yaml
 
@@ -23,6 +23,7 @@ from .config import Config, load_config
 from .selection import select
 from .utils import (
     ACEMATH_SYSTEM_PROMPT,
+    answers_match,
     cuda_memory_gb,
     extract_gsm8k_answer,
     format_gsm8k_gold,
@@ -197,7 +198,7 @@ def _build_eval_prompt(question: str, tokenizer) -> str:
 
 
 def evaluate(cfg: Config, model, tokenizer, console: Console) -> float:
-    """Greedy-decode exact-match eval on the GSM8k test split."""
+    """Greedy-decode exact-match eval on the GSM8K test split."""
     ds = load_dataset(cfg.data.name, cfg.data.subset, split=cfg.data.test_split)
     if cfg.data.max_test_samples is not None:
         ds = ds.select(range(min(cfg.data.max_test_samples, len(ds))))
@@ -246,7 +247,7 @@ def evaluate(cfg: Config, model, tokenizer, console: Console) -> float:
             for row, completion in zip(batch, completions, strict=True):
                 pred = extract_gsm8k_answer(completion)
                 gold = row["gold"]
-                is_correct = pred is not None and pred.strip() == gold.strip()
+                is_correct = answers_match(pred, gold)
                 correct += int(is_correct)
                 total += 1
                 samples.append((row["question"], gold, pred or "<none>", completion))
@@ -326,7 +327,7 @@ def main(cfg: Config) -> None:
     model.gradient_checkpointing_disable()
     model.config.use_cache = True
 
-    # Stage 3c: evaluate on GSM8k test split.
+    # Stage 3c: evaluate on GSM8K test split.
     accuracy = evaluate(cfg, model, tokenizer, console)
     wandb.log({"test_accuracy": accuracy, "selection/strategy": cfg.selection.strategy})
 
@@ -342,7 +343,7 @@ def main(cfg: Config) -> None:
 
 def main_cli() -> None:
     parser = argparse.ArgumentParser(
-        description="Rejection sampling: selection + SFT + GSM8k eval."
+        description="Rejection sampling: selection + SFT + GSM8K eval."
     )
     parser.add_argument("--config", type=str, required=True, help="Path to YAML config file")
     args = parser.parse_args()

--- a/code/rejection_sampling/utils.py
+++ b/code/rejection_sampling/utils.py
@@ -1,4 +1,4 @@
-# Shared helpers: VRAM cleanup, cache-key hashing, GSM8k answer parsing.
+# Shared helpers: VRAM cleanup, cache-key hashing, GSM8K answer parsing.
 
 import gc
 import hashlib
@@ -153,7 +153,7 @@ def cache_key(cfg: Config) -> str:
 
 
 def format_gsm8k_gold(answer_field: str) -> str:
-    """GSM8k gold answers live after `####` at the end of the CoT."""
+    """GSM8K gold answers live after `####` at the end of the CoT."""
     gold = (
         answer_field.split("####", 1)[1].strip() if "####" in answer_field else answer_field.strip()
     )

--- a/code/reward_models/train_prm.py
+++ b/code/reward_models/train_prm.py
@@ -136,7 +136,9 @@ def get_steps_and_labels(example: Dict) -> tuple[List[str], List[int]]:
 
         # Fallback to other fields
         text = step.get("human_completion") or step.get("text") or step.get("completion")
-        rating = step.get("rating") or step.get("score")
+        rating = step.get("rating")
+        if rating is None or rating == "":
+            rating = step.get("score")
         if text and rating is not None:
             text = to_plain_text(text).strip()
             if text:


### PR DESCRIPTION
## Summary

- Fix minor wording, punctuation, and capitalization issues in `code/` docs and comments without carrying over end-of-line whitespace cleanup.
- Correct small code/config inconsistencies found during the review, including direct-alignment experiment script paths, stale step-count comments, policy-gradient loss exports/docs, rejection-sampling answer matching, and PRM fallback rating handling.
- Keep the branch rebased onto `main` after PR #418 so the compare view shows only this `code/` patch.

## Validation

- `git diff --check`
- `uvx ruff@0.14.5 check .`
- `uvx ruff@0.14.5 format --check .`
- `uv run --extra dev pytest` (32 passed)
- Targeted parser/import checks for PRM fallback ratings, rejection-sampling answer matching, direct-alignment config loading, and policy-gradient loss exports
