### PR TITLE
[codex] Address RL cheatsheet and lecture 3 feedback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,6 +302,7 @@ COURSE_LECTURE_NAMES = $(basename $(notdir $(COURSE_LECTURE_SOURCES)))
 
 # Map from dir name to its .md source file (prefer talk.md over slides.md)
 teach_source = $(firstword $(wildcard teach/$(1)/talk.md teach/$(1)/slides.md))
+COLLOQUIUM = uv run --extra teach colloquium
 
 teach: $(foreach d,$(TEACH_DIRS),teach-$(d)) course-lectures
 
@@ -309,22 +310,22 @@ course-lectures: $(foreach l,$(COURSE_LECTURE_NAMES),course-lecture-$(l))
 
 teach-%:
 	@mkdir -p $(BUILD)/html/teach/$*
-	uv run colloquium build $(call teach_source,$*) -o $(BUILD)/html/teach/$*/
+	$(COLLOQUIUM) build $(call teach_source,$*) -o $(BUILD)/html/teach/$*/
 	@# Rename output to index.html so the directory URL works
 	@cd $(BUILD)/html/teach/$* && for f in *.html; do [ "$$f" != "index.html" ] && mv "$$f" index.html; done || true
 	@# Export PDF
-	uv run colloquium export $(call teach_source,$*) -o $(BUILD)/html/teach/$*/slides.pdf
+	$(COLLOQUIUM) export $(call teach_source,$*) -o $(BUILD)/html/teach/$*/slides.pdf
 	@# Copy talk assets (images) if present
 	@test -d teach/$*/assets && cp -r teach/$*/assets $(BUILD)/html/teach/$*/ || true
 	@echo "Built teach/$*"
 
 course-lecture-%:
 	@mkdir -p $(BUILD)/html/teach/course/$*
-	uv run colloquium build teach/course/$*.md -o $(BUILD)/html/teach/course/$*/
+	$(COLLOQUIUM) build teach/course/$*.md -o $(BUILD)/html/teach/course/$*/
 	@# Rename output to index.html so the directory URL works
 	@cd $(BUILD)/html/teach/course/$* && for f in *.html; do [ "$$f" != "index.html" ] && mv "$$f" index.html; done || true
 	@# Export PDF
-	uv run colloquium export teach/course/$*.md -o $(BUILD)/html/teach/course/$*/slides.pdf
+	$(COLLOQUIUM) export teach/course/$*.md -o $(BUILD)/html/teach/course/$*/slides.pdf
 	@# Copy course assets if present
 	@test -d teach/course/assets && cp -r teach/course/assets $(BUILD)/html/teach/course/$*/ || true
 	@echo "Built teach/course/$*"

