### PR TITLE
Course: add Extra Resources section

### DIFF
--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -568,6 +568,7 @@
         <div class="talk-group">
           <h4>Chapter 8 &middot; Direct-Alignment Algorithms</h4>
           <ul>
+            <li><a href="https://www.youtube.com/watch?v=dnF463_Ar9I" target="_blank" rel="noopener noreferrer">Life After DPO (Stanford CS224N)</a> <span class="when">May 2024</span></li>
             <li><a href="https://www.youtube.com/watch?v=YJMCSVLRUNs" target="_blank" rel="noopener noreferrer">DPO Debate: Is RL Needed for RLHF?</a></li>
             <li><a href="https://www.youtube.com/watch?v=rDF7eFPeVto" target="_blank" rel="noopener noreferrer">An Update on DPO vs PPO for LLM Alignment</a></li>
           </ul>

--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -336,12 +336,13 @@
 
     /* Concentrated talk list, grouped by chapter */
     .talk-groups {
-      column-width: 280px;
-      column-gap: 2em;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 0 2em;
+      align-items: start;
     }
 
     .talk-group {
-      break-inside: avoid;
       margin-bottom: 1.1em;
     }
 
@@ -547,42 +548,46 @@
       </a>
     </div>
 
-    <h3>More from Nathan</h3>
-    <p class="meta" style="margin-bottom: 0.8em;">Talks and deep dives from over the years, grouped by the chapter they pair with.</p>
+    <h3>More talks from Nathan</h3>
+    <p class="meta" style="margin-bottom: 0.8em;">Various presentations over my last few years working in post-training, grouped by corresponding chapter.</p>
     <div class="talk-groups">
-      <div class="talk-group">
-        <h4>Chapter 3 &middot; Training Overview</h4>
-        <ul>
-          <li><a href="https://www.youtube.com/watch?v=6yIMb0K-aS4" target="_blank" rel="noopener noreferrer">How Language Model Post-Training Is Done Today</a> <span class="when">Jan 2025</span></li>
-          <li><a href="https://www.youtube.com/watch?v=uaZ3yRdYg8A" target="_blank" rel="noopener noreferrer">How We Built a Leading Reasoning Model (Olmo 3)</a> <span class="when">Dec 2025</span></li>
-        </ul>
+      <div class="talk-col">
+        <div class="talk-group">
+          <h4>Chapter 3 &middot; Training Overview</h4>
+          <ul>
+            <li><a href="https://www.youtube.com/watch?v=6yIMb0K-aS4" target="_blank" rel="noopener noreferrer">How Language Model Post-Training Is Done Today</a> <span class="when">Jan 2025</span></li>
+            <li><a href="https://www.youtube.com/watch?v=uaZ3yRdYg8A" target="_blank" rel="noopener noreferrer">How We Built a Leading Reasoning Model (Olmo 3)</a> <span class="when">Dec 2025</span></li>
+          </ul>
+        </div>
+        <div class="talk-group">
+          <h4>Chapter 6 &middot; Reinforcement Learning</h4>
+          <ul>
+            <li><a href="https://www.youtube.com/watch?v=amrJDwMUFNs" target="_blank" rel="noopener noreferrer">GRPO's New Variants and Implementation Secrets</a></li>
+          </ul>
+        </div>
+        <div class="talk-group">
+          <h4>Chapter 8 &middot; Direct-Alignment Algorithms</h4>
+          <ul>
+            <li><a href="https://www.youtube.com/watch?v=YJMCSVLRUNs" target="_blank" rel="noopener noreferrer">DPO Debate: Is RL Needed for RLHF?</a></li>
+            <li><a href="https://www.youtube.com/watch?v=rDF7eFPeVto" target="_blank" rel="noopener noreferrer">An Update on DPO vs PPO for LLM Alignment</a></li>
+          </ul>
+        </div>
       </div>
