### PR TITLE
Course page: unlink "the book" in the intro

### DIFF
--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -511,7 +511,7 @@
   <h1>Course</h1>
 
   <p>
-    A full course accompanying <a href="https://rlhfbook.com">the book</a> with added resources and other lectures I've given.
+    A full course accompanying the book with added resources and other lectures I've given.
   </p>
 
   <div class="welcome-video">


### PR DESCRIPTION
## Summary
Removes the self-link on "the book" in the course page intro (it just points back to the same site).

This is also the first PR to exercise the course-only CI fast path from #448 — it touches only `book/templates/course.html`, so the run should skip the TeX/PDF/EPUB steps, take the "Build site (course-only change)" step instead, and finish in roughly 2.5 minutes.

🤖 Generated with [Claude Code](https://claude.ai/code)