--- a/book/rl-cheatsheet/index.html
+++ b/book/rl-cheatsheet/index.html
@@ -79,7 +79,7 @@
     }
 
     table.equations {
-      width: 100%;
+      width: auto;
       min-width: 58em;
       margin: 0 auto 1em;
       border-collapse: collapse;

--- a/book/rl-cheatsheet/index.html
+++ b/book/rl-cheatsheet/index.html
@@ -331,8 +331,14 @@
       <tr>
         <td>\(r_\theta(y \mid x)\)</td>
         <td>Reward model score</td>
-        <td></td>
-        <td></td>
+        <td>\(T\)</td>
+        <td>Trajectory length / time horizon</td>
+      </tr>
+      <tr>
+        <td>\(K\)</td>
+        <td>Number of sampled completions</td>
+        <td>\(G\)</td>
+        <td>Group size for GRPO / GSPO</td>
       </tr>
     </table>
   </div>

--- a/book/rl-cheatsheet/index.html
+++ b/book/rl-cheatsheet/index.html
@@ -32,6 +32,9 @@
       max-width: none;
       margin-left: 50%;
       transform: translateX(-50%);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
     }
 
     .download-buttons {
@@ -59,6 +62,7 @@
     }
 
     .cheatsheet-section h2 {
+      width: 100%;
       font-size: 1.1em;
       text-align: center;
       margin-top: 3em;
@@ -66,6 +70,7 @@
     }
 
     .cheatsheet-section hr {
+      width: 100%;
       margin-bottom: 0.5em;
       border: none;
       border-top: 1px solid #ccc;
@@ -135,6 +140,10 @@
     @media (max-width: 720px) {
       body {
         max-width: 100%;
+      }
+
+      .cheatsheet-section {
+        align-items: flex-start;
       }
 
       table.equations td:first-child {

--- a/book/rl-cheatsheet/index.html
+++ b/book/rl-cheatsheet/index.html
@@ -230,7 +230,10 @@
           Proximal Policy Optimization
           <span class="subtitle">(PPO)</span>
         </td>
-        <td>\(\displaystyle -\;\frac{1}{T}\sum_{t=1}^{T}\min\!\left(\frac{\pi_\theta(a_t\mid s_t)}{\pi_{\theta_{\text{old}}}(a_t\mid s_t)} A_t,\; \text{clip}\!\left(\frac{\pi_\theta(a_t\mid s_t)}{\pi_{\theta_{\text{old}}}(a_t\mid s_t)},\, 1\!-\!\varepsilon,\, 1\!+\!\varepsilon\right) A_t\right)\)</td>
+        <td>
+          \(\displaystyle -\;\frac{1}{T}\sum_{t=1}^{T}\min\!\left(\frac{\pi_\theta(a_t\mid s_t)}{\pi_{\theta_{\text{old}}}(a_t\mid s_t)} A_t,\; \text{clip}\!\left(\frac{\pi_\theta(a_t\mid s_t)}{\pi_{\theta_{\text{old}}}(a_t\mid s_t)},\, 1\!-\!\varepsilon,\, 1\!+\!\varepsilon\right) A_t\right)\)
+          <p class="eq-note">PPO usually estimates \(A_t\) with GAE; other advantage estimates are possible.</p>
+        </td>
       </tr>
       <tr>
         <td>

--- a/book/rl-cheatsheet/index.html
+++ b/book/rl-cheatsheet/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="rl-cheatsheet-page">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
@@ -19,9 +19,17 @@
       text-align: center;
     }
 
+    html.rl-cheatsheet-page {
+      overflow-x: auto;
+    }
+
+    html.rl-cheatsheet-page body {
+      overflow-x: visible;
+    }
+
     .cheatsheet-section {
-      width: 80vw;
-      max-width: 60em;
+      width: min(92vw, 88rem);
+      max-width: none;
       margin-left: 50%;
       transform: translateX(-50%);
     }
@@ -71,7 +79,8 @@
     }
 
     table.equations {
-      width: 92%;
+      width: 100%;
+      min-width: 58em;
       margin: 0 auto 1em;
       border-collapse: collapse;
       border: none;

--- a/book/rl-cheatsheet/inside_cover_back.tex
+++ b/book/rl-cheatsheet/inside_cover_back.tex
@@ -50,7 +50,9 @@ Proximal Policy Optimization
 \newline\mdseries (PPO)
 &
 $\displaystyle -\;\frac{1}{T}\sum_{t=1}^{T}\min\!\left(\frac{\pi_\theta(a_t\mid s_t)}{\pi_{\theta_{\text{old}}}(a_t\mid s_t)} A_t,\; \mathrm{clip}\!\left(\frac{\pi_\theta(a_t\mid s_t)}{\pi_{\theta_{\text{old}}}(a_t\mid s_t)},\, 1\!-\!\varepsilon,\, 1\!+\!\varepsilon\right) A_t\right)$
-\\[22pt]
+\newline
+{\scriptsize PPO usually estimates $A_t$ with GAE; other advantage estimates are possible.}
+\\[20pt]
 
 Group Relative Policy Optimization
 \newline\mdseries (GRPO)
@@ -120,7 +122,8 @@ y_c \succ y_r & $y_c$ is preferred over $y_r$ & \sigma(z) & Sigmoid: $1/(1+e^{-z
 \pi_\theta & Policy (the model being trained) & \mathcal{D}_{\text{KL}}(P \| Q) & KL divergence between $P$ and $Q$ \\
 \pi_{\text{ref}} & Reference policy (frozen copy) & G_t & Return: $\sum_{k=0}^{\infty} \gamma^k R_{t+k+1}$ \\
 \pi_{\theta_{\text{old}}} & Policy at start of RL batch updates & V(s) & Value: $\mathbb{E}[G_t \mid S_t = s]$ \\
-r_\theta(y \mid x) & Reward model score & & \\
+r_\theta(y \mid x) & Reward model score & T & Trajectory length / time horizon \\
+K & Number of sampled completions & G & Group size for GRPO / GSPO \\
 \end{tabular}
 
 \vspace*{\fill}

--- a/book/rl-cheatsheet/inside_cover_back.tex
+++ b/book/rl-cheatsheet/inside_cover_back.tex
@@ -40,7 +40,7 @@ Characteristic Eligibility)
 $\displaystyle -\;\frac{1}{T}\sum_{t=1}^{T}\log \pi_\theta(a_t\mid s_t)\,(G_t - b(s_t))$
 \\[22pt]
 
-REINFORCE Leave One Out
+REINFORCE Leave-One-Out
 \newline\mdseries (RLOO)
 &
 $\displaystyle -\;\frac{1}{K}\sum_{i=1}^{K}\sum_t \log \pi_\theta(a_{i,t}\mid s_{i,t})\!\left(R_i - \frac{1}{K\!-\!1}\sum_{j\neq i}R_j\right)$

--- a/teach/README.md
+++ b/teach/README.md
@@ -18,6 +18,7 @@ uv sync --extra teach
 ```
 
 The `teach` extra intentionally tracks the GitHub source while `colloquium` is moving quickly.
+When running slide commands directly, use `uv run --extra teach ...` so `colloquium` is available even in a fresh environment.
 
 Or install from a local clone for development:
 
@@ -36,7 +37,7 @@ make teach
 Or build a single lecture:
 
 ```bash
-uv run colloquium build teach/course/lec1-chap1-3.md -o build/html/teach/course/lec1-chap1-3/
+uv run --extra teach colloquium build teach/course/lec1-chap1-3.md -o build/html/teach/course/lec1-chap1-3/
 ```
 
 Output goes to `build/html/teach/`.
@@ -47,7 +48,7 @@ For development with live reload:
 
 ```bash
 cd teach/SALA-2026
-uv run colloquium serve talk.md
+uv run --extra teach colloquium serve talk.md
 ```
 
 ## Talk Assets

--- a/teach/course/lec3-chap6-p1.md
+++ b/teach/course/lec3-chap6-p1.md
@@ -949,16 +949,6 @@ Proximal Policy Optimization **(PPO)** [@schulman2017proximal] gets TRPO-like st
 
 ---
 
-## PPO core idea 1: constrained updates
-
-<!-- cite-right: schulman2017proximal -->
-
-Large gradient steps can destroy the policy (instability, over-optimization, etc.)
-
-The solution: **trust regions** — limit how far the policy can move in a single update. 
-
----
-
 ## What can we do with more conservative gradients?
 
 Extract more signal from the batch! 
@@ -966,6 +956,16 @@ This introduces new problems:
 
 - How do we constrain the updates over multiple gradient updates?
 - How do we take the policy gradient if the data has drifted off-policy?
+
+---
+
+## PPO core idea 1: constrained updates
+
+<!-- cite-right: schulman2017proximal -->
+
+Large gradient steps can destroy the policy (instability, over-optimization, etc.)
+
+The solution: **trust regions** — limit how far the policy can move in a single update.
 
 ---
 


### PR DESCRIPTION
## Summary

Addresses the RL cheatsheet and Lecture 3 feedback from #382, plus the original wide-layout clipping fix for the cheatsheet page.

## Details

- Restores horizontal overflow only for the RL cheatsheet page so its intentionally wide equation table is no longer clipped by the shared site overflow lock.
- Centers the web cheatsheet equation table at its natural width, closer to the PDF layout where algorithm names align on the left and equations set the right edge.
- Adds a short PPO note that `A_t` is usually estimated with GAE while preserving the more general clipped objective formula.
- Adds `T`, `K`, and `G` notation entries to both the web cheatsheet and downloadable TeX/PDF source.
- Keeps the downloadable TeX/PDF source aligned with the web page, including `REINFORCE Leave-One-Out` naming.
- Reorders Lecture 3 PPO slides so the flow is: "What can we do with more conservative gradients?" -> "PPO core idea 1: constrained updates" -> "PPO core idea 2: Importance sampling".
- Documents the `teach` extra for slide builds and makes Makefile slide targets invoke `uv run --extra teach colloquium`.

## Validation

- `git diff --check`
- `make rl-cheatsheet files`
- `make rl-cheatsheet`
- `make course-lecture-lec3-chap6-p1`
- `uv run --extra teach colloquium build teach/course/lec3-chap6-p1.md -o build/html/teach/course/lec3-chap6-p1/`
- Rendered the cheatsheet PDF to PNG and visually checked that the PPO note and notation additions still fit on one page.
- Browser check at 1280px/1600px: equation table renders centered without clipping.
- Browser check at 390px: page had horizontal overflow, first label stayed visible, and horizontal scroll reached the equation column.