### PR TITLE
Lec 6 DPO: math-nit fixes (parens on u, factor beta on slide 38)

### DIFF
--- a/teach/course/lec6-chap8-dpo.md
+++ b/teach/course/lec6-chap8-dpo.md
@@ -585,7 +585,7 @@ $$
 \nabla_{\theta}\mathcal{L}_{\text{DPO}} = -\,\nabla_{\theta}\,\mathbb{E}_{(x,y_c,y_r)}\Big[ \log \sigma\big(\beta \log \tfrac{\pi_{\theta}(y_c\mid x)}{\pi_{\text{ref}}(y_c\mid x)} - \beta \log \tfrac{\pi_{\theta}(y_r\mid x)}{\pi_{\text{ref}}(y_r\mid x)}\big) \Big]
 $$
 
-Let $u = \beta \log \tfrac{\pi_{\theta}(y_c\mid x)}{\pi_{\text{ref}}(y_c\mid x)} - \beta \log \tfrac{\pi_{\theta}(y_r\mid x)}{\pi_{\text{ref}}(y_r\mid x)}$ — the term inside $\sigma$.
+Let $u = \big(\beta \log \tfrac{\pi_{\theta}(y_c\mid x)}{\pi_{\text{ref}}(y_c\mid x)} - \beta \log \tfrac{\pi_{\theta}(y_r\mid x)}{\pi_{\text{ref}}(y_r\mid x)}\big)$ — the term inside $\sigma$.
 
 <!-- step -->
 
@@ -632,7 +632,7 @@ $$
 Substitute $\nabla_{\theta} u$ and write $\sigma(-u)$ out in full:
 
 $$
-\nabla_{\theta}\mathcal{L}_{\text{DPO}} = -\,\mathbb{E}_{(x,y_c,y_r)}\Big[ \beta\,\sigma\big(\beta\log\tfrac{\pi_{\theta}(y_r\mid x)}{\pi_{\text{ref}}(y_r\mid x)} - \beta\log\tfrac{\pi_{\theta}(y_c\mid x)}{\pi_{\text{ref}}(y_c\mid x)}\big)\,\big[\nabla_{\theta}\log\pi(y_c\mid x) - \nabla_{\theta}\log\pi(y_r\mid x)\big] \Big]
+\nabla_{\theta}\mathcal{L}_{\text{DPO}} = -\,\beta\,\mathbb{E}_{(x,y_c,y_r)}\Big[ \sigma\big(\beta\log\tfrac{\pi_{\theta}(y_r\mid x)}{\pi_{\text{ref}}(y_r\mid x)} - \beta\log\tfrac{\pi_{\theta}(y_c\mid x)}{\pi_{\text{ref}}(y_c\mid x)}\big)\,\big[\nabla_{\theta}\log\pi(y_c\mid x) - \nabla_{\theta}\log\pi(y_r\mid x)\big] \Big]
 $$
 
 ---


### PR DESCRIPTION
Two small clarity fixes to the Lecture 6 (DPO) slides, from a review pass. **Math is unchanged** — these are presentation nits.

## Changes
1. **"Let u =" gradient slide** — wrapped the definition in parens, `u = (β log … − β log …)`, so the trailing em-dash ("— the term inside σ") can't be misread as a minus sign.
2. **Slide 38 ("write σ(−u) in full")** — factored the coefficient `β` to the front: `−β 𝔼[ σ(β log… − β log…)(…) ]`. The three β's were always correct (one coefficient from ∇u, two inside the sigmoid argument), but the `β σ(β…` adjacency reads as a duplicate. Factoring it out removes the ambiguity and matches the factored final-gradient slide.

## Verification
- Renders clean via `colloquium serve`: HTTP 200, **0 KaTeX errors**.
- Ran an independent audit of the full derivation (P1 objective→optimal policy, P2 implicit reward, P3 Bradley-Terry, P4 loss+gradient) and the variant losses (IPO/ORPO/SimPO) — **no other math errors found**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)