### PR TITLE
Use tokenizer chat templates (if available) in preference RM training

### DIFF
--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,7 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
-- 2026-06-13: [PR #TBD](https://github.com/natolambert/rlhf-book/pull/TBD) updated preference reward model tokenization to apply tokenizer chat templates when available, including the demo reward comparison path.
+- 2026-06-13: [PR #450](https://github.com/natolambert/rlhf-book/pull/450) updated preference reward model tokenization to apply tokenizer chat templates when available, including the demo reward comparison path. This changes tokenization for the default `Qwen3-0.6B-Base` run (which ships a chat template), so loss scale is not directly comparable to prior runs; the chosen/rejected formatting stays symmetric, so the Bradley-Terry objective is unaffected.
 - 2026-05-15: [PR #425](https://github.com/natolambert/rlhf-book/pull/425) added `[code]` link to `code/instruction_tuning` in the site navbar and listed Chapter 4 (Instruction Tuning) under the Book Chapters section of `code/README.md`.
 - 2026-05-15: [PR #424](https://github.com/natolambert/rlhf-book/pull/424) documented the instruction-tuning reference run in `code/README.md` and `code/instruction_tuning/README.md` — added a new SFT section with the wandb training-results image (`code/images/wandb_instruction_tuning.png`) and an example-run table linking to [wandb run `nybj8sdx`](https://wandb.ai/rlhf-book/core/runs/nybj8sdx), illustrated the base→assistant transition with step-100 vs step-650 sample panels, and dropped the placeholder `TODO(@natolambert)` from the reader experiment table.
 - 2026-05-13: [PR #421](https://github.com/natolambert/rlhf-book/pull/421) added optional `WANDB_ENTITY` support across the code examples and migrated verified reference links to the `rlhf-book/core` team project.

--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,6 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
+- 2026-06-13: [PR #TBD](https://github.com/natolambert/rlhf-book/pull/TBD) updated preference reward model tokenization to apply tokenizer chat templates when available, including the demo reward comparison path.
 - 2026-05-15: [PR #425](https://github.com/natolambert/rlhf-book/pull/425) added `[code]` link to `code/instruction_tuning` in the site navbar and listed Chapter 4 (Instruction Tuning) under the Book Chapters section of `code/README.md`.
 - 2026-05-15: [PR #424](https://github.com/natolambert/rlhf-book/pull/424) documented the instruction-tuning reference run in `code/README.md` and `code/instruction_tuning/README.md` — added a new SFT section with the wandb training-results image (`code/images/wandb_instruction_tuning.png`) and an example-run table linking to [wandb run `nybj8sdx`](https://wandb.ai/rlhf-book/core/runs/nybj8sdx), illustrated the base→assistant transition with step-100 vs step-650 sample panels, and dropped the placeholder `TODO(@natolambert)` from the reader experiment table.
 - 2026-05-13: [PR #421](https://github.com/natolambert/rlhf-book/pull/421) added optional `WANDB_ENTITY` support across the code examples and migrated verified reference links to the `rlhf-book/core` team project.

--- a/code/reward_models/train_preference_rm.py
+++ b/code/reward_models/train_preference_rm.py
@@ -69,6 +69,33 @@ def format_conversation(messages: List[Dict]) -> str:
     return "\n".join(result)
 
 
+def tokenize_messages(
+    tokenizer: AutoTokenizer,
+    messages: List[Dict],
+    max_length: int,
+    return_tensors: str | None = None,
+) -> Dict:
+    """Tokenize messages with the tokenizer chat template when available."""
+    if tokenizer.chat_template is not None:
+        return tokenizer.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=False,
+            max_length=max_length,
+            truncation=True,
+            return_dict=True,
+            return_tensors=return_tensors,
+        )
+
+    return tokenizer(
+        format_conversation(messages),
+        max_length=max_length,
+        truncation=True,
+        add_special_tokens=True,
+        return_tensors=return_tensors,
+    )
+
+
 def build_preference_dataset(
     tokenizer: AutoTokenizer,
     dataset_name: str = DEFAULT_DATASET,
@@ -100,27 +127,22 @@ def build_preference_dataset(
         # Handle different dataset formats
         if isinstance(chosen, list) and len(chosen) > 0:
             # Conversation format
-            chosen_text = format_conversation(chosen)
-            rejected_text = format_conversation(rejected)
+            chosen_messages = chosen
+            rejected_messages = rejected
         elif isinstance(chosen, str):
-            chosen_text = f"user: {prompt}\nassistant: {chosen}"
-            rejected_text = f"user: {prompt}\nassistant: {rejected}"
+            chosen_messages = [
+                {"role": "user", "content": prompt},
+                {"role": "assistant", "content": chosen},
+            ]
+            rejected_messages = [
+                {"role": "user", "content": prompt},
+                {"role": "assistant", "content": rejected},
+            ]
         else:
             continue
 
-        # Tokenize
-        chosen_tokens = tokenizer(
-            chosen_text,
-            max_length=max_length,
-            truncation=True,
-            add_special_tokens=True,
-        )
-        rejected_tokens = tokenizer(
-            rejected_text,
-            max_length=max_length,
-            truncation=True,
-            add_special_tokens=True,
-        )
+        chosen_tokens = tokenize_messages(tokenizer, chosen_messages, max_length)
+        rejected_tokens = tokenize_messages(tokenizer, rejected_messages, max_length)
 
         records.append(
             {
@@ -386,13 +408,24 @@ for certain problems like breaking codes or simulating molecules."""
     bad_response = """Quantum computing is complicated. It uses physics.
 Computers are electronic devices. I don't really know much about it."""
 
-    # Format as conversations
-    good_text = f"user: {prompt}\nassistant: {good_response}"
-    bad_text = f"user: {prompt}\nassistant: {bad_response}"
-
-    # Tokenize
-    good_tokens = tokenizer(good_text, return_tensors="pt", max_length=512, truncation=True)
-    bad_tokens = tokenizer(bad_text, return_tensors="pt", max_length=512, truncation=True)
+    good_tokens = tokenize_messages(
+        tokenizer,
+        [
+            {"role": "user", "content": prompt},
+            {"role": "assistant", "content": good_response},
+        ],
+        max_length=512,
+        return_tensors="pt",
+    )
+    bad_tokens = tokenize_messages(
+        tokenizer,
+        [
+            {"role": "user", "content": prompt},
+            {"role": "assistant", "content": bad_response},
+        ],
+        max_length=512,
+        return_tensors="pt",
+    )
 
     with torch.no_grad():
         good_reward = model.get_reward(


### PR DESCRIPTION
## Summary

Update preference reward model tokenization to respect tokenizer-native chat templates when available.

When a tokenizer defines `chat_template`, preference examples are now tokenized directly with `tokenizer.apply_chat_template(..., tokenize=True)`. Tokenizers without a chat template
continue to use the existing simple `role: content` fallback formatting.

## Changes

- Add a `tokenize_messages` helper for conversation tokenization
- Use `apply_chat_template(..., tokenize=True, add_generation_prompt=False)` when available
- Preserve the existing fallback formatting for tokenizers without chat templates
- Normalize string-format chosen/rejected examples into message lists before tokenization
- Use the same tokenization path in `demo_scoring`

## Checks

```bash
uv run --extra dev ruff check reward_models/train_preference_rm.py
uv run --extra dev ruff format --check reward_models/train_preference_rm.py
uv run python -m compileall reward_models/train_preference_rm.py
```

## Disclosure
Codex was used under supervision