### PR TITLE
Add instruction tuning code link to navbar and chapter list

### DIFF
--- a/book/templates/nav.js
+++ b/book/templates/nav.js
@@ -44,7 +44,7 @@ class NavigationDropdown extends HTMLElement {
       <div class="section">
         <h3>Core Training Pipeline</h3>
         <ol start="4">
-          <li><a href="/c/04-instruction-tuning">Instruction Fine-Tuning</a></li>
+          <li><a href="/c/04-instruction-tuning">Instruction Fine-Tuning</a> [<a href="https://github.com/natolambert/rlhf-book/tree/main/code/instruction_tuning">code</a>]</li>
           <li><a href="/c/05-reward-models">Reward Modeling</a> [<a href="https://github.com/natolambert/rlhf-book/tree/main/code/reward_models">code</a>]</li>
           <li><a href="/c/06-policy-gradients">Reinforcement Learning</a> [<a href="https://github.com/natolambert/rlhf-book/tree/main/code/policy_gradients">code</a>]</li>
           <li><a href="/c/07-reasoning">Reasoning and Inference-Time Scaling</a></li>

--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,7 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
-- 2026-05-15: Added `[code]` link to `code/instruction_tuning` in the site navbar and listed Chapter 4 (Instruction Tuning) under the Book Chapters section of `code/README.md`.
+- 2026-05-15: [PR #425](https://github.com/natolambert/rlhf-book/pull/425) added `[code]` link to `code/instruction_tuning` in the site navbar and listed Chapter 4 (Instruction Tuning) under the Book Chapters section of `code/README.md`.
 - 2026-05-15: [PR #424](https://github.com/natolambert/rlhf-book/pull/424) documented the instruction-tuning reference run in `code/README.md` and `code/instruction_tuning/README.md` — added a new SFT section with the wandb training-results image (`code/images/wandb_instruction_tuning.png`) and an example-run table linking to [wandb run `nybj8sdx`](https://wandb.ai/rlhf-book/core/runs/nybj8sdx), illustrated the base→assistant transition with step-100 vs step-650 sample panels, and dropped the placeholder `TODO(@natolambert)` from the reader experiment table.
 - 2026-05-13: [PR #421](https://github.com/natolambert/rlhf-book/pull/421) added optional `WANDB_ENTITY` support across the code examples and migrated verified reference links to the `rlhf-book/core` team project.
 - 2026-05-12: [PR #419](https://github.com/natolambert/rlhf-book/pull/419) fixed minor code docs and comments, direct-alignment experiment script paths, rejection-sampling answer matching, policy-gradient loss exports, and PRM fallback rating handling.

--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,6 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
+- 2026-05-15: Added `[code]` link to `code/instruction_tuning` in the site navbar and listed Chapter 4 (Instruction Tuning) under the Book Chapters section of `code/README.md`.
 - 2026-05-15: [PR #424](https://github.com/natolambert/rlhf-book/pull/424) documented the instruction-tuning reference run in `code/README.md` and `code/instruction_tuning/README.md` — added a new SFT section with the wandb training-results image (`code/images/wandb_instruction_tuning.png`) and an example-run table linking to [wandb run `nybj8sdx`](https://wandb.ai/rlhf-book/core/runs/nybj8sdx), illustrated the base→assistant transition with step-100 vs step-650 sample panels, and dropped the placeholder `TODO(@natolambert)` from the reader experiment table.
 - 2026-05-13: [PR #421](https://github.com/natolambert/rlhf-book/pull/421) added optional `WANDB_ENTITY` support across the code examples and migrated verified reference links to the `rlhf-book/core` team project.
 - 2026-05-12: [PR #419](https://github.com/natolambert/rlhf-book/pull/419) fixed minor code docs and comments, direct-alignment experiment script paths, rejection-sampling answer matching, policy-gradient loss exports, and PRM fallback rating handling.

--- a/code/README.md
+++ b/code/README.md
@@ -363,6 +363,7 @@ uv run --extra dev pytest
 
 These examples correspond to:
 
+- **Chapter 4**: Instruction Tuning (SFT)
 - **Chapter 5**: Reward Models (ORM, PRM, Preference RM)
 - **Chapter 6**: Policy Gradient Methods (REINFORCE, PPO, GRPO, etc.)
 - **Chapter 8**: Direct Alignment (DPO, IPO, SimPO, KTO, etc.)


### PR DESCRIPTION
## Summary
- Added `[code]` link to `code/instruction_tuning` next to "Instruction Fine-Tuning" in the site navbar (`book/templates/nav.js`), matching the pattern used for chapters 5/6/8/9.
- Listed Chapter 4 (Instruction Tuning, SFT) under the Book Chapters section of `code/README.md`.

## Test plan
- [ ] Verify the navbar renders the new `[code]` link next to Instruction Fine-Tuning.
- [ ] Confirm the link resolves to https://github.com/natolambert/rlhf-book/tree/main/code/instruction_tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)