### PR TITLE
Fix dark mode search result colors

### DIFF
--- a/book/templates/style.css
+++ b/book/templates/style.css
@@ -683,7 +683,12 @@ thead {
 #search .pagefind-ui__result {
     text-align: left;
 }
+#search .pagefind-ui__message,
+#search .pagefind-ui__result-link {
+    color: var(--color-heading);
+}
 #search .pagefind-ui__result-excerpt {
+    color: var(--color-text);
     text-align: left;
 }
 


### PR DESCRIPTION
## Summary
- use the dark theme heading color for Pagefind result counts and titles
- use the normal theme text color for result excerpts

This is how the search looks after the PR:
<img width="1560" height="1992" alt="CleanShot 2026-06-07 at 10 53 06@2x" src="https://github.com/user-attachments/assets/59884252-680a-42ba-b7bf-1d44a57308db" />