-      <div class="talk-group">
-        <h4>Chapter 6 &middot; Reinforcement Learning</h4>
-        <ul>
-          <li><a href="https://www.youtube.com/watch?v=amrJDwMUFNs" target="_blank" rel="noopener noreferrer">GRPO's New Variants and Implementation Secrets</a></li>
-        </ul>
-      </div>
-      <div class="talk-group">
-        <h4>Chapter 7 &middot; Reasoning &amp; Inference-Time Scaling</h4>
-        <ul>
-          <li><a href="https://www.youtube.com/watch?v=J1APR8Bo9dE" target="_blank" rel="noopener noreferrer">Early Stages of the Reinforcement Learning Era of Language Models</a></li>
-          <li><a href="https://www.youtube.com/watch?v=zYeIqzULzr0" target="_blank" rel="noopener noreferrer">Experimenting with Reinforcement Learning with Verifiable Rewards (RLVR)</a></li>
-          <li><a href="https://www.youtube.com/watch?v=YXTYbr3hiFU" target="_blank" rel="noopener noreferrer">An Unexpected Reinforcement Learning Renaissance</a></li>
-        </ul>
-      </div>
-      <div class="talk-group">
-        <h4>Chapter 8 &middot; Direct-Alignment Algorithms</h4>
-        <ul>
-          <li><a href="https://www.youtube.com/watch?v=YJMCSVLRUNs" target="_blank" rel="noopener noreferrer">DPO Debate: Is RL Needed for RLHF?</a></li>
-          <li><a href="https://www.youtube.com/watch?v=rDF7eFPeVto" target="_blank" rel="noopener noreferrer">An Update on DPO vs PPO for LLM Alignment</a></li>
-        </ul>
-      </div>
-      <div class="talk-group">
-        <h4>Chapter 10 &middot; The Nature of Preferences</h4>
-        <ul>
-          <li><a href="https://www.youtube.com/watch?v=Mu_-FWIuhDA" target="_blank" rel="noopener noreferrer">15 Minute History of Reinforcement Learning and Human Feedback</a></li>
-        </ul>
+      <div class="talk-col">
+        <div class="talk-group">
+          <h4>Chapter 7 &middot; Reasoning &amp; Inference-Time Scaling</h4>
+          <ul>
+            <li><a href="https://www.youtube.com/watch?v=J1APR8Bo9dE" target="_blank" rel="noopener noreferrer">Early Stages of the Reinforcement Learning Era of Language Models</a></li>
+            <li><a href="https://www.youtube.com/watch?v=zYeIqzULzr0" target="_blank" rel="noopener noreferrer">Experimenting with Reinforcement Learning with Verifiable Rewards (RLVR)</a></li>
+            <li><a href="https://www.youtube.com/watch?v=YXTYbr3hiFU" target="_blank" rel="noopener noreferrer">An Unexpected Reinforcement Learning Renaissance</a></li>
+          </ul>
+        </div>
+        <div class="talk-group">
+          <h4>Chapter 10 &middot; The Nature of Preferences</h4>
+          <ul>
+            <li><a href="https://www.youtube.com/watch?v=Mu_-FWIuhDA" target="_blank" rel="noopener noreferrer">15 Minute History of Reinforcement Learning and Human Feedback</a></li>
+          </ul>
+        </div>
       </div>
     </div>
   </section>

--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -268,6 +268,117 @@
       color: #666;
       margin: 0;
     }
+
+    .page-guide {
+      margin: 0 0 2em;
+      padding-left: 1.2em;
+      color: #333;
+    }
+
+    .page-guide li {
+      margin-bottom: 0.45em;
+    }
+
+    /* Compact Books & Courses grid */
+    .resource-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+      gap: 0.7em;
+      margin-bottom: 1.75em;
+    }
+
+    .resource-card {
+      display: block;
+      border: 1px solid #e2e2e2;
+      border-radius: 0.35em;
+      background: #fff;
+      box-shadow: 0 2px 6px rgba(17, 17, 17, 0.05);
+      padding: 0.7em 0.85em;
+      text-decoration: none;
+      color: inherit;
+    }
+
+    .resource-card:hover {
+      border-color: #0645ad;
+      background: rgba(6, 69, 173, 0.03);
+    }
+
+    .resource-card .rc-kind {
+      display: inline-block;
+      font-size: 0.68em;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: #0645ad;
+      background: rgba(6, 69, 173, 0.08);
+      padding: 0.12em 0.5em;
+      border-radius: 0.25em;
+      margin-bottom: 0.45em;
+    }
+
+    .resource-card .rc-kind.course {
+      color: #c0392b;
+      background: rgba(192, 57, 43, 0.08);
+    }
+
+    .resource-card .rc-title {
+      display: block;
+      font-weight: 600;
+      font-size: 0.92em;
+      line-height: 1.25;
+    }
+
+    .resource-card .rc-meta {
+      display: block;
+      font-size: 0.8em;
+      color: #666;
+      margin-top: 0.2em;
+    }
+
+    /* Concentrated talk list, grouped by chapter */
+    .talk-groups {
+      column-width: 280px;
+      column-gap: 2em;
+    }
+
+    .talk-group {
+      break-inside: avoid;
+      margin-bottom: 1.1em;
+    }
+
+    .talk-group h4 {
+      margin: 0 0 0.35em;
+      font-size: 0.82em;
+      color: #555;
+      border-bottom: 1px solid #e2e2e2;
+      padding-bottom: 0.2em;
+    }
+
+    .talk-group ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    .talk-group li {
+      margin-bottom: 0.35em;
+      font-size: 0.9em;
+      line-height: 1.3;
+    }
+
+    .talk-group li a {
+      color: #0645ad;
+      text-decoration: none;
+    }
+
+    .talk-group li a:hover {
+      text-decoration: underline;
+    }
+
+    .talk-group .when {
+      color: #999;
+      font-size: 0.82em;
+      white-space: nowrap;
+    }
   </style>
 
   <!-- Privacy-friendly analytics by Plausible -->
