### PR TITLE
[codex] Migrate W&B links to core project

### DIFF
--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,6 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
+- 2026-05-13: Added optional `WANDB_ENTITY` support across the code examples and migrated verified reference links to the `rlhf-book/core` team project.
 - 2026-05-12: [PR #419](https://github.com/natolambert/rlhf-book/pull/419) fixed minor code docs and comments, direct-alignment experiment script paths, rejection-sampling answer matching, policy-gradient loss exports, and PRM fallback rating handling.
 - 2026-05-11: [PR #417](https://github.com/natolambert/rlhf-book/pull/417) documented reader experiment paths for the code examples, added agent guidance for running small RLHF Book experiments, and expanded contributor notes for adding new modules.
 - 2026-05-06: [PR #400](https://github.com/natolambert/rlhf-book/pull/400) added `dpo_norm` variant in direct-alignment that applies standard DPO with average response log-probs for both policy and reference model.

--- a/code/CLAUDE.md
+++ b/code/CLAUDE.md
@@ -18,8 +18,12 @@ See `CONTRIBUTING.md` for branch naming, PR conventions, and pre-submit checks.
 cd code/
 uv sync
 
-# Optional: log to wandb (public project for book examples)
+# Optional: log to your own/default W&B entity
 export WANDB_PROJECT=rlhf-book
+
+# Maintainers creating official reference runs should instead target the team project:
+# export WANDB_ENTITY=rlhf-book
+# export WANDB_PROJECT=core
 
 # Run training scripts
 uv run python -m policy_gradients.train --config policy_gradients/configs/grpo.yaml
@@ -91,7 +95,11 @@ If not installed, prompt user to install:
 
 ## Wandb
 
-Reference runs are published at https://wandb.ai/natolambert/rlhf-book (public, no login needed). When contributing new algorithms or configs, log runs to your own wandb project and include the link in your PR.
+Official runs are published at https://wandb.ai/rlhf-book/core. For ordinary
+contributor or reader runs, log to your own/default W&B entity with
+`WANDB_PROJECT=rlhf-book`. If the task is to publish, refresh, or validate
+official reference runs and you have access to the `rlhf-book` team, set
+`WANDB_ENTITY=rlhf-book` and `WANDB_PROJECT=core`.
 
 ## Memory Notes
 

--- a/code/README.md
+++ b/code/README.md
@@ -131,16 +131,16 @@ uv run python -m policy_gradients.train --config policy_gradients/configs/rloo.y
 
 | Algorithm | Config | Description | Example Run |
 |-----------|--------|-------------|-------------|
-| REINFORCE | `reinforce.yaml` | Williams (1992) - vanilla policy gradient | [wandb](https://wandb.ai/natolambert/rlhf-book/runs/0uqbq4oz) |
-| RLOO | `rloo.yaml` | REINFORCE Leave-One-Out (Ahmadian et al., 2024) | [wandb](https://wandb.ai/natolambert/rlhf-book/runs/07xeasn8) |
-| PPO | `ppo.yaml` | Proximal Policy Optimization (Schulman et al., 2017) | [wandb](https://wandb.ai/natolambert/rlhf-book/runs/ku3r3g9j) |
-| GRPO | `grpo.yaml` | Group Relative Policy Optimization (Shao et al., 2024) | [wandb](https://wandb.ai/natolambert/rlhf-book/runs/vjp7lgdi) |
-| Dr. GRPO | `drgrpo.yaml` | Dr. GRPO (Liu et al., 2025) | [wandb](https://wandb.ai/natolambert/rlhf-book/runs/a1swuynq) |
-| GSPO | `gspo.yaml` | Group-Sequence Policy Optimization (Zheng et al., 2025) | [wandb](https://wandb.ai/natolambert/rlhf-book/runs/10sxytli) |
-| CISPO | `cispo.yaml` | Clipped Importance Sampling PO (MiniMax, 2025) | [wandb](https://wandb.ai/natolambert/rlhf-book/runs/6dg0m06n) |
-| SAPO | `sapo.yaml` | Soft Adaptive Policy Optimization (Qwen Team, 2025) | [wandb](https://wandb.ai/natolambert/rlhf-book/runs/79608nwk) |
-| DAPO | `dapo.yaml` | Decoupled Clip and Dynamic sAmpling Policy Optimization (ByteDance, 2025) | [wandb](https://wandb.ai/natolambert/rlhf-book/runs/db1pipip) |
-| MaxRL | `maxrl.yaml` | Maximum Likelihood Reinforcement Learning (Tajwar et al., 2026) | [wandb](https://wandb.ai/natolambert/rlhf-book/runs/fdowf1se) |
+| REINFORCE | `reinforce.yaml` | Williams (1992) - vanilla policy gradient | [wandb](https://wandb.ai/rlhf-book/core/runs/0uqbq4oz) |
+| RLOO | `rloo.yaml` | REINFORCE Leave-One-Out (Ahmadian et al., 2024) | [wandb](https://wandb.ai/rlhf-book/core/runs/07xeasn8) |
+| PPO | `ppo.yaml` | Proximal Policy Optimization (Schulman et al., 2017) | [wandb](https://wandb.ai/rlhf-book/core/runs/ku3r3g9j) |
+| GRPO | `grpo.yaml` | Group Relative Policy Optimization (Shao et al., 2024) | [wandb](https://wandb.ai/rlhf-book/core/runs/vjp7lgdi) |
+| Dr. GRPO | `drgrpo.yaml` | Dr. GRPO (Liu et al., 2025) | [wandb](https://wandb.ai/rlhf-book/core/runs/a1swuynq) |
+| GSPO | `gspo.yaml` | Group-Sequence Policy Optimization (Zheng et al., 2025) | [wandb](https://wandb.ai/rlhf-book/core/runs/10sxytli) |
+| CISPO | `cispo.yaml` | Clipped Importance Sampling PO (MiniMax, 2025) | [wandb](https://wandb.ai/rlhf-book/core/runs/6dg0m06n) |
+| SAPO | `sapo.yaml` | Soft Adaptive Policy Optimization (Qwen Team, 2025) | [wandb](https://wandb.ai/rlhf-book/core/runs/79608nwk) |
+| DAPO | `dapo.yaml` | Decoupled Clip and Dynamic sAmpling Policy Optimization (ByteDance, 2025) | [wandb](https://wandb.ai/rlhf-book/core/runs/db1pipip) |
+| MaxRL | `maxrl.yaml` | Maximum Likelihood Reinforcement Learning (Tajwar et al., 2026) | [wandb](https://wandb.ai/rlhf-book/core/runs/fdowf1se) |
 
 ## Reward Model Training
 
@@ -179,9 +179,9 @@ learning to rate individual reasoning steps as {-1, 0, 1} (bad, neutral, good).
 
 | Model | Description | Example Run |
 |-------|-------------|-------------|
-| Preference RM | Bradley-Terry on UltraFeedback | [wandb](https://wandb.ai/natolambert/rlhf-book/runs/1g3y9bcc) |
-| ORM | Outcome RM on GSM8K | [wandb](https://wandb.ai/natolambert/rlhf-book/runs/3gkoqb7f) |
-| PRM | Process RM on PRM800K | [wandb](https://wandb.ai/natolambert/rlhf-book/runs/iv4d966d) |
+| Preference RM | Bradley-Terry on UltraFeedback | [wandb](https://wandb.ai/rlhf-book/core/runs/1g3y9bcc) |
+| ORM | Outcome RM on GSM8K | [wandb](https://wandb.ai/rlhf-book/core/runs/3gkoqb7f) |
+| PRM | Process RM on PRM800K | [wandb](https://wandb.ai/rlhf-book/core/runs/iv4d966d) |
 
 ## Direct Alignment Training
 
@@ -250,10 +250,10 @@ uv run python -m rejection_sampling.train \
 
 | Strategy | Description | Example Run |
 |----------|-------------|-------------|
-| `top_per_prompt` | Best-of-N completion per prompt | [wandb](https://wandb.ai/natolambert/rlhf-book/runs/ohm3xnga) |
-| `random_per_prompt` | Random per-prompt control | [wandb](https://wandb.ai/natolambert/rlhf-book/runs/y3pbcla7) |
-| `top_k_overall` | Best K completions across the full pool | [wandb](https://wandb.ai/natolambert/rlhf-book/runs/w75hklzs) |
-| `random_k_overall` | Random flat-pool control | [wandb](https://wandb.ai/natolambert/rlhf-book/runs/egeyr1q3) |
+| `top_per_prompt` | Best-of-N completion per prompt | [wandb](https://wandb.ai/rlhf-book/core/runs/ohm3xnga) |
+| `random_per_prompt` | Random per-prompt control | [wandb](https://wandb.ai/rlhf-book/core/runs/y3pbcla7) |
+| `top_k_overall` | Best K completions across the full pool | [wandb](https://wandb.ai/rlhf-book/core/runs/w75hklzs) |
+| `random_k_overall` | Random flat-pool control | [wandb](https://wandb.ai/rlhf-book/core/runs/egeyr1q3) |
 
 On the reference 1k-train / 200-test GSM8K slice, `top_k_overall` beat its
 matched random baseline, while `top_per_prompt` and `random_per_prompt` were
@@ -272,13 +272,18 @@ export WANDB_API_KEY="your-key"
 # Optional: Override project name (default: from config file)
 export WANDB_PROJECT="rlhf-book"
 
+# Official maintainers publishing reference runs can target the team project:
+# export WANDB_ENTITY="rlhf-book"
+# export WANDB_PROJECT="core"
+
 # Optional: Override run name
 export WANDB_RUN_NAME="grpo_experiment_1"
 ```
 
-The official runs for this repo are logged to: **[wandb.ai/natolambert/rlhf-book](https://wandb.ai/natolambert/rlhf-book)**
+Official runs for this repo are logged to: **[wandb.ai/rlhf-book/core](https://wandb.ai/rlhf-book/core)**
 
-All runs are **public** - no login required to view training curves, configs, and metrics.
+For public reference links, set the project visibility to **Public** in W&B so
+no login is required to view training curves, configs, and metrics.
 
 To disable wandb logging entirely, set `wandb_project: null` in your config or:
 ```bash

--- a/code/direct_alignment/ORPO_SIMPO.md
+++ b/code/direct_alignment/ORPO_SIMPO.md
@@ -22,10 +22,10 @@ Status: **Needs validation** — see [#358](https://github.com/natolambert/rlhf-
 cd code/
 
 # SimPO sanity run
-WANDB_PROJECT=rlhf-book ./direct_alignment/experiments/2026-02-08-orpo-simpo/run_simpo_small.sh
+WANDB_ENTITY=rlhf-book WANDB_PROJECT=core ./direct_alignment/experiments/2026-02-08-orpo-simpo/run_simpo_small.sh
 
 # ORPO sanity run
-WANDB_PROJECT=rlhf-book ./direct_alignment/experiments/2026-02-08-orpo-simpo/run_orpo_small.sh
+WANDB_ENTITY=rlhf-book WANDB_PROJECT=core ./direct_alignment/experiments/2026-02-08-orpo-simpo/run_orpo_small.sh
 ```
 
 ### Useful overrides

--- a/code/direct_alignment/README.md
+++ b/code/direct_alignment/README.md
@@ -11,14 +11,14 @@ As of 2026-02-08, ORPO/SimPO are still under investigation. See `direct_alignmen
 
 | Algorithm | wandb | Status |
 |-----------|-------|--------|
-| **DPO** | [dpo-olmo-1b](https://wandb.ai/natolambert/rlhf-book/runs/fzy8k8go) | ✅ Validated |
-| **DPO-Norm** | [dpo-norm-olmo-1b](https://wandb.ai/natolambert/rlhf-book/runs/giyhitjw) | ✅ Validated |
-| **IPO** | [ipo-olmo-1b](https://wandb.ai/natolambert/rlhf-book/runs/5s29syo6) | ✅ Validated |
-| **SimPO** | [simpo-olmo-1b](https://wandb.ai/natolambert/rlhf-book/runs/ftv5rs3x) | ⚠️ Noisy - needs debugging |
-| **ORPO** | [orpo-olmo-1b](https://wandb.ai/natolambert/rlhf-book/runs/o38ffli5) | ⚠️ Noisy - needs debugging |
-| **KTO** | [kto-olmo-1b](https://wandb.ai/natolambert/rlhf-book/runs/hgqrkfi6) | ✅ Validated |
-| **APO Zero** | [apo-zero-olmo-1b](https://wandb.ai/natolambert/rlhf-book/runs/3m2uiyw3) | ✅ Validated |
-| **APO Down** | [apo-down-olmo-1b](https://wandb.ai/natolambert/rlhf-book/runs/tqzkmyi6) | ✅ Validated |
+| **DPO** | [dpo-olmo-1b](https://wandb.ai/rlhf-book/core/runs/fzy8k8go) | ✅ Validated |
+| **DPO-Norm** | [dpo-norm-olmo-1b](https://wandb.ai/rlhf-book/core/runs/giyhitjw) | ✅ Validated |
+| **IPO** | [ipo-olmo-1b](https://wandb.ai/rlhf-book/core/runs/5s29syo6) | ✅ Validated |
+| **SimPO** | [simpo-olmo-1b](https://wandb.ai/rlhf-book/core/runs/ftv5rs3x) | ⚠️ Noisy - needs debugging |
+| **ORPO** | [orpo-olmo-1b](https://wandb.ai/rlhf-book/core/runs/o38ffli5) | ⚠️ Noisy - needs debugging |
+| **KTO** | [kto-olmo-1b](https://wandb.ai/rlhf-book/core/runs/hgqrkfi6) | ✅ Validated |
+| **APO Zero** | [apo-zero-olmo-1b](https://wandb.ai/rlhf-book/core/runs/3m2uiyw3) | ✅ Validated |
+| **APO Down** | [apo-down-olmo-1b](https://wandb.ai/rlhf-book/core/runs/tqzkmyi6) | ✅ Validated |
 
 ![Direct alignment accuracy curves for DPO, IPO, and KTO](../images/wandb_direct_alignment.png)
 

--- a/code/direct_alignment/config.py
+++ b/code/direct_alignment/config.py
@@ -55,6 +55,7 @@ class Config:
     bf16: bool = True
 
     # Logging
+    wandb_entity: str | None = None
     wandb_project: str | None = None
     wandb_run_name: str | None = None
     log_every: int = 10

--- a/code/direct_alignment/experiments/2026-02-08-orpo-simpo.md
+++ b/code/direct_alignment/experiments/2026-02-08-orpo-simpo.md
@@ -32,45 +32,45 @@ This is an experiment log for the ORPO/SimPO debugging and sweep work done in th
 
 ## Baseline Runs (Before This Sweep)
 
-- ORPO baseline from earlier work: https://wandb.ai/natolambert/rlhf-book/runs/oulqxp2i
-- SimPO baseline from earlier work: https://wandb.ai/natolambert/rlhf-book/runs/7s100ned
+- ORPO baseline from earlier work: https://wandb.ai/rlhf-book/core/runs/oulqxp2i
+- SimPO baseline from earlier work: https://wandb.ai/rlhf-book/core/runs/7s100ned
 
 ## W&B Runs Tried In This Session
 
-- SimPO, `lr=1e-6`, `gamma=0.3`, `samples=3200`, default script length (512): https://wandb.ai/natolambert/rlhf-book/runs/53pqrzt4
+- SimPO, `lr=1e-6`, `gamma=0.3`, `samples=3200`, default script length (512): https://wandb.ai/rlhf-book/core/runs/53pqrzt4
   - Final: `loss=0.7520`, `accuracy=75%`, `margins=0.31738`.
-- SimPO, `lr=1e-6`, `gamma=0.1`, `samples=3200`, default script length (512): https://wandb.ai/natolambert/rlhf-book/runs/6yzwk11y
+- SimPO, `lr=1e-6`, `gamma=0.1`, `samples=3200`, default script length (512): https://wandb.ai/rlhf-book/core/runs/6yzwk11y
   - Final: `loss=0.5747`, `accuracy=75%`, `margins=0.31738`.
-- SimPO, `lr=2e-6`, `gamma=0.1`, `samples=3200`, default script length (512): https://wandb.ai/natolambert/rlhf-book/runs/2gz0njwu
+- SimPO, `lr=2e-6`, `gamma=0.1`, `samples=3200`, default script length (512): https://wandb.ai/rlhf-book/core/runs/2gz0njwu
   - Final: `loss=0.5693`, `accuracy=75%`, `margins=0.32861`.
-- SimPO, `lr=2e-6`, `gamma=0.0`, `samples=3200`, default script length (512): https://wandb.ai/natolambert/rlhf-book/runs/sass9db0
+- SimPO, `lr=2e-6`, `gamma=0.0`, `samples=3200`, default script length (512): https://wandb.ai/rlhf-book/core/runs/sass9db0
   - Final: `loss=0.4944`, `accuracy=75%`, `margins=0.32764`.
-- SimPO, `lr=2e-6`, `gamma=0.1`, `max_length=1024`, `samples=1600`: https://wandb.ai/natolambert/rlhf-book/runs/bxqfssoz
+- SimPO, `lr=2e-6`, `gamma=0.1`, `max_length=1024`, `samples=1600`: https://wandb.ai/rlhf-book/core/runs/bxqfssoz
   - Final: `loss=0.9219`, `accuracy=50%`, `margins=0.01562`.
-- SimPO, `lr=2e-6`, `gamma=0.0`, `max_length=1024`, `samples=1600`: https://wandb.ai/natolambert/rlhf-book/runs/6h01t41k
+- SimPO, `lr=2e-6`, `gamma=0.0`, `max_length=1024`, `samples=1600`: https://wandb.ai/rlhf-book/core/runs/6h01t41k
   - Final: `loss=0.8149`, `accuracy=50%`, `margins=0.01709`.
-- SimPO, `lr=2e-6`, `gamma=0.0`, `max_length=512`, `samples=1600`: https://wandb.ai/natolambert/rlhf-book/runs/a57ccg0b
+- SimPO, `lr=2e-6`, `gamma=0.0`, `max_length=512`, `samples=1600`: https://wandb.ai/rlhf-book/core/runs/a57ccg0b
   - Final: `loss=0.7498`, `accuracy=50%`, `margins=0.06494`.
-- SimPO, `lr=2e-6`, `gamma=0.0`, `max_length=1024`, `samples=3200`: https://wandb.ai/natolambert/rlhf-book/runs/oek7xtxa
+- SimPO, `lr=2e-6`, `gamma=0.0`, `max_length=1024`, `samples=3200`: https://wandb.ai/rlhf-book/core/runs/oek7xtxa
   - Final: `loss=0.4485`, `accuracy=75%`, `margins=0.38135`.
-- ORPO, `beta=0.5`, `lr=5e-6`, `max_length=2048`, `samples=1600`: https://wandb.ai/natolambert/rlhf-book/runs/ha54crna
+- ORPO, `beta=0.5`, `lr=5e-6`, `max_length=2048`, `samples=1600`: https://wandb.ai/rlhf-book/core/runs/ha54crna
   - Final: `loss=1.4657`, `accuracy=50%`, `margins=0.00964`, `log_odds_ratio=0.00557`, `or_loss=0.38925`.
-- ORPO debug sanity, `beta=1.0`, `lr=5e-6`, `max_length=2048`, `samples=64`: https://wandb.ai/natolambert/rlhf-book/runs/g83zbxka
+- ORPO debug sanity, `beta=1.0`, `lr=5e-6`, `max_length=2048`, `samples=64`: https://wandb.ai/rlhf-book/core/runs/g83zbxka
   - Final: `loss=1.5125`, `accuracy=50%`, `margins=0.10352`, `log_odds_ratio=0.19609`, `or_loss=0.6121`.
-- ORPO long follow-up, `beta=1.0`, `lr=5e-6`, `max_length=2048`, `samples=1600`: https://wandb.ai/natolambert/rlhf-book/runs/tmh0enbt
+- ORPO long follow-up, `beta=1.0`, `lr=5e-6`, `max_length=2048`, `samples=1600`: https://wandb.ai/rlhf-book/core/runs/tmh0enbt
   - Status: in progress as of last check in this session.
 
 ### Additional Runs (Later in Session)
 
-- ORPO quick foreground sanity, `beta=2.0`, `lr=5e-6`, `max_length=2048`, `samples=64`: https://wandb.ai/natolambert/rlhf-book/runs/qnevkkls
+- ORPO quick foreground sanity, `beta=2.0`, `lr=5e-6`, `max_length=2048`, `samples=64`: https://wandb.ai/rlhf-book/core/runs/qnevkkls
   - Final: `loss=1.9281`, `accuracy=75%`, `margins=0.41602`, `log_odds_ratio=0.36625`, `or_loss=1.09409`, `sft_loss=0.83301`.
-- ORPO probe, `beta=2.0`, `lr=5e-6`, `max_length=2048`, `samples=160`: https://wandb.ai/natolambert/rlhf-book/runs/7pruw05c
+- ORPO probe, `beta=2.0`, `lr=5e-6`, `max_length=2048`, `samples=160`: https://wandb.ai/rlhf-book/core/runs/7pruw05c
   - Final: `loss=3.2088`, `accuracy=37.5%`, `margins=-0.48047`, `log_odds_ratio=-0.35272`, `or_loss=1.87631`, `sft_loss=1.33203`.
-- ORPO probe, `beta=1.0`, `lr=8e-6`, `max_length=2048`, `samples=160`: https://wandb.ai/natolambert/rlhf-book/runs/58ywuqr4
+- ORPO probe, `beta=1.0`, `lr=8e-6`, `max_length=2048`, `samples=160`: https://wandb.ai/rlhf-book/core/runs/58ywuqr4
   - Final: `loss=2.2654`, `accuracy=37.5%`, `margins=-0.23877`, `log_odds_ratio=-0.35103`, `or_loss=0.93680`, `sft_loss=1.33008`.
-- SimPO probe, `beta=2.0`, `gamma=0.0`, `lr=2e-6`, `max_length=1024`, `samples=160`: https://wandb.ai/natolambert/rlhf-book/runs/myvyfkat
+- SimPO probe, `beta=2.0`, `gamma=0.0`, `lr=2e-6`, `max_length=1024`, `samples=160`: https://wandb.ai/rlhf-book/core/runs/myvyfkat
   - Final: `loss=1.0664`, `accuracy=37.5%`, `margins=-0.24170`.
-- ORPO probe (aborted at step 12), `beta=1.0`, `lr=1e-5`, `max_length=2048`, `samples=160`: https://wandb.ai/natolambert/rlhf-book/runs/hi16cuou
+- ORPO probe (aborted at step 12), `beta=1.0`, `lr=1e-5`, `max_length=2048`, `samples=160`: https://wandb.ai/rlhf-book/core/runs/hi16cuou
   - Read: same oscillatory, batch-dominated pattern through step 12 (no clear early trend improvement vs lower-LR probes).
 
 ## Non-W&B / Aborted Probes
@@ -91,4 +91,4 @@ This is an experiment log for the ORPO/SimPO debugging and sweep work done in th
 - Add a stable eval signal (fixed eval subset and periodic eval logging) before trusting short-run train-step curves.
 - Re-run ORPO/SimPO with larger effective batch for smoother metrics (e.g., target effective batch 16-32 if memory allows).
 - After picking the best-smoothed config, scale to `max_samples=640`, then `1600+`.
-- Keep W&B enabled for all runs (`WANDB_PROJECT=rlhf-book`, never `WANDB_MODE=disabled` for benchmark sweeps).
+- Keep W&B enabled for all runs (`WANDB_ENTITY=rlhf-book WANDB_PROJECT=core`, never `WANDB_MODE=disabled` for benchmark sweeps).

--- a/code/direct_alignment/train.py
+++ b/code/direct_alignment/train.py
@@ -569,6 +569,7 @@ def main(cfg: Config):
     scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
 
     # Initialize wandb
+    wandb_entity = os.environ.get("WANDB_ENTITY", cfg.wandb_entity)
     wandb_project = os.environ.get("WANDB_PROJECT", cfg.wandb_project)
     wandb_run_name = os.environ.get("WANDB_RUN_NAME", cfg.wandb_run_name)
 
@@ -576,6 +577,7 @@ def main(cfg: Config):
         wandb.init(mode="disabled")
     else:
         wandb.init(
+            entity=wandb_entity,
             project=wandb_project,
             name=wandb_run_name or f"{cfg.loss}-{cfg.model_name.split('/')[-1]}",
             config=vars(cfg),
@@ -782,6 +784,7 @@ def main_cli():
     parser.add_argument("--num_epochs", type=int, help="Number of epochs")
     parser.add_argument("--batch_size", type=int, help="Batch size")
     parser.add_argument("--gradient_accumulation_steps", type=int)
+    parser.add_argument("--wandb_entity", type=str, help="Wandb entity/team name")
     parser.add_argument("--wandb_project", type=str, help="Wandb project name")
     parser.add_argument(
         "--sample_every", type=int, help="Generate samples every N steps (0 to disable)"

--- a/code/policy_gradients/README.md
+++ b/code/policy_gradients/README.md
@@ -25,16 +25,16 @@ See the parent [`code/README.md`](../README.md) for installation, configuration,
 
 | Algorithm | wandb | Status |
 |-----------|-------|--------|
-| **REINFORCE** | [run](https://wandb.ai/natolambert/rlhf-book/runs/0uqbq4oz) | ✅ Validated |
-| **RLOO** | [run](https://wandb.ai/natolambert/rlhf-book/runs/07xeasn8) | ✅ Validated |
-| **PPO** | [run](https://wandb.ai/natolambert/rlhf-book/runs/ku3r3g9j) | ✅ Validated |
-| **GRPO** | [run](https://wandb.ai/natolambert/rlhf-book/runs/vjp7lgdi) | ✅ Validated |
-| **Dr. GRPO** | [run](https://wandb.ai/natolambert/rlhf-book/runs/a1swuynq) | ✅ Validated |
-| **GSPO** | [run](https://wandb.ai/natolambert/rlhf-book/runs/10sxytli) | ✅ Validated |
-| **CISPO** | [run](https://wandb.ai/natolambert/rlhf-book/runs/6dg0m06n) | ✅ Validated |
-| **SAPO** | [run](https://wandb.ai/natolambert/rlhf-book/runs/79608nwk) | ✅ Validated |
-| **DAPO** | [run](https://wandb.ai/natolambert/rlhf-book/runs/db1pipip) | ✅ Validated |
-| **MaxRL** | [run](https://wandb.ai/natolambert/rlhf-book/runs/fdowf1se) | ✅ Validated |
+| **REINFORCE** | [run](https://wandb.ai/rlhf-book/core/runs/0uqbq4oz) | ✅ Validated |
+| **RLOO** | [run](https://wandb.ai/rlhf-book/core/runs/07xeasn8) | ✅ Validated |
+| **PPO** | [run](https://wandb.ai/rlhf-book/core/runs/ku3r3g9j) | ✅ Validated |
+| **GRPO** | [run](https://wandb.ai/rlhf-book/core/runs/vjp7lgdi) | ✅ Validated |
+| **Dr. GRPO** | [run](https://wandb.ai/rlhf-book/core/runs/a1swuynq) | ✅ Validated |
+| **GSPO** | [run](https://wandb.ai/rlhf-book/core/runs/10sxytli) | ✅ Validated |
+| **CISPO** | [run](https://wandb.ai/rlhf-book/core/runs/6dg0m06n) | ✅ Validated |
+| **SAPO** | [run](https://wandb.ai/rlhf-book/core/runs/79608nwk) | ✅ Validated |
+| **DAPO** | [run](https://wandb.ai/rlhf-book/core/runs/db1pipip) | ✅ Validated |
+| **MaxRL** | [run](https://wandb.ai/rlhf-book/core/runs/fdowf1se) | ✅ Validated |
 
 ## Quick Start
 

--- a/code/policy_gradients/config.py
+++ b/code/policy_gradients/config.py
@@ -131,6 +131,7 @@ class Config(BaseModel):
     model_device_id: int = 0
 
     # Logging
+    wandb_entity: str | None = None
     wandb_project: str | None = None
     wandb_run_name: str | None = None
 

--- a/code/policy_gradients/train.py
+++ b/code/policy_gradients/train.py
@@ -71,14 +71,20 @@ def main(cfg: Config):
     params = list(model.parameters()) + (list(val_model.parameters()) if val_model else [])
     optimizer = optim.Adam(params, lr=cfg.lr)
 
-    # wandb project can be set via env var WANDB_PROJECT or config file
+    # wandb entity/project can be set via env vars or the config file
+    wandb_entity = os.environ.get("WANDB_ENTITY", cfg.wandb_entity)
     wandb_project = os.environ.get("WANDB_PROJECT", cfg.wandb_project)
     wandb_run_name = os.environ.get("WANDB_RUN_NAME", cfg.wandb_run_name)
 
     if wandb_project is None:
         wandb.init(mode="disabled")
     else:
-        wandb.init(project=wandb_project, name=wandb_run_name, config=vars(cfg))
+        wandb.init(
+            entity=wandb_entity,
+            project=wandb_project,
+            name=wandb_run_name,
+            config=vars(cfg),
+        )
     print_model_info(model)
 
     start_time = time.time()

--- a/code/rejection_sampling/README.md
+++ b/code/rejection_sampling/README.md
@@ -37,10 +37,10 @@ cache is shared across strategies — only the selection step differs.
 
 | Strategy | wandb | Status |
 |----------|-------|--------|
-| **top_per_prompt** | [rs_top_per_prompt_gsm8k](https://wandb.ai/natolambert/rlhf-book/runs/ohm3xnga) | ✅ Completed |
-| **random_per_prompt** | [rs_random_per_prompt_gsm8k](https://wandb.ai/natolambert/rlhf-book/runs/y3pbcla7) | ✅ Completed |
-| **top_k_overall** | [rs_top_k_overall_gsm8k](https://wandb.ai/natolambert/rlhf-book/runs/w75hklzs) | ✅ Completed |
-| **random_k_overall** | [rs_random_k_overall_gsm8k](https://wandb.ai/natolambert/rlhf-book/runs/egeyr1q3) | ✅ Completed |
+| **top_per_prompt** | [rs_top_per_prompt_gsm8k](https://wandb.ai/rlhf-book/core/runs/ohm3xnga) | ✅ Completed |
+| **random_per_prompt** | [rs_random_per_prompt_gsm8k](https://wandb.ai/rlhf-book/core/runs/y3pbcla7) | ✅ Completed |
+| **top_k_overall** | [rs_top_k_overall_gsm8k](https://wandb.ai/rlhf-book/core/runs/w75hklzs) | ✅ Completed |
+| **random_k_overall** | [rs_random_k_overall_gsm8k](https://wandb.ai/rlhf-book/core/runs/egeyr1q3) | ✅ Completed |
 
 ![Rejection sampling accuracy curves across the four reference runs](../images/wandb_rejection_sampling.png)
 
@@ -103,7 +103,10 @@ The `output/` directory is gitignored.
 
 ## Wandb
 
-The module reads `WANDB_PROJECT`, `WANDB_RUN_NAME`, and `WANDB_API_KEY` from
-the environment. The YAML configs set `wandb_project: rlhf-book` by default;
-set `WANDB_PROJECT` in your shell to override it, or set `wandb_project: null`
-in the YAML (and unset the env var) to disable logging entirely.
+The module reads `WANDB_ENTITY`, `WANDB_PROJECT`, `WANDB_RUN_NAME`, and
+`WANDB_API_KEY` from the environment. The YAML configs set
+`wandb_project: rlhf-book` by default and intentionally do not set an entity,
+so runs land in your default W&B account or team. Official maintainers can set
+`WANDB_ENTITY=rlhf-book WANDB_PROJECT=core` to publish reference runs, or set
+`wandb_project: null` in the YAML (and unset the env var) to disable logging
+entirely.

--- a/code/rejection_sampling/config.py
+++ b/code/rejection_sampling/config.py
@@ -64,6 +64,7 @@ class Config(BaseModel):
     reward_model_device_id: int = 0
     output_dir: str = "./rejection_sampling/output"
     save_checkpoint: bool = False
+    wandb_entity: str | None = None
     wandb_project: str | None = None
     wandb_run_name: str | None = None
 

--- a/code/rejection_sampling/train.py
+++ b/code/rejection_sampling/train.py
@@ -297,11 +297,13 @@ def main(cfg: Config) -> None:
         )
     )
 
+    wandb_entity = os.environ.get("WANDB_ENTITY", cfg.wandb_entity)
     wandb_project = os.environ.get("WANDB_PROJECT", cfg.wandb_project)
     if wandb_project is None:
         wandb.init(mode="disabled")
     else:
         wandb.init(
+            entity=wandb_entity,
             project=wandb_project,
             name=os.environ.get("WANDB_RUN_NAME", cfg.wandb_run_name)
             or f"rs-{cfg.selection.strategy}",

--- a/code/reward_models/README.md
+++ b/code/reward_models/README.md
@@ -19,9 +19,9 @@ See **Chapter 5: Reward Models** for mathematical derivations and intuitions.
 
 | Algorithm | wandb | Status |
 |-----------|-------|--------|
-| **ORM** | [run](https://wandb.ai/natolambert/rlhf-book/runs/xm8mlcpl) | Experimental |
-| **Preference RM** | [run](https://wandb.ai/natolambert/rlhf-book/runs/6sninll5) | Experimental |
-| **PRM** | [run](https://wandb.ai/natolambert/rlhf-book/runs/abhkbn4q) | Experimental |
+| **ORM** | [run](https://wandb.ai/rlhf-book/core/runs/xm8mlcpl) | Experimental |
+| **Preference RM** | [run](https://wandb.ai/rlhf-book/core/runs/6sninll5) | Experimental |
+| **PRM** | [run](https://wandb.ai/rlhf-book/core/runs/abhkbn4q) | Experimental |
 
 ## Quick Start
 

--- a/code/reward_models/base.py
+++ b/code/reward_models/base.py
@@ -121,10 +121,12 @@ def init_wandb(
     Returns:
         True if wandb is enabled, False otherwise
     """
+    wandb_entity = os.environ.get("WANDB_ENTITY")
     wandb_project = os.environ.get("WANDB_PROJECT")
 
     if use_wandb and wandb_project:
         wandb.init(
+            entity=wandb_entity,
             project=wandb_project,
             name=os.environ.get("WANDB_RUN_NAME", default_run_name),
             config=config,

--- a/code/scripts/run_all_policy_gradients.sh
+++ b/code/scripts/run_all_policy_gradients.sh
@@ -50,5 +50,9 @@ uv run python -m policy_gradients.train --config policy_gradients/configs/sapo.y
 echo ""
 echo "=========================================="
 echo "All runs complete!"
-echo "Check wandb project: https://wandb.ai/natolambert/$WANDB_PROJECT"
+if [ -n "${WANDB_ENTITY:-}" ]; then
+  echo "Check wandb project: https://wandb.ai/${WANDB_ENTITY}/${WANDB_PROJECT}"
+else
+  echo "Check wandb project: ${WANDB_PROJECT}"
+fi
 echo "=========================================="


### PR DESCRIPTION
## Summary

- Add optional `WANDB_ENTITY` support across the code examples so maintainers can target the `rlhf-book` team explicitly.
- Keep checked-in example configs contributor-friendly by leaving W&B entity unset and retaining the project-only `wandb_project: rlhf-book` default.
- Update documented W&B reference links to the moved `https://wandb.ai/rlhf-book/core/...` run paths.

## Verification

- Queried the W&B API and confirmed the documented run IDs resolve under `rlhf-book/core` before rewriting links.
- `git diff --check`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check .`
- `uv run --extra dev python -m pytest`