### PR TITLE
Course: add Lecture 6 (DPO) + Conversation 1 videos, link Lecture 6 on DPO chapter

### DIFF
--- a/book/chapters/08-direct-alignment.md
+++ b/book/chapters/08-direct-alignment.md
@@ -12,6 +12,9 @@ search-title: "Chapter 8: Direct-Alignment Algorithms"
 meta-description: "Direct alignment algorithms such as DPO that optimize preference objectives without an explicit reward model or RL loop."
 next-chapter: "Rejection Sampling"
 next-url: "09-rejection-sampling"
+lectures:
+  - video: "https://www.youtube.com/watch?v=6g6b4gvO-y0&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=8"
+    label: "Lecture 6: Direct Preference Optimization"
 ---
 
 # Direct-Alignment Algorithms

--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -614,6 +614,7 @@
           <p class="meta">Chapter 8 &middot; Deriving DPO step by step, plus variants and practice</p>
         </div>
         <div class="talk-actions">
+          <a href="https://www.youtube.com/watch?v=6g6b4gvO-y0&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=8" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
           <a href="/teach/course/lec6-chap8-dpo/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
           <a href="/teach/course/lec6-chap8-dpo/" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
           <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec6-chap8-dpo.md?plain=1" class="btn btn-source" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
@@ -624,6 +625,7 @@
           <h3>Conversation 1: Frontier post-training recipes in 2026 (w/ Finbarr Timbers)</h3>
         </div>
         <div class="talk-actions">
+          <a href="https://www.youtube.com/watch?v=sbXEPxIazqY&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=9" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
           <a href="/teach/course/conversation-01/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
           <a href="/teach/course/conversation-01/" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
           <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/conversation-01.md?plain=1" class="btn btn-source" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>


### PR DESCRIPTION
## Summary
Adds the YouTube links for the two newest course videos, following the same pattern as #440.

## Changes
- **Lecture 6: Direct Preference Optimization** ([video](https://www.youtube.com/watch?v=6g6b4gvO-y0&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=8)): Watch button on the course page and a `lectures:` frontmatter entry on chapter 8 (`08-direct-alignment.md`).
- **Conversation 1: Frontier post-training recipes in 2026** ([video](https://www.youtube.com/watch?v=sbXEPxIazqY&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=9)): Watch button on the course page only.

Verified with `make html`: both links render on the course page and the lecture link appears on the chapter 8 page.

🤖 Generated with [Claude Code](https://claude.ai/code)