@@ -291,9 +402,6 @@
     </symbol>
     <symbol id="icon-github" viewBox="0 0 16 16" fill="currentColor">
       <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
-    </symbol>
-    <symbol id="icon-book" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
     </symbol>
   </svg>
 
@@ -323,6 +431,12 @@
       </a>
     </div>
   </div>
+
+  <ul class="page-guide">
+    <li><a href="#lectures"><strong>Primary Material</strong></a> &mdash; the core lecture series that follows the book chapter by chapter, with recordings, slides, PDFs, and source.</li>
+    <li><a href="#extra-resources"><strong>Extra Resources</strong></a> &mdash; recommended books, external RL courses, and Nathan's own talks paired with the chapters they go with.</li>
+    <li><a href="#other-lectures"><strong>Other Guest Lectures and Talks</strong></a> &mdash; invited talks and standalone presentations.</li>
+  </ul>
 
   <section class="slides-section" id="lectures">
     <h2>Primary Material</h2>
@@ -403,144 +517,73 @@
   <section class="other-lectures-section" id="extra-resources">
     <h2>Extra Resources</h2>
 
-    <p class="meta" style="margin-bottom: 1em;">Outside material that pairs well with this course for going deeper on reinforcement learning and language models.</p>
+    <p class="meta" style="margin-bottom: 1em;">Outside material that I've personally used for going deeper on reinforcement learning and language models. The books in particular are wonderful complements.</p>
 
-    <h3>Books</h3>
-    <div class="course-list">
-      <div class="course-entry" id="resource-sutton-barto">
-        <div>
-          <h3>Reinforcement Learning: An Introduction</h3>
-          <p class="meta">Sutton &amp; Barto &middot; The foundational RL textbook</p>
-        </div>
-        <div class="talk-actions">
-          <a href="https://amzn.to/4vfAM2E" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-book"/></svg> Amazon</a>
-        </div>
-      </div>
-      <div class="course-entry" id="resource-build-llm">
-        <div>
-          <h3>Build a Large Language Model (From Scratch)</h3>
-          <p class="meta">Sebastian Raschka &middot; Implement a GPT-style LLM step by step</p>
-        </div>
-        <div class="talk-actions">
-          <a href="https://amzn.to/4ef1DWP" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-book"/></svg> Amazon</a>
-        </div>
-      </div>
-      <div class="course-entry" id="resource-build-reasoning">
-        <div>
-          <h3>Build a Reasoning Model (From Scratch)</h3>
-          <p class="meta">Sebastian Raschka &middot; Build reasoning and RLVR techniques from the ground up</p>
-        </div>
-        <div class="talk-actions">
-          <a href="https://amzn.to/4x14Kcu" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-book"/></svg> Amazon</a>
-        </div>
-      </div>
-    </div>
-
-    <h3>Courses</h3>
-    <div class="course-list">
-      <div class="course-entry" id="resource-cs285">
-        <div>
-          <h3>CS285: Deep Reinforcement Learning (2023)</h3>
-          <p class="meta">UC Berkeley &middot; Sergey Levine</p>
-        </div>
-        <div class="talk-actions">
-          <a href="https://www.youtube.com/watch?v=SupFHGbytvA&list=PL_iWQOsE6TfVYGEGiAOMaOzzv41Jfm_Ps&index=1" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
-        </div>
-      </div>
-      <div class="course-entry" id="resource-silver-rl">
-        <div>
-          <h3>Introduction to Reinforcement Learning (2015)</h3>
-          <p class="meta">DeepMind / UCL &middot; David Silver &middot; The classic RL lecture series</p>
-        </div>
-        <div class="talk-actions">
-          <a href="https://www.youtube.com/watch?v=2pWv7GOvuf0&list=PLzuuYNsE1EZAXYR4FJ75jcJseBmo4KQ9-" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
-        </div>
-      </div>
+    <h3>Books &amp; Courses</h3>
+    <div class="resource-grid">
+      <a class="resource-card" href="https://amzn.to/4vfAM2E" target="_blank" rel="noopener noreferrer">
+        <span class="rc-kind">Book</span>
+        <span class="rc-title">Reinforcement Learning: An Introduction</span>
+        <span class="rc-meta">Sutton &amp; Barto &middot; The foundational RL textbook</span>
+      </a>
+      <a class="resource-card" href="https://amzn.to/4ef1DWP" target="_blank" rel="noopener noreferrer">
+        <span class="rc-kind">Book</span>
+        <span class="rc-title">Build a Large Language Model (From Scratch)</span>
+        <span class="rc-meta">Sebastian Raschka</span>
+      </a>
+      <a class="resource-card" href="https://amzn.to/4x14Kcu" target="_blank" rel="noopener noreferrer">
+        <span class="rc-kind">Book</span>
+        <span class="rc-title">Build a Reasoning Model (From Scratch)</span>
+        <span class="rc-meta">Sebastian Raschka</span>
+      </a>
+      <a class="resource-card" href="https://www.youtube.com/watch?v=SupFHGbytvA&list=PL_iWQOsE6TfVYGEGiAOMaOzzv41Jfm_Ps&index=1" target="_blank" rel="noopener noreferrer">
+        <span class="rc-kind course">Course</span>
+        <span class="rc-title">CS285: Deep Reinforcement Learning (2023)</span>
+        <span class="rc-meta">UC Berkeley &middot; Sergey Levine</span>
+      </a>
+      <a class="resource-card" href="https://www.youtube.com/watch?v=2pWv7GOvuf0&list=PLzuuYNsE1EZAXYR4FJ75jcJseBmo4KQ9-" target="_blank" rel="noopener noreferrer">
+        <span class="rc-kind course">Course</span>
+        <span class="rc-title">Introduction to Reinforcement Learning (2015)</span>
+        <span class="rc-meta">DeepMind / UCL &middot; David Silver</span>
+      </a>
     </div>
 
     <h3>More from Nathan</h3>
-    <p class="meta" style="margin-bottom: 1em;">Talks and deep dives from over the years, organized by the chapter they pair with.</p>
-    <div class="course-list">
-      <div class="course-entry" id="talk-post-training-today">
-        <div>
-          <h3>How Language Model Post-Training Is Done Today</h3>
-          <p class="meta">Chapter 3: Training Overview &middot; January 2025</p>
-        </div>
-        <div class="talk-actions">
-          <a href="https://www.youtube.com/watch?v=6yIMb0K-aS4" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
-        </div>
+    <p class="meta" style="margin-bottom: 0.8em;">Talks and deep dives from over the years, grouped by the chapter they pair with.</p>
+    <div class="talk-groups">
+      <div class="talk-group">
+        <h4>Chapter 3 &middot; Training Overview</h4>
+        <ul>
+          <li><a href="https://www.youtube.com/watch?v=6yIMb0K-aS4" target="_blank" rel="noopener noreferrer">How Language Model Post-Training Is Done Today</a> <span class="when">Jan 2025</span></li>
+          <li><a href="https://www.youtube.com/watch?v=uaZ3yRdYg8A" target="_blank" rel="noopener noreferrer">How We Built a Leading Reasoning Model (Olmo 3)</a> <span class="when">Dec 2025</span></li>
+        </ul>
       </div>
-      <div class="course-entry" id="talk-olmo3-reasoning">
-        <div>
-          <h3>How We Built a Leading Reasoning Model (Olmo 3)</h3>
-          <p class="meta">Chapter 3: Training Overview &middot; December 2025</p>
-        </div>
-        <div class="talk-actions">
-          <a href="https://www.youtube.com/watch?v=uaZ3yRdYg8A" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
-        </div>
+      <div class="talk-group">
+        <h4>Chapter 6 &middot; Reinforcement Learning</h4>
+        <ul>
+          <li><a href="https://www.youtube.com/watch?v=amrJDwMUFNs" target="_blank" rel="noopener noreferrer">GRPO's New Variants and Implementation Secrets</a></li>
+        </ul>
       </div>
-      <div class="course-entry" id="talk-grpo-variants">
-        <div>
-          <h3>GRPO's New Variants and Implementation Secrets</h3>
-          <p class="meta">Chapter 6: Reinforcement Learning</p>
-        </div>
-        <div class="talk-actions">
-          <a href="https://www.youtube.com/watch?v=amrJDwMUFNs" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
-        </div>
+      <div class="talk-group">
+        <h4>Chapter 7 &middot; Reasoning &amp; Inference-Time Scaling</h4>
+        <ul>
+          <li><a href="https://www.youtube.com/watch?v=J1APR8Bo9dE" target="_blank" rel="noopener noreferrer">Early Stages of the Reinforcement Learning Era of Language Models</a></li>
+          <li><a href="https://www.youtube.com/watch?v=zYeIqzULzr0" target="_blank" rel="noopener noreferrer">Experimenting with Reinforcement Learning with Verifiable Rewards (RLVR)</a></li>
+          <li><a href="https://www.youtube.com/watch?v=YXTYbr3hiFU" target="_blank" rel="noopener noreferrer">An Unexpected Reinforcement Learning Renaissance</a></li>
+        </ul>
       </div>
-      <div class="course-entry" id="talk-rl-era-early">
-        <div>
-          <h3>Early Stages of the Reinforcement Learning Era of Language Models</h3>
-          <p class="meta">Chapter 7: Reasoning and Inference-Time Scaling</p>
-        </div>
-        <div class="talk-actions">
-          <a href="https://www.youtube.com/watch?v=J1APR8Bo9dE" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
-        </div>
+      <div class="talk-group">
+        <h4>Chapter 8 &middot; Direct-Alignment Algorithms</h4>
+        <ul>
+          <li><a href="https://www.youtube.com/watch?v=YJMCSVLRUNs" target="_blank" rel="noopener noreferrer">DPO Debate: Is RL Needed for RLHF?</a></li>
+          <li><a href="https://www.youtube.com/watch?v=rDF7eFPeVto" target="_blank" rel="noopener noreferrer">An Update on DPO vs PPO for LLM Alignment</a></li>
+        </ul>
       </div>
-      <div class="course-entry" id="talk-rlvr-experiments">
-        <div>
-          <h3>Experimenting with Reinforcement Learning with Verifiable Rewards (RLVR)</h3>
-          <p class="meta">Chapter 7: Reasoning and Inference-Time Scaling</p>
-        </div>
-        <div class="talk-actions">
-          <a href="https://www.youtube.com/watch?v=zYeIqzULzr0" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
-        </div>
-      </div>
-      <div class="course-entry" id="talk-rl-renaissance">
-        <div>
-          <h3>An Unexpected Reinforcement Learning Renaissance</h3>
-          <p class="meta">Chapter 7: Reasoning and Inference-Time Scaling</p>
-        </div>
-        <div class="talk-actions">
-          <a href="https://www.youtube.com/watch?v=YXTYbr3hiFU" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
-        </div>
-      </div>
-      <div class="course-entry" id="talk-dpo-debate">
-        <div>
-          <h3>DPO Debate: Is RL Needed for RLHF?</h3>
-          <p class="meta">Chapter 8: Direct-Alignment Algorithms</p>
-        </div>
-        <div class="talk-actions">
-          <a href="https://www.youtube.com/watch?v=YJMCSVLRUNs" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
-        </div>
-      </div>
-      <div class="course-entry" id="talk-dpo-vs-ppo">
-        <div>
-          <h3>An Update on DPO vs PPO for LLM Alignment</h3>
-          <p class="meta">Chapter 8: Direct-Alignment Algorithms</p>
-        </div>
-        <div class="talk-actions">
-          <a href="https://www.youtube.com/watch?v=rDF7eFPeVto" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
-        </div>
-      </div>
-      <div class="course-entry" id="talk-rlhf-history">
-        <div>
-          <h3>15 Minute History of Reinforcement Learning and Human Feedback</h3>
-          <p class="meta">Chapter 10: The Nature of Preferences</p>
-        </div>
-        <div class="talk-actions">
-          <a href="https://www.youtube.com/watch?v=Mu_-FWIuhDA" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
-        </div>
+      <div class="talk-group">
+        <h4>Chapter 10 &middot; The Nature of Preferences</h4>
+        <ul>
+          <li><a href="https://www.youtube.com/watch?v=Mu_-FWIuhDA" target="_blank" rel="noopener noreferrer">15 Minute History of Reinforcement Learning and Human Feedback</a></li>
+        </ul>
       </div>
     </div>
   </section>

--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -292,6 +292,9 @@
     <symbol id="icon-github" viewBox="0 0 16 16" fill="currentColor">
       <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
     </symbol>
+    <symbol id="icon-book" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
+    </symbol>
   </svg>
 
   <header id="title-block-header">
@@ -392,6 +395,151 @@
           <a href="/teach/course/lec5-chap7/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
           <a href="/teach/course/lec5-chap7/" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
           <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec5-chap7.md?plain=1" class="btn btn-source" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="other-lectures-section" id="extra-resources">
+    <h2>Extra Resources</h2>
+
+    <p class="meta" style="margin-bottom: 1em;">Outside material that pairs well with this course for going deeper on reinforcement learning and language models.</p>
+
+    <h3>Books</h3>
+    <div class="course-list">
+      <div class="course-entry" id="resource-sutton-barto">
+        <div>
+          <h3>Reinforcement Learning: An Introduction</h3>
+          <p class="meta">Sutton &amp; Barto &middot; The foundational RL textbook</p>
+        </div>
+        <div class="talk-actions">
+          <a href="https://amzn.to/4vfAM2E" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-book"/></svg> Amazon</a>
+        </div>
+      </div>
+      <div class="course-entry" id="resource-build-llm">
+        <div>
+          <h3>Build a Large Language Model (From Scratch)</h3>
+          <p class="meta">Sebastian Raschka &middot; Implement a GPT-style LLM step by step</p>
+        </div>
+        <div class="talk-actions">
+          <a href="https://amzn.to/4ef1DWP" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-book"/></svg> Amazon</a>
+        </div>
+      </div>
+      <div class="course-entry" id="resource-build-reasoning">
+        <div>
+          <h3>Build a Reasoning Model (From Scratch)</h3>
+          <p class="meta">Sebastian Raschka &middot; Build reasoning and RLVR techniques from the ground up</p>
+        </div>
+        <div class="talk-actions">
+          <a href="https://amzn.to/4x14Kcu" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-book"/></svg> Amazon</a>
+        </div>
+      </div>
+    </div>
+
+    <h3>Courses</h3>
+    <div class="course-list">
+      <div class="course-entry" id="resource-cs285">
+        <div>
+          <h3>CS285: Deep Reinforcement Learning (2023)</h3>
+          <p class="meta">UC Berkeley &middot; Sergey Levine</p>
+        </div>
+        <div class="talk-actions">
+          <a href="https://www.youtube.com/watch?v=SupFHGbytvA&list=PL_iWQOsE6TfVYGEGiAOMaOzzv41Jfm_Ps&index=1" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
+        </div>
+      </div>
+      <div class="course-entry" id="resource-silver-rl">
+        <div>
+          <h3>Introduction to Reinforcement Learning (2015)</h3>
+          <p class="meta">DeepMind / UCL &middot; David Silver &middot; The classic RL lecture series</p>
+        </div>
+        <div class="talk-actions">
+          <a href="https://www.youtube.com/watch?v=2pWv7GOvuf0&list=PLzuuYNsE1EZAXYR4FJ75jcJseBmo4KQ9-" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
+        </div>
+      </div>
+    </div>
+
+    <h3>More from Nathan</h3>
+    <p class="meta" style="margin-bottom: 1em;">Talks and deep dives from over the years, organized by the chapter they pair with.</p>
+    <div class="course-list">
+      <div class="course-entry" id="talk-post-training-today">
+        <div>
+          <h3>How Language Model Post-Training Is Done Today</h3>
+          <p class="meta">Chapter 3: Training Overview &middot; January 2025</p>
+        </div>
+        <div class="talk-actions">
+          <a href="https://www.youtube.com/watch?v=6yIMb0K-aS4" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
+        </div>
+      </div>
+      <div class="course-entry" id="talk-olmo3-reasoning">
+        <div>
+          <h3>How We Built a Leading Reasoning Model (Olmo 3)</h3>
+          <p class="meta">Chapter 3: Training Overview &middot; December 2025</p>
+        </div>
+        <div class="talk-actions">
+          <a href="https://www.youtube.com/watch?v=uaZ3yRdYg8A" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
+        </div>
+      </div>
+      <div class="course-entry" id="talk-grpo-variants">
+        <div>
+          <h3>GRPO's New Variants and Implementation Secrets</h3>
+          <p class="meta">Chapter 6: Reinforcement Learning</p>
+        </div>
+        <div class="talk-actions">
+          <a href="https://www.youtube.com/watch?v=amrJDwMUFNs" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
+        </div>
+      </div>
+      <div class="course-entry" id="talk-rl-era-early">
+        <div>
+          <h3>Early Stages of the Reinforcement Learning Era of Language Models</h3>
+          <p class="meta">Chapter 7: Reasoning and Inference-Time Scaling</p>
+        </div>
+        <div class="talk-actions">
+          <a href="https://www.youtube.com/watch?v=J1APR8Bo9dE" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
+        </div>
+      </div>
+      <div class="course-entry" id="talk-rlvr-experiments">
+        <div>
+          <h3>Experimenting with Reinforcement Learning with Verifiable Rewards (RLVR)</h3>
+          <p class="meta">Chapter 7: Reasoning and Inference-Time Scaling</p>
+        </div>
+        <div class="talk-actions">
+          <a href="https://www.youtube.com/watch?v=zYeIqzULzr0" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
+        </div>
+      </div>
+      <div class="course-entry" id="talk-rl-renaissance">
+        <div>
+          <h3>An Unexpected Reinforcement Learning Renaissance</h3>
+          <p class="meta">Chapter 7: Reasoning and Inference-Time Scaling</p>
+        </div>
+        <div class="talk-actions">
+          <a href="https://www.youtube.com/watch?v=YXTYbr3hiFU" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
+        </div>
+      </div>
+      <div class="course-entry" id="talk-dpo-debate">
+        <div>
+          <h3>DPO Debate: Is RL Needed for RLHF?</h3>
+          <p class="meta">Chapter 8: Direct-Alignment Algorithms</p>
+        </div>
+        <div class="talk-actions">
+          <a href="https://www.youtube.com/watch?v=YJMCSVLRUNs" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
+        </div>
+      </div>
+      <div class="course-entry" id="talk-dpo-vs-ppo">
+        <div>
+          <h3>An Update on DPO vs PPO for LLM Alignment</h3>
+          <p class="meta">Chapter 8: Direct-Alignment Algorithms</p>
+        </div>
+        <div class="talk-actions">
+          <a href="https://www.youtube.com/watch?v=rDF7eFPeVto" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
+        </div>
+      </div>
+      <div class="course-entry" id="talk-rlhf-history">
+        <div>
+          <h3>15 Minute History of Reinforcement Learning and Human Feedback</h3>
+          <p class="meta">Chapter 10: The Nature of Preferences</p>
+        </div>
+        <div class="talk-actions">
+          <a href="https://www.youtube.com/watch?v=Mu_-FWIuhDA" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
         </div>
       </div>
     </div>

--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -553,6 +553,12 @@
     <div class="talk-groups">
       <div class="talk-col">
         <div class="talk-group">
+          <h4>Chapter 1 &middot; Introduction</h4>
+          <ul>
+            <li><a href="https://www.youtube.com/watch?v=AdLgPmcrXwQ" target="_blank" rel="noopener noreferrer">Aligning Open Language Models (Stanford CS25)</a> <span class="when">Apr 2024</span></li>
+          </ul>
+        </div>
+        <div class="talk-group">
           <h4>Chapter 3 &middot; Training Overview</h4>
           <ul>
             <li><a href="https://www.youtube.com/watch?v=6yIMb0K-aS4" target="_blank" rel="noopener noreferrer">How Language Model Post-Training Is Done Today</a> <span class="when">Jan 2025</span></li>
@@ -562,15 +568,13 @@
         <div class="talk-group">
           <h4>Chapter 6 &middot; Reinforcement Learning</h4>
           <ul>
-            <li><a href="https://www.youtube.com/watch?v=amrJDwMUFNs" target="_blank" rel="noopener noreferrer">GRPO's New Variants and Implementation Secrets</a></li>
+            <li><a href="https://www.youtube.com/watch?v=amrJDwMUFNs" target="_blank" rel="noopener noreferrer">GRPO's New Variants and Implementation Secrets</a> <span class="when">Mar 2025</span></li>
           </ul>
         </div>
         <div class="talk-group">
-          <h4>Chapter 8 &middot; Direct-Alignment Algorithms</h4>
+          <h4>Chapter 10 &middot; The Nature of Preferences</h4>
           <ul>
-            <li><a href="https://www.youtube.com/watch?v=dnF463_Ar9I" target="_blank" rel="noopener noreferrer">Life After DPO (Stanford CS224N)</a> <span class="when">May 2024</span></li>
-            <li><a href="https://www.youtube.com/watch?v=YJMCSVLRUNs" target="_blank" rel="noopener noreferrer">DPO Debate: Is RL Needed for RLHF?</a></li>
-            <li><a href="https://www.youtube.com/watch?v=rDF7eFPeVto" target="_blank" rel="noopener noreferrer">An Update on DPO vs PPO for LLM Alignment</a></li>
+            <li><a href="https://www.youtube.com/watch?v=Mu_-FWIuhDA" target="_blank" rel="noopener noreferrer">15 Minute History of Reinforcement Learning and Human Feedback</a> <span class="when">Dec 2023</span></li>
           </ul>
         </div>
       </div>
@@ -578,15 +582,17 @@
         <div class="talk-group">
           <h4>Chapter 7 &middot; Reasoning &amp; Inference-Time Scaling</h4>
           <ul>
-            <li><a href="https://www.youtube.com/watch?v=J1APR8Bo9dE" target="_blank" rel="noopener noreferrer">Early Stages of the Reinforcement Learning Era of Language Models</a></li>
-            <li><a href="https://www.youtube.com/watch?v=zYeIqzULzr0" target="_blank" rel="noopener noreferrer">Experimenting with Reinforcement Learning with Verifiable Rewards (RLVR)</a></li>
-            <li><a href="https://www.youtube.com/watch?v=YXTYbr3hiFU" target="_blank" rel="noopener noreferrer">An Unexpected Reinforcement Learning Renaissance</a></li>
+            <li><a href="https://www.youtube.com/watch?v=YXTYbr3hiFU" target="_blank" rel="noopener noreferrer">An Unexpected Reinforcement Learning Renaissance</a> <span class="when">Feb 2025</span></li>
+            <li><a href="https://www.youtube.com/watch?v=J1APR8Bo9dE" target="_blank" rel="noopener noreferrer">Early Stages of the Reinforcement Learning Era of Language Models</a> <span class="when">Mar 2025</span></li>
+            <li><a href="https://www.youtube.com/watch?v=zYeIqzULzr0" target="_blank" rel="noopener noreferrer">Experimenting with Reinforcement Learning with Verifiable Rewards (RLVR)</a> <span class="when">Apr 2025</span></li>
           </ul>
         </div>
         <div class="talk-group">
-          <h4>Chapter 10 &middot; The Nature of Preferences</h4>
+          <h4>Chapter 8 &middot; Direct-Alignment Algorithms</h4>
           <ul>
-            <li><a href="https://www.youtube.com/watch?v=Mu_-FWIuhDA" target="_blank" rel="noopener noreferrer">15 Minute History of Reinforcement Learning and Human Feedback</a></li>
+            <li><a href="https://www.youtube.com/watch?v=YJMCSVLRUNs" target="_blank" rel="noopener noreferrer">DPO Debate: Is RL Needed for RLHF?</a> <span class="when">Dec 2023</span></li>
+            <li><a href="https://www.youtube.com/watch?v=dnF463_Ar9I" target="_blank" rel="noopener noreferrer">Life After DPO (Stanford CS224N)</a> <span class="when">May 2024</span></li>
+            <li><a href="https://www.youtube.com/watch?v=rDF7eFPeVto" target="_blank" rel="noopener noreferrer">An Update on DPO vs PPO for LLM Alignment</a> <span class="when">Jul 2024</span></li>
           </ul>
         </div>
       </div>

--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -415,8 +415,7 @@
   <h1>Course</h1>
 
   <p>
-    Course lectures and talks based on <a href="https://rlhfbook.com">the RLHF Book</a>, built with <a href="https://github.com/natolambert/colloquium">Colloquium</a>.
-    Click into a deck to navigate through the slides, or open in full screen.
+    A full course accompanying <a href="https://rlhfbook.com">the book</a> with added resources and other lectures I've given.
   </p>
 
   <div class="welcome-video">


### PR DESCRIPTION
Adds an **Extra Resources** section to the course page (between the lectures and "Other Guest Lectures and Talks"), plus a short on-page guide, reusing the existing card styling so it matches the rest of the page.

### On-page guide
Three bullets after the Welcome box linking the page's sections: Primary Material, Extra Resources, and Other Guest Lectures.

### Extra Resources → Books & Courses
A compact grid of clickable cards (Book/Course badges):
- Reinforcement Learning: An Introduction — Sutton & Barto
- Build a Large Language Model (From Scratch) — Sebastian Raschka
- Build a Reasoning Model (From Scratch) — Sebastian Raschka
- CS285: Deep Reinforcement Learning (2023) — UC Berkeley · Sergey Levine
- Introduction to Reinforcement Learning (2015) — DeepMind/UCL · David Silver

### Extra Resources → More talks from Nathan
A concentrated two-column list of my own talks, grouped by the chapter they pair with and dated:

| Chapter | Talk | Date |
|---|---|---|
| 1 · Introduction | Aligning Open Language Models (Stanford CS25) | Apr 2024 |
| 3 · Training Overview | How Language Model Post-Training Is Done Today | Jan 2025 |
| 3 · Training Overview | How We Built a Leading Reasoning Model (Olmo 3) | Dec 2025 |
| 6 · Reinforcement Learning | GRPO's New Variants and Implementation Secrets | Mar 2025 |
| 7 · Reasoning & Inference-Time Scaling | An Unexpected Reinforcement Learning Renaissance | Feb 2025 |
| 7 | Early Stages of the Reinforcement Learning Era of Language Models | Mar 2025 |
| 7 | Experimenting with RLVR | Apr 2025 |
| 8 · Direct-Alignment Algorithms | DPO Debate: Is RL Needed for RLHF? | Dec 2023 |
| 8 | Life After DPO (Stanford CS224N) | May 2024 |
| 8 | An Update on DPO vs PPO for LLM Alignment | Jul 2024 |
| 10 · The Nature of Preferences | 15 Minute History of RL and Human Feedback | Dec 2023 |

Talks are sorted oldest→newest within each chapter group. The two Chapter 3 talks span different post-training eras (Jan 2025 → Dec 2025). The two-column layout is height-balanced (left = Ch 1/3/6/10, right = Ch 7/8) and collapses to one column on narrow screens.

### Notes
- Page intro reworded to frame this as a full course with added resources and other lectures.
- All video URLs are stripped of timestamp (`&t=`) and tracking (`&pp=`) params.
- New `resource-card` / `talk-group` styles added; the throwaway book icon used in an earlier iteration was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
