### PR TITLE
Course: add Q&A 1 + Lecture 5 videos, link Lecture 5 on reasoning TOC

### DIFF
--- a/book/chapters/07-reasoning.md
+++ b/book/chapters/07-reasoning.md
@@ -12,6 +12,9 @@ search-title: "Chapter 7: Reasoning and Inference-Time Scaling"
 meta-description: "Reasoning training and inference-time scaling in post-training, including RLVR and thinking models."
 next-chapter: "Direct-Alignment Algorithms"
 next-url: "08-direct-alignment"
+lectures:
+  - video: "https://www.youtube.com/watch?v=o4AB5xHIDdM&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=7"
+    label: "Lecture 5: The Rise of Reasoning Models"
 ---
 
 # Reasoning and Inference-Time Scaling

--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -495,6 +495,7 @@
           <h3>Q&amp;A 1: Reader questions, lec. 1-4</h3>
         </div>
         <div class="talk-actions">
+          <a href="https://www.youtube.com/watch?v=x-MqKBzoxkI&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=6" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
           <a href="/teach/course/qa-01/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
           <a href="/teach/course/qa-01/" class="btn" target="_blank"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
           <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/qa-01.md?plain=1" class="btn btn-source" target="_blank"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
@@ -506,6 +507,7 @@
           <p class="meta">Chapter 7 &middot; RLVR, inference-time scaling, and the 2025 reasoning model wave</p>
         </div>
         <div class="talk-actions">
+          <a href="https://www.youtube.com/watch?v=o4AB5xHIDdM&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=7" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
           <a href="/teach/course/lec5-chap7/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
           <a href="/teach/course/lec5-chap7/" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
           <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec5-chap7.md?plain=1" class="btn btn-source" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>


### PR DESCRIPTION
Adds the newly published recordings for Q&A 1 and Lecture 5, and surfaces Lecture 5 on the reasoning chapter.

### Course page (`book/templates/course.html`)
- **Q&A 1** — add a Watch button → playlist link (`x-MqKBzoxkI`, index 6).
- **Lecture 5: The Rise of Reasoning Models** — add a Watch button → playlist link (`o4AB5xHIDdM`, index 7).

Both use the existing `btn btn-watch` styling and sit first in the action row, matching the other lectures.

### Reasoning chapter (`book/chapters/07-reasoning.md`)
- Add a `lectures:` front-matter entry for Lecture 5 so it renders as a lecture link in the chapter's table of contents (same mechanism Chapters 1–6 already use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
