### PR TITLE
[codex] Reveal answers after questions in QA slides

### DIFF
--- a/teach/course/qa-01.md
+++ b/teach/course/qa-01.md
@@ -42,6 +42,10 @@ custom_css: |
 
 ## What prerequisites should a learner cover before this course?
 
+---
+
+## What prerequisites should a learner cover before this course?
+
 This course is approximately designed for early AI PhD/MS students. Traditional coursework path to this course:
 * Basics of language modeling / NLP
 * Basic ML (e.g. intro to AI course and intro to ML course)
@@ -59,6 +63,10 @@ Related courses: [David Silver's RL Course (2015)](https://www.youtube.com/watch
 <!-- title: center -->
 
 ## Data & instruction tuning
+
+---
+
+## For synthetic SFT data, is one teacher model better than many?
 
 ---
 
@@ -116,11 +124,20 @@ To making a general model, very, but the solutions aren't too surprising. Harder
 
 ## Is there a unified benchmark across pairwise RMs, ORMs, PRMs, and generative RMs?
 
+---
+
+## Is there a unified benchmark across pairwise RMs, ORMs, PRMs, and generative RMs?
+
 <!-- footnote-right: Source: [@jeromeeusebius on YouTube (Lecture 2)](https://www.youtube.com/watch?v=4gIwiSPmQkU&lc=Ugz41N1_9VKNNZN8N7N4AaABAg) -->
 
 Context: the question asks whether one labeled dataset could support comparison data, per-token labels, and outcome labels for apples-to-apples RM evaluation.
 
 **Answer: No**. Fragmentation of the community makes progress more diffuse. This is okay, and a normal evolution.
+
+---
+<!-- columns: 50/50 -->
+
+## Why choose token-level rewards over sequence-level rewards?
 
 ---
 <!-- columns: 50/50 -->
@@ -163,6 +180,10 @@ Counterpoint: if the reward is only final-answer correctness, sequence-level adv
 
 ## Is GAE the only way to compute the advantage in PPO?
 
+---
+
+## Is GAE the only way to compute the advantage in PPO?
+
 <!-- footnote-right: Source: [issue #382 on GitHub](https://github.com/natolambert/rlhf-book/issues/382) -->
 
 The PPO clipped objective on the [cheatsheet](https://rlhfbook.com/rl-cheatsheet/):
@@ -170,6 +191,15 @@ The PPO clipped objective on the [cheatsheet](https://rlhfbook.com/rl-cheatsheet
 $$J(\theta) = \mathbb{E}_t\!\left[\min\!\left(\rho_t(\theta)\hat{A}_t,\; \text{clip}(\rho_t(\theta),\, 1-\varepsilon,\, 1+\varepsilon)\hat{A}_t\right)\right]$$
 
 No! But I don't know of anyone using something else, or a raw value model. GAE works.
+
+---
+<!-- columns: 50/50 -->
+
+## What is the shape of $\rho$?
+
+<!-- footnote-right: Source: [@JGLambourne on YouTube (Lecture 3)](https://www.youtube.com/watch?v=K_Sj_-1BUMM&lc=UgwC9D0I4zmtGtyyGz14AaABAg) -->
+
+$$\rho_t(\theta) = \frac{\pi_\theta(a_t \mid s_t)}{\pi_{\theta_\text{old}}(a_t \mid s_t)}$$
 
 ---
 <!-- columns: 50/50 -->
@@ -209,6 +239,11 @@ rho = torch.exp(new_logps - old_logps)
 <!-- title: center -->
 
 ## PPO implementation & debugging
+
+---
+
+<!-- columns: 52/48 -->
+## Why does PPO use `torch.max` for both policy and value losses?
 
 ---
 
@@ -259,6 +294,10 @@ Same pattern: compare unclipped vs clipped, train on the worse one.
 <!-- title: center -->
 
 ## Human feedback operations
+
+---
+
+## How should data-annotation companies stay valuable as synthetic data gets simpler?
 
 ---
 


### PR DESCRIPTION
## Summary

- Split selected Q&A slides so the question appears first and the answer follows on the next slide.
- Preserved the existing QA lecture source and Colloquium formatting conventions.

## Validation

- `uv sync --extra teach` recreated the broken local `.venv` successfully.
- `uv run --extra teach colloquium build teach/course/qa-01.md -o /private/tmp/qa-01-pr-check`
- `uv run --extra teach colloquium export teach/course/qa-01.md -o /private/tmp/qa-01-pr-check/slides.pdf`
- Local preview is running at `http://127.0.0.1:8080/qa-01.html`.

Note: the Colloquium live watcher logs `rendered HTML failed structural validation` after startup, but the one-shot HTML build and PDF export both pass.