### PR TITLE
Ch8 + Lec6: fix bare π → π_θ in BT DPO gradient terms (closes #451)

### DIFF
--- a/book/chapters/08-direct-alignment.md
+++ b/book/chapters/08-direct-alignment.md
@@ -66,7 +66,7 @@ Hence, DPO is increasing the gap in relative log-probabilities between the chose
 
 With the reward in @eq:dpo_reward, we can write the gradient of the loss to further interpret what is going on:
 
-$$\nabla_{\theta}\mathcal{L}_{\text{DPO}}(\pi_{\theta}; \pi_{\text{ref}}) = -\beta \mathbb{E}_{(x, y_c, y_r)\sim \mathcal{D}}\left[ w \cdot \left(\nabla_{\theta}\log \pi(y_c \mid x) - \nabla_{\theta}\log \pi(y_r \mid x)\right) \right]$$ {#eq:dpo_gradient}
+$$\nabla_{\theta}\mathcal{L}_{\text{DPO}}(\pi_{\theta}; \pi_{\text{ref}}) = -\beta \mathbb{E}_{(x, y_c, y_r)\sim \mathcal{D}}\left[ w \cdot \left(\nabla_{\theta}\log \pi_{\theta}(y_c \mid x) - \nabla_{\theta}\log \pi_{\theta}(y_r \mid x)\right) \right]$$ {#eq:dpo_gradient}
 
 where $w = \sigma\!\left(r_{\theta}(x, y_r) - r_{\theta}(x, y_c)\right)$.
 
@@ -233,7 +233,7 @@ $$\nabla_{\theta}\mathcal{L}_{\text{DPO}}(\pi_{\theta};\pi_{\text{ref}}) = -\mat
 
 Expanding this and using the above expressions for sigmoid and logarithms results in the gradient introduced earlier:
 
-$$ -\mathbb{E}_{(x,y_c,y_r)\sim\mathcal{D}}\left[\beta\sigma\left(\beta\log\frac{\pi_{\theta}(y_r|x)}{\pi_{\text{ref}}(y_r|x)} - \beta\log\frac{\pi_{\theta}(y_c|x)}{\pi_{\text{ref}}(y_c|x)}\right)\left[\nabla_{\theta}\log\pi(y_c|x)-\nabla_{\theta}\log\pi(y_r|x)\right]\right] $$ {#eq:dpo_grad_3}
+$$ -\mathbb{E}_{(x,y_c,y_r)\sim\mathcal{D}}\left[\beta\sigma\left(\beta\log\frac{\pi_{\theta}(y_r|x)}{\pi_{\text{ref}}(y_r|x)} - \beta\log\frac{\pi_{\theta}(y_c|x)}{\pi_{\text{ref}}(y_c|x)}\right)\left[\nabla_{\theta}\log\pi_{\theta}(y_c|x)-\nabla_{\theta}\log\pi_{\theta}(y_r|x)\right]\right] $$ {#eq:dpo_grad_3}
 
 ## Numerical Concerns, Weaknesses, and Alternatives
 

--- a/teach/course/lec6-chap8-dpo.md
+++ b/teach/course/lec6-chap8-dpo.md
@@ -632,7 +632,7 @@ $$
 Substitute $\nabla_{\theta} u$ and write $\sigma(-u)$ out in full:
 
 $$
-\nabla_{\theta}\mathcal{L}_{\text{DPO}} = -\,\beta\,\mathbb{E}_{(x,y_c,y_r)}\Big[ \sigma\big(\beta\log\tfrac{\pi_{\theta}(y_r\mid x)}{\pi_{\text{ref}}(y_r\mid x)} - \beta\log\tfrac{\pi_{\theta}(y_c\mid x)}{\pi_{\text{ref}}(y_c\mid x)}\big)\,\big[\nabla_{\theta}\log\pi(y_c\mid x) - \nabla_{\theta}\log\pi(y_r\mid x)\big] \Big]
+\nabla_{\theta}\mathcal{L}_{\text{DPO}} = -\,\beta\,\mathbb{E}_{(x,y_c,y_r)}\Big[ \sigma\big(\beta\log\tfrac{\pi_{\theta}(y_r\mid x)}{\pi_{\text{ref}}(y_r\mid x)} - \beta\log\tfrac{\pi_{\theta}(y_c\mid x)}{\pi_{\text{ref}}(y_c\mid x)}\big)\,\big[\nabla_{\theta}\log\pi_{\theta}(y_c\mid x) - \nabla_{\theta}\log\pi_{\theta}(y_r\mid x)\big] \Big]
 $$
 
 ---
@@ -644,7 +644,7 @@ $$
 
 $$
 \begin{aligned}
-\nabla_{\theta}\mathcal{L}_{\text{DPO}} &= -\,\beta\, \mathbb{E}_{(x,y_c,y_r)}\Big[\, \underbrace{w}_{\text{how wrong}} \cdot \big( \nabla_{\theta}\log\pi(y_c\mid x) - \nabla_{\theta}\log\pi(y_r\mid x) \big)\,\Big] \\[6pt]
+\nabla_{\theta}\mathcal{L}_{\text{DPO}} &= -\,\beta\, \mathbb{E}_{(x,y_c,y_r)}\Big[\, \underbrace{w}_{\text{how wrong}} \cdot \big( \nabla_{\theta}\log\pi_{\theta}(y_c\mid x) - \nabla_{\theta}\log\pi_{\theta}(y_r\mid x) \big)\,\Big] \\[6pt]
 &\hspace{6em}\text{where}\quad w = \sigma\big(r_\theta(x,y_r) - r_\theta(x,y_c)\big)
 \end{aligned}
 $$


### PR DESCRIPTION
## Summary

Fixes [#451](https://github.com/natolambert/rlhf-book/issues/451) (thanks @Itachi1999). In the BT DPO gradient, the final $\nabla_\theta \log \pi(\cdot)$ terms were written with a bare $\pi$. Since the gradient is taken with respect to $\theta$ — and $\pi_{\text{ref}}$ is fixed — the differentiated policy is $\pi_\theta$, matching every other term in the equation and the DPO paper's eq. 7. The same slip appears in both the book chapter and the DPO lecture, so this fixes both.

## Changes

**Book chapter** (`book/chapters/08-direct-alignment.md`):
- `eq:dpo_gradient` — the intuition gradient in "How DPO Works"
- `eq:dpo_grad_3` — the derivation result in "Deriving the BT DPO Gradient" (the equation the issue cites)

**DPO lecture** (`teach/course/lec6-chap8-dpo.md`):
- Two gradient slides used a bare $\pi$ while an earlier slide already used $\pi_\theta$ — the deck was internally inconsistent. Both now use $\pi_\theta$.

The $\pi^*$ terms in the reward derivation (eqs. `dpo_reward_deriv1–3`) are the optimal policy, not gradient terms, and are left unchanged.

Verified with `make html` (chapter) and `colloquium build` (lecture) — all equations render with $\pi_\theta$, no KaTeX errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)