### PR TITLE
CI: skip PDF/EPUB/TeX build for course-only changes

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -99,7 +99,7 @@ jobs:
           echo "/Library/TeX/texbin" >> $GITHUB_PATH
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.2.0
 
       - name: Clean build directory
         run: |

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -65,7 +65,10 @@ jobs:
         id: cache-texlive
         with:
           path: /usr/local/texlive
-          key: texlive-macos-${{ hashFiles('.github/workflows/static.yml') }}
+          # Manual version: bump when changing the tlmgr package list below.
+          # (Previously keyed on a hash of this file, which re-installed TeX
+          # Live on every workflow edit.)
+          key: texlive-macos-v1
 
       - name: Install brew dependencies
         run: |

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -42,14 +42,15 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         continue-on-error: true
         with:
+          # 'every' makes a file count only when it matches the union pattern
+          # AND the negation (i.e. is not the course template). The default
+          # 'some' quantifier matches each pattern independently, where a bare
+          # negation matches every file and exclusions silently do nothing.
+          predicate-quantifier: 'every'
           filters: |
             book:
-              - 'book/**'
+              - '{book/**,Makefile,pyproject.toml,uv.lock,.github/workflows/static.yml}'
               - '!book/templates/course.html'
-              - 'Makefile'
-              - 'pyproject.toml'
-              - 'uv.lock'
-              - '.github/workflows/static.yml'
 
       - name: Setup Pandoc
         uses: pandoc/actions/setup@main

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,12 +34,13 @@ jobs:
 
       # Course-only changes (teach/** and the course page template) skip the
       # slow PDF/EPUB/TeX path and reuse the published book artifacts instead.
-      # If this step is skipped (workflow_dispatch), outputs are empty and the
-      # full build runs.
+      # If this step is skipped (workflow_dispatch) or fails, outputs are empty
+      # and the full build runs — change detection must never block a deploy.
       - name: Detect changed paths
         uses: dorny/paths-filter@v4
         id: changes
         if: github.event_name != 'workflow_dispatch'
+        continue-on-error: true
         with:
           filters: |
             book:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,15 +31,35 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Course-only changes (teach/** and the course page template) skip the
+      # slow PDF/EPUB/TeX path and reuse the published book artifacts instead.
+      # If this step is skipped (workflow_dispatch), outputs are empty and the
+      # full build runs.
+      - name: Detect changed paths
+        uses: dorny/paths-filter@v3
+        id: changes
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          filters: |
+            book:
+              - 'book/**'
+              - '!book/templates/course.html'
+              - 'Makefile'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.github/workflows/static.yml'
+
       - name: Setup Pandoc
         uses: pandoc/actions/setup@main
         with:
           version: 3.7.0.2
 
       - name: Prepare TeX Live cache directory
+        if: steps.changes.outputs.book != 'false'
         run: sudo mkdir -p /usr/local/texlive && sudo chown -R $(whoami) /usr/local/texlive
 
       - name: Cache TeX Live
+        if: steps.changes.outputs.book != 'false'
         uses: actions/cache@v4
         id: cache-texlive
         with:
@@ -52,8 +72,8 @@ jobs:
           brew install make
           brew install pandoc-crossref
           brew install poppler
-          # Only install TeX if not cached
-          if [ "${{ steps.cache-texlive.outputs.cache-hit }}" != "true" ]; then
+          # Only install TeX if not cached (and skip entirely for course-only changes)
+          if [ "${{ steps.changes.outputs.book }}" != "false" ] && [ "${{ steps.cache-texlive.outputs.cache-hit }}" != "true" ]; then
             echo "Cache miss - installing TeX Live..."
             brew install --cask basictex
             eval "$(/usr/libexec/path_helper)"
@@ -65,6 +85,7 @@ jobs:
           fi
 
       - name: Set up LaTeX PATH
+        if: steps.changes.outputs.book != 'false'
         run: |
           # Find the actual texlive bin directory (varies by year/arch)
           TEXLIVE_BIN=$(find /usr/local/texlive -type d -name "bin" -exec find {} -type d -name "*-darwin" \; 2>/dev/null | head -1)
@@ -82,9 +103,25 @@ jobs:
           mkdir -p build/html
 
       - name: Build book (HTML, PDF, EPUB, Kindle)
+        if: steps.changes.outputs.book != 'false'
         run: |
           make
           make files
+
+      # Cloudflare Pages deploys are full-site snapshots, so the book artifacts
+      # must exist in build/html even when we don't rebuild them. Reuse the
+      # currently published ones.
+      - name: Build site (course-only change, reuse published book artifacts)
+        if: steps.changes.outputs.book == 'false'
+        run: |
+          make html
+          make files
+          mkdir -p build/html/rl-cheatsheet
+          curl -fsSL https://rlhfbook.com/book.pdf -o build/html/book.pdf
+          curl -fsSL https://rlhfbook.com/book.epub -o build/html/book.epub
+          curl -fsSL https://rlhfbook.com/book.kindle.epub -o build/html/book.kindle.epub
+          curl -fsSL https://rlhfbook.com/rl-cheatsheet/ -o build/html/rl-cheatsheet/index.html
+          curl -fsSL https://rlhfbook.com/rl-cheatsheet/inside_cover_back.pdf -o build/html/rl-cheatsheet/inside_cover_back.pdf
 
       - name: Build teaching slides
         run: |

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       contents: read
       deployments: write
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,14 +30,14 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Course-only changes (teach/** and the course page template) skip the
       # slow PDF/EPUB/TeX path and reuse the published book artifacts instead.
       # If this step is skipped (workflow_dispatch), outputs are empty and the
       # full build runs.
       - name: Detect changed paths
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         if: github.event_name != 'workflow_dispatch'
         with:
@@ -61,7 +61,7 @@ jobs:
 
       - name: Cache TeX Live
         if: steps.changes.outputs.book != 'false'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-texlive
         with:
           path: /usr/local/texlive
@@ -99,7 +99,7 @@ jobs:
           echo "/Library/TeX/texbin" >> $GITHUB_PATH
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8
 
       - name: Clean build directory
         run: |
@@ -137,7 +137,7 @@ jobs:
 
       - name: Deploy preview to Cloudflare Pages
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -146,7 +146,7 @@ jobs:
 
       - name: Deploy production to Cloudflare Pages
         if: github.event_name != 'pull_request'
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
PRs that only touch `teach/**` (and/or `book/templates/course.html`) no longer rebuild the PDF/EPUB/Kindle/TeX artifacts, which were ~3.5 minutes of every ~6 minute run. Along the way this PR also fixes the TeX cache key and migrates all actions to Node 24 versions ahead of the June 16 forced migration.

## How it works
- `dorny/paths-filter` classifies the change: anything in `book/**` (except the course page template), `Makefile`, `pyproject.toml`, `uv.lock`, or the workflow itself triggers the full build, same as today.
- Course-only runs skip the TeX cache restore, basictex install, and `make` (pdf/epub/kindle/docx), running only `make html` + `make files` + slides.
- Because Cloudflare Pages deploys are full-site snapshots, the skipped artifacts (`book.pdf`, `book.epub`, `book.kindle.epub`, `rl-cheatsheet/`) are fetched from the live site so download links keep working on previews and course-only production deploys.
- Fail-safe: if change detection is skipped (`workflow_dispatch`) or errors (`continue-on-error`), outputs are empty and everything falls back to the full build — detection can never block a deploy.

## Also in this PR
- `pull-requests: read` permission for paths-filter (Codex review).
- TeX Live cache key pinned to `texlive-macos-v1` instead of hashing the workflow file — previously any workflow edit re-installed TeX from scratch (~3 min). Bump the suffix when changing the tlmgr package list.
- Action bumps for Node 24: `checkout@v6`, `cache@v5`, `setup-uv@v8.2.0`, `wrangler-action@v4`, `paths-filter@v4`. Verified `cache@v5` restores the cache saved by `cache@v4` (12s hit on a run that edited the workflow).

## Validation
- Full-build path: green runs on this PR (which is itself in the heavy filter), including with all bumped actions.
- Fast path: first exercised by the next course-only PR; expected ~2.5 min instead of ~6.

🤖 Generated with [Claude Code](https://claude.ai/code)