### PR TITLE
Add instruction_tuning module to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ rlhf-book/
 │   ├── scripts/            # Build utilities
 │   └── data/               # Library data
 ├── code/                   # Reference implementations
+│   ├── instruction_tuning/ # SFT a base model with chat templates
 │   ├── policy_gradients/   # PPO, REINFORCE, GRPO, RLOO
 │   ├── reward_models/      # Preference RM, ORM, PRM training
 │   ├── direct_alignment/   # DPO and variants
-│   ├── instruction_tuning/ # SFT a base model with chat templates
 │   └── rejection_sampling/ # Best-of-N rejection sampling
 ├── diagrams/               # Diagram source files
 │   ├── scripts/            # Python generation scripts
@@ -51,10 +51,10 @@ rlhf-book/
 ## Code Library
 
 Reference implementations for RLHF algorithms in `code/`:
+- Instruction tuning (SFT a base model with chat templates)
 - Policy gradient methods (PPO, REINFORCE, GRPO, RLOO, etc.)
 - Reward model training (preference RM, ORM, PRM)
 - Direct alignment methods (DPO and variants)
-- Instruction tuning (SFT a base model with chat templates)
 - Rejection sampling (best-of-N)
 
 See [code/README.md](code/README.md) for setup and usage.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Reference implementations for RLHF algorithms in `code/`:
 - Policy gradient methods (PPO, REINFORCE, GRPO, RLOO, etc.)
 - Reward model training (preference RM, ORM, PRM)
 - Direct alignment methods (DPO and variants)
+- Instruction tuning (SFT a base model with chat templates)
 - Rejection sampling (best-of-N)
 
 See [code/README.md](code/README.md) for setup and usage.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ rlhf-book/
 │   ├── policy_gradients/   # PPO, REINFORCE, GRPO, RLOO
 │   ├── reward_models/      # Preference RM, ORM, PRM training
 │   ├── direct_alignment/   # DPO and variants
+│   ├── instruction_tuning/ # SFT a base model with chat templates
 │   └── rejection_sampling/ # Best-of-N rejection sampling
 ├── diagrams/               # Diagram source files
 │   ├── scripts/            # Python generation scripts


### PR DESCRIPTION
## Summary
- Add `instruction_tuning/` to the repository structure tree
- Add instruction tuning to the Code Library list
- Place it first in both lists since it corresponds to chapter 4 (the earliest chapter among the listed modules)

cc @natolambert for review

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)