### PR TITLE
Course: Lecture 0 prerequisite review deck

### DIFF
--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -548,6 +548,18 @@
 
     <p>If you prefer the traditional coursework path, the usual background is the basics of language modeling / NLP plus basic machine learning (e.g. an intro to AI course and an intro to ML course).</p>
 
+    <div class="course-entry" id="prerequisite-review">
+      <div>
+        <h3>Prerequisite Review</h3>
+        <p class="meta">A 20–30 minute refresher on language models, optimization, probability, and RL before you start the lecture series</p>
+      </div>
+      <div class="talk-actions">
+        <a href="/teach/course/lec0-prereq-review/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
+        <a href="/teach/course/lec0-prereq-review/" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
+        <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec0-prereq-review.md?plain=1" class="btn btn-source" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
+      </div>
+    </div>
+
     <p class="meta"><a href="#extra-resources" style="display: inline-flex; align-items: center; gap: 0.4em;"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>Additional learning material</a></p>
   </section>
 
@@ -678,18 +690,6 @@
     <h2>Extra Resources</h2>
 
     <p class="meta" style="margin-bottom: 1em;">Outside material that I've personally used for going deeper on reinforcement learning and language models. The books in particular are wonderful complements.</p>
-
-    <div class="course-entry" id="prerequisite-review">
-      <div>
-        <h3>Prerequisite Review</h3>
-        <p class="meta">A 20–30 minute refresher on language models, optimization, probability, and RL before you start the lecture series</p>
-      </div>
-      <div class="talk-actions">
-        <a href="/teach/course/lec0-prereq-review/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
-        <a href="/teach/course/lec0-prereq-review/" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
-        <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec0-prereq-review.md?plain=1" class="btn btn-source" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
-      </div>
-    </div>
 
     <h3>Books &amp; Courses</h3>
     <div class="resource-grid">

--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -677,6 +677,18 @@
 
     <p class="meta" style="margin-bottom: 1em;">Outside material that I've personally used for going deeper on reinforcement learning and language models. The books in particular are wonderful complements.</p>
 
+    <div class="course-entry" id="prerequisite-review">
+      <div>
+        <h3>Prerequisite Review</h3>
+        <p class="meta">A 20–30 minute refresher on language models, optimization, probability, and RL before you start the lecture series</p>
+      </div>
+      <div class="talk-actions">
+        <a href="/teach/course/lec0-prereq-review/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
+        <a href="/teach/course/lec0-prereq-review/" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
+        <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec0-prereq-review.md?plain=1" class="btn btn-source" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>
+      </div>
+    </div>
+
     <h3>Books &amp; Courses</h3>
     <div class="resource-grid">
       <a class="resource-card" href="https://amzn.to/4vfAM2E" target="_blank" rel="noopener noreferrer">

--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -517,6 +517,8 @@
     A full course accompanying the book with added resources and other lectures I've given.
   </p>
 
+  <p class="meta">The slide decks are usually built with Claude Opus, with substantial human revisions. (Exceptions are noted on the deck itself.)</p>
+
   <div class="welcome-video">
     <div>
       <h3>Welcome to the Course</h3>

--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -550,8 +550,8 @@
 
     <div class="course-entry" id="prerequisite-review">
       <div>
-        <h3>Prerequisite Review</h3>
-        <p class="meta">A 20–30 minute refresher on language models, optimization, probability, and RL before you start the lecture series</p>
+        <h3>The ML Foundations of LLM Post-Training</h3>
+        <p class="meta">A 20–30 minute refresher on the ML foundations of post-training — from cross-entropy to preferences and RL — before the lecture series</p>
       </div>
       <div class="talk-actions">
         <a href="/teach/course/lec0-prereq-review/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>

--- a/teach/.gitignore
+++ b/teach/.gitignore
@@ -1,1 +1,2 @@
 *.html
+slides/

--- a/teach/course/lec0-prereq-review.md
+++ b/teach/course/lec0-prereq-review.md
@@ -32,20 +32,22 @@ custom_css: |
 <p class="colloquium-title-name">Nathan Lambert</p>
 </div>
 
-<p class="colloquium-title-note">A 20–30 minute refresher on language models, optimization, probability, and RL — before Lecture 1.</p>
+<p class="colloquium-title-note">A 20–30 minute refresher on language models, optimization, probability, and RL framing — before Lecture 1.</p>
+
+<p class="colloquium-title-note" style="font-size: 0.6em; opacity: 0.7;">This deck was drafted with assistance from GLM 5.2.</p>
 
 ---
 
 ## What this review covers
 
-This course assumes the basics of language modeling / NLP and an intro ML course. The lectures *use* the following ideas without re-teaching them. This deck rebuilds the four pillars you'll lean on:
+**No prior reinforcement learning is assumed.** We assume intro-ML comfort with losses, gradients, and probability, plus basic PyTorch tensor fluency for the implementation lectures (Lecture 4 onward). This deck refreshes autoregressive language models and the handful of ideas the course *uses* without re-teaching them:
 
-- **Language models** — what an LM is, the LM head, softmax, cross-entropy
-- **Optimization** — gradient descent, the training loop, pretraining → mid-training → SFT
-- **Probability** — entropy, KL divergence, the log-derivative trick
-- **Reinforcement learning** — policies, returns, policy gradients, why RL for LMs
+- **Language models** — autoregressive factorization, the LM head, softmax, cross-entropy, and the tensor-shape anatomy of one training example
+- **Optimization** — gradient descent, the training loop, pretraining → SFT
+- **Probability** — KL divergence (with entropy), sigmoid and pairwise likelihood
+- **Reinforcement learning framing** — the MDP setup and the goal of RL; the course derives the algorithms themselves
 
-You do **not** need prior RL or language-modeling background to start the course — this is a refresher, not a gate.
+This is a refresher, not a gate — chase what excites you and skip what you already know.
 
 ---
 
@@ -64,20 +66,20 @@ Given $x = (x_1, \ldots, x_T)$, the model factorizes the sequence probability:
 
 $$P_\theta(x) = \prod_{t=1}^{T} P_\theta(x_t \mid x_1, \ldots, x_{t-1}).$$
 
-Modern LMs (ChatGPT, Claude, Gemini) are **decoder-only Transformers** built on **self-attention**.
+Modern LMs (ChatGPT, Claude, Gemini) are **decoder-only Transformers** built on **self-attention** — each position attends only to itself and the positions before it.
 
 |||
 
-![The original Transformer architecture diagram. 2017.](assets/transformer.webp)
+![Next-token prediction: a decoder-only language model predicts one token at a time from the prefix before it.](assets/pretraining_next_token_tikz.png)
 <!-- cite-right: Vaswani2017AttentionIA -->
 
 ---
 
 ## The LM head
 
-The transformer backbone outputs a vector per token in an internal **embedding space**. The **LM head** is a final linear projection from that embedding space back to the **vocabulary** (tokenizer space).
+The transformer backbone outputs a **hidden state** vector per token. The **LM head** is a final linear projection from the hidden dimension back to the **vocabulary** (tokenizer space).
 
-- Embedding $\xrightarrow{\text{LM head}}$ **logits** (one score per vocab token)
+- Hidden state $\xrightarrow{\text{LM head}}$ **logits** (one score per vocab token)
 - **softmax** over logits $\rightarrow$ a probability distribution over the next token
 - Sampling / argmax from that distribution $\rightarrow$ the generated token
 
@@ -96,6 +98,57 @@ In practice we almost always work in **log-space**. The log-probability of a seq
 $$\log P_\theta(x) = \sum_{t=1}^{T} \log P_\theta(x_t \mid x_{<t}).$$
 
 Why log-probs? **Numerical stability** (products of many small probabilities underflow), and sums are easier to differentiate than products.
+
+---
+
+## Anatomy of one LM training example
+
+Lecture 4 jumps straight into shifting logits, gathering target log-probs, and masking. Here is the whole path once, up front:
+
+```text
+input_ids  ∈ ℕ^{B × L}          # token IDs, batch B, length L
+   → model(input_ids).logits ∈ ℝ^{B × L × V}     # one vector per position, V = vocab
+   → log_softmax + gather    ∈ ℝ^{B × (L-1)}     # log-prob of each observed token
+   → (× completion_mask).sum ∈ ℝ^{B}             # one completion log-prob per sequence
+```
+
+```python
+logits = model(input_ids).logits            # (B, L, V)
+logits = logits[:, :-1, :]                  # shift: logit at t predicts token at t+1
+labels = input_ids[:, 1:]                   # (B, L-1)
+log_probs = logits.log_softmax(dim=-1)
+token_log_probs = log_probs.gather(-1, labels.unsqueeze(-1)).squeeze(-1)  # (B, L-1)
+```
+
+The **one-token shift** is the autoregressive step made literal: position $t$'s logits predict token $t+1$. Sum the per-token log-probs and `loss.backward()` — autodiff turns that sum into the corresponding sum of per-token gradients.
+
+---
+
+## Three masks — don't confuse them
+
+Masking is where silent bugs live. Three different masks do three different jobs:
+
+- **Causal mask** (built into decoder attention) — position $t$ cannot attend to positions $> t$. This is what makes the model autoregressive; you never touch it in training code.
+- **Attention / padding mask** — tells attention to ignore padding tokens (variable-length sequences batched together). Shape `(B, L)`.
+- **Completion / loss mask** — `1` only on completion tokens; the loss is multiplied by it before summing. **Prompt tokens condition the prediction but contribute no loss.**
+
+> Get the completion mask wrong and you either train on the prompt (wastes gradient on tokens you can't change) or on padding (trains on noise). Lecture 4 lists exactly these as the most common silent failures.
+
+---
+
+## Teacher forcing vs generation
+
+How the sequence you score gets into the model determines what kind of training you're doing:
+
+- **SFT** — score a **supplied** target under *teacher forcing*: the model always sees the correct prefix, one token off from the label.
+- **RL** — **sample** a new sequence from the current policy, then score *that sampled* sequence. The model sees its own prefixes, which may be wrong.
+- **Preference optimization** — score **supplied** chosen and rejected sequences (no sampling).
+
+A small decoding review:
+
+$$y_t \sim \mathrm{softmax}(z_t / T)$$
+
+with $T$ a temperature (high $T$ → flatter, more random) and truncation methods (top-$k$, top-$p$) shaping the sample. The key distinction: **the model distribution** ($\pi_\theta$) vs **the sampling procedure** applied to it. Teacher-forced training never encounters the model's own errors; rollout training does — this is the root of *on-policy data*, *distribution shift*, and why RL infrastructure is different.
 
 ---
 
@@ -124,10 +177,10 @@ Training repeats one step:
 $$\theta \leftarrow \theta - \eta \,\nabla_\theta \mathcal{L}(\theta).$$
 
 - $\theta$ — model parameters, $\eta$ — learning rate, $\nabla_\theta \mathcal{L}$ — gradient of the loss
-- In practice everyone uses **Adam** (adaptive, momentum-based) rather than plain SGD
-- One **step** per batch; sweep the dataset in **epochs**; the learning-rate schedule matters as much as the rate itself
+- **AdamW** and related adaptive optimizers are standard for LM training (adaptive, momentum-based) rather than plain SGD
+- Training is measured in optimizer **steps / tokens**; **epochs** are a useful unit for finite fine-tuning datasets. The learning-rate schedule matters as much as the rate itself
 
-The machinery is identical across pretraining, mid-training, and fine-tuning — what changes is the **data** and the **objective**, not the optimizer.
+The basic backprop loop is shared across pretraining, mid-training, and fine-tuning — what differs is **masking, sampling, batching, data construction, and systems**, not the optimizer.
 
 ---
 
@@ -135,9 +188,9 @@ The machinery is identical across pretraining, mid-training, and fine-tuning —
 
 The boundary at the *end* of pretraining is fuzzy and worth naming:
 
-- **Pretraining** — next-token cross-entropy on massive raw web/code data.
-- **Mid-training** — the annealing / high-quality-data phase at the very end of pretraining: "mid-training like annealing / high-quality end of pretraining web data." Quality ramps up here before any instruction data.
-- **SFT (supervised fine-tuning)** — still cross-entropy, but now on **instruction–response** pairs: the model learns to *respond*, not just continue text.
+- **Pretraining** — next-token cross-entropy on massive raw web/code data; **every** token contributes to the loss.
+- **Mid-training** — the annealing / high-quality-data phase at the very end of pretraining, before any instruction data. Quality ramps up here.
+- **SFT (supervised fine-tuning)** — still cross-entropy, but now on **instruction–response** pairs with a **completion mask**: only the response tokens contribute to the loss, the prompt merely conditions. The model learns to *respond*, not just continue text.
 
 Modern post-training pipelines start from a **mid-trained** checkpoint, so this is where the course's story effectively begins.
 
@@ -149,18 +202,7 @@ Modern post-training pipelines start from a **mid-trained** checkpoint, so this 
 
 ---
 
-## Entropy
-
-The **entropy** of a distribution $p$ measures its uncertainty / average surprisal:
-
-$$H(p) = -\sum_i p_i \log p_i.$$
-
-- Uniform distributions have **high** entropy; peaked ones have **low** entropy
-- Entropy shows up in this course when we talk about preference distributions (Lecture 8) and as a regularizer that keeps an RLHF'd policy from collapsing onto a single mode
-
----
-
-## KL divergence
+## KL divergence (and entropy)
 
 The **Kullback–Leibler divergence** measures how one distribution differs from another:
 
@@ -170,72 +212,89 @@ Three things to remember:
 
 - **Asymmetric** — $\mathcal{D}_{\text{KL}}(p\|q) \neq \mathcal{D}_{\text{KL}}(q\|p)$; direction matters
 - **Non-negative**, and $0$ only when $p = q$
-- **The** central object of alignment: the RLHF KL penalty (Lectures 3–4) keeps the policy close to its SFT start, and the DPO loss (Lecture 6) is derived from a KL-bound objective
+- **The** central object of alignment: the RLHF KL penalty (Lectures 3–4) keeps the policy close to its SFT start, and the DPO loss (Lecture 6) is derived from a **KL-regularized reward-maximization** objective
+
+> **Entropy** $H(p) = -\sum_i p_i \log p_i$ is the uncertainty of a distribution (uniform = high, peaked = low). It shows up here as a regularizer that keeps an RLHF'd policy from collapsing onto a single mode, and in Lecture 8's preference distributions.
 
 You will see KL in essentially every alignment lecture.
 
 ---
 
-## Expectations & the log-derivative trick
+## Sigmoid & pairwise likelihood
 
-Many RL quantities are **expectations** under the model's own distribution, e.g. $\mathbb{E}_{p_\theta}[f]$. We need their *gradients*, but we can't differentiate through a sample.
+A preference ("response $y_w$ is better than $y_l$") is a **binary** outcome, so a score difference is squeezed through a **sigmoid** into a probability:
 
-The **log-derivative trick** (a.k.a. score-function / REINFORCE estimator) sidesteps this:
+$$\sigma(z) = \frac{1}{1+e^{-z}}, \qquad P(y_w \succ y_l \mid x) = \sigma\!\left(r(x,y_w) - r(x,y_l)\right).$$
 
-$$\nabla_\theta \,\mathbb{E}_{p_\theta}[f] = \mathbb{E}_{p_\theta}\!\left[\,f \,\nabla_\theta \log p_\theta\,\right].$$
+Three things to recognize:
 
-Intuition: $\nabla_\theta \log p_\theta$ is the *score* — it points in the direction that increases the model's log-probability of a sample. Weight it by how good the sample was, and you get a usable gradient. This is the bridge into policy gradients.
+- sigmoid converts a **score difference** into a binary probability
+- only **relative** reward differences matter — shifting both rewards by a constant changes nothing
+- $-\log \sigma(\cdot)$ is just **binary negative log-likelihood**
+
+**Lecture 2 derives this Bradley–Terry model in full** to train a reward model; **Lecture 6 reuses the exact same $\sigma(\Delta r)$ shape** inside DPO. This slide is "recognize the pattern" — the derivations come later.
 
 ---
 
 <!-- layout: section-break -->
 
-## Reinforcement learning basics
+## Reinforcement learning framing
 
 ---
 
-## RL framing
+## Language models as an MDP
 
-Reinforcement learning is about learning to **act** by maximizing accumulated **reward**.
+Reinforcement learning studies an agent acting in a **Markov decision process** $(\mathcal{S}, \mathcal{A}, P, r, \gamma)$: states, actions, a transition function, a reward, and a discount. Generation maps cleanly onto one:
 
-- **Agent** takes **actions** in an **environment**; receives **rewards**
-- **Policy** $\pi(a \mid s)$ — a distribution over actions given state
-- **Return** $G_t$ — discounted future reward from time $t$
-- **Value** $V^\pi(s)$ — expected return from state $s$ under $\pi$
+| MDP concept | Language model |
+|-------------|---------------|
+| State $s_t$ | Prompt + tokens so far: $(x, y_{<t})$ |
+| Action $a_t$ | Next token $y_t$ |
+| Transition $P$ | Deterministic: append the token |
+| Policy $\pi_\theta(a_t \mid s_t)$ | LM next-token distribution |
+| Reward $r$ | Usually **terminal**: RM score or verifier output |
+| Discount $\gamma$ | Typically $1.0$ (no discounting) |
 
-The hard part is **credit assignment**: rewards are sparse and delayed, so which action *caused* the payoff?
-<!-- cite-right: sutton2018reinforcement -->
+The policy is the LM, factorized over tokens:
 
----
+$$\pi_\theta(y \mid x) = \prod_t \pi_\theta(y_t \mid x, y_{<t}).$$
 
-## Policy gradients / REINFORCE
+> **The supervision is usually response-level, but the gradient and KL bookkeeping are token-level.** That single distinction explains a large fraction of the notation the course uses later — far more useful than memorizing the bare five-tuple.
 
-Instead of learning a value function, **directly optimize the policy**. The policy-gradient theorem (REINFORCE) gives a gradient of expected return:
-
-$$\nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim \pi_\theta}\!\left[\, R(\tau)\, \nabla_\theta \log \pi_\theta(\tau)\,\right].$$
-
-Read it with slide 13 in hand: $R(\tau)$ is "how good was this trajectory," $\nabla_\theta \log \pi_\theta(\tau)$ is "nudge the policy to make this trajectory more likely." Together: **make good trajectories more probable**.
-
-This is exactly what Lecture 3 builds on — the course just specializes $\pi$ to a language model and $R$ to a reward model.
-<!-- cite-right: williams1992simple -->
+**Lecture 3 develops policy gradients, baselines, and PPO/GRPO from this setup; Lecture 4 turns them into code.** More on the algorithms there.
 
 ---
 
-## Why RL for language models?
+## The goal of RL, and why for language models
 
-A human preference ("response A is better than B") is:
+The goal of RL is to choose policy parameters $\theta$ that maximize **expected reward** under the policy itself:
+
+$$J(\theta) = \mathbb{E}_{y \sim \pi_\theta}[R(x, y)].$$
+
+A human preference (or a verifier) is a single scalar at the *end* of a response:
 
 - **Sparse** — one label per whole response, not per token
-- **Non-differentiable** — there's no cross-entropy target for "preferred"
 - **Delayed** — the quality of a token depends on the whole completion
+- **No token-level target** — and ordinary gradients can't pass back through the discrete sampled token
 
-So we can't write human feedback as a loss and backprop. RL lets us **optimize a reward signal we can't differentiate through** — first by *learning* that signal as a reward model, then by *optimizing* it with policy gradients. That is the whole motivation for RLHF.
+So there is no cross-entropy target for "preferred." Policy gradients optimize the expected evaluator score anyway — first by *learning* that signal as a reward model, then by *optimizing* it. That is the whole motivation for RLHF.
+
+> **Lecture 3 derives the policy-gradient math; Lecture 4 turns it into code.** This deck stops at the framing.
 
 ---
 
-## Where to go deeper
+## You are ready if…
 
-You're now ready for **Lecture 1**. If any pillar felt rusty:
+You can do all of the following (or know which one to come back to):
+
+- **Shift and gather** — explain why `logits[:, :-1]` predicts `input_ids[:, 1:]` and what `gather` does
+- **Name the three masks** — causal, attention/padding, completion/loss — and which one the loss multiplies by
+- **Distinguish teacher forcing from rollout** — and say why RL infrastructure is different
+- **Read $\mathcal{D}_{\text{KL}}(p \| q)$** — asymmetric, non-negative, and central to alignment
+- **Read a sigmoid score difference** — $P(y_w \succ y_l) = \sigma(r_w - r_l)$, and know only the *difference* matters
+- **State the LM-as-MDP mapping** — and the response-level-vs-token-level takeaway
+
+If any felt rusty:
 
 - **RL** — Sutton & Barto, *Reinforcement Learning: An Introduction*; David Silver's UCL course; UC Berkeley CS285
 - **Language models from scratch** — Sebastian Raschka, *Build a Large Language Model (From Scratch)*

--- a/teach/course/lec0-prereq-review.md
+++ b/teach/course/lec0-prereq-review.md
@@ -116,8 +116,10 @@ input_ids  ∈ ℕ^{B × L}          # token IDs, batch B, length L
 logits = model(input_ids).logits            # (B, L, V)
 logits = logits[:, :-1, :]                  # shift: logit at t predicts token at t+1
 labels = input_ids[:, 1:]                   # (B, L-1)
+completion_mask = completion_mask[:, 1:]    # (B, L-1) — shift the mask to match labels
 log_probs = logits.log_softmax(dim=-1)
 token_log_probs = log_probs.gather(-1, labels.unsqueeze(-1)).squeeze(-1)  # (B, L-1)
+seq_log_probs = (token_log_probs * completion_mask).sum(dim=-1)           # (B,)
 ```
 
 The **one-token shift** is the autoregressive step made literal: position $t$'s logits predict token $t+1$. Sum the per-token log-probs and `loss.backward()` — autodiff turns that sum into the corresponding sum of per-token gradients.

--- a/teach/course/lec0-prereq-review.md
+++ b/teach/course/lec0-prereq-review.md
@@ -24,7 +24,7 @@ custom_css: |
 <!-- layout: title-sidebar -->
 <!-- valign: bottom -->
 
-# The ML Foundations of LLM Post-Training
+# Course Prereqs: The ML Foundations of LLM Post-Training
 
 <div class="colloquium-title-eyebrow">rlhfbook.com</div>
 

--- a/teach/course/lec0-prereq-review.md
+++ b/teach/course/lec0-prereq-review.md
@@ -32,7 +32,7 @@ custom_css: |
 <p class="colloquium-title-name">Nathan Lambert</p>
 </div>
 
-<p class="colloquium-title-note">From cross-entropy to preferences and reinforcement learning — a 20–30 minute refresher before Lecture 1.</p>
+<p class="colloquium-title-note">From cross-entropy to preferences and reinforcement learning — a short, optional refresher before Lecture 1.</p>
 
 <p class="colloquium-title-note" style="font-size: 0.6em; opacity: 0.7;">This deck was drafted with assistance from GLM 5.2.</p>
 
@@ -40,14 +40,12 @@ custom_css: |
 
 ## What this review covers
 
-**No prior reinforcement learning is assumed.** We assume intro-ML comfort with losses, gradients, and probability, plus basic PyTorch tensor fluency for the implementation lectures (Lecture 4 onward). This deck refreshes autoregressive language models and the handful of ideas the course *uses* without re-teaching them:
+**No prior reinforcement learning is assumed.** We assume intro-ML comfort with losses, gradients, and probability, plus basic PyTorch tensor fluency. This deck is a refresher on autoregressive language models and the handful of ideas the course uses:
 
-- **Language models** — autoregressive factorization, the LM head, softmax, cross-entropy, and the tensor-shape anatomy of one training example
+- **Language models** — autoregressive factorization of log-probs, the LM head, softmax, cross-entropy, and the tensor-shape anatomy
 - **Optimization** — gradient descent, the training loop, pretraining → SFT
 - **Probability** — KL divergence (with entropy), sigmoid and pairwise likelihood
-- **Reinforcement learning framing** — the MDP setup and the goal of RL; the course derives the algorithms themselves
-
-This is a refresher, not a gate — chase what excites you and skip what you already know.
+- **Reinforcement learning framing** — the MDP setup and the goal of RL
 
 ---
 
@@ -89,13 +87,15 @@ The same backbone can carry **different heads** for different jobs. In this cour
 
 ## Softmax & log-probabilities
 
-**Softmax** turns logits $z$ into a distribution:
+**Softmax** turns the logits $z^{(t)}$ at step $t$ into the next-token distribution — producing each per-token probability:
 
-$$\mathrm{softmax}(z)_i = \frac{e^{z_i}}{\sum_j e^{z_j}}.$$
+$$P_\theta(x_t \mid x_{<t}) = \mathrm{softmax}(z^{(t)})_{x_t} = \frac{e^{z^{(t)}_{x_t}}}{\sum_j e^{z^{(t)}_j}}.$$
 
-In practice we almost always work in **log-space**. The log-probability of a sequence is the sum of per-token log-probs:
+A whole sequence is the **product** of these terms (chain rule), and in **log-space** the product becomes a sum:
 
-$$\log P_\theta(x) = \sum_{t=1}^{T} \log P_\theta(x_t \mid x_{<t}).$$
+$$\log P_\theta(x) = \log \prod_{t=1}^{T} P_\theta(x_t \mid x_{<t}) = \sum_{t=1}^{T} \log P_\theta(x_t \mid x_{<t}).$$
+
+So every term in the sum is a `log_softmax` of the logits read off at the true token — which is exactly the (negative) cross-entropy loss at that position.
 
 Why log-probs? **Numerical stability** (products of many small probabilities underflow), and sums are easier to differentiate than products.
 
@@ -103,64 +103,133 @@ Why log-probs? **Numerical stability** (products of many small probabilities und
 
 ## Anatomy of one LM training example
 
-Lecture 4 jumps straight into shifting logits, gathering target log-probs, and masking. Here is the whole path once, up front:
+Lectures discuss shifting logits, gathering target log-probs, and masking. Here is the whole path once, at the level of tensor shapes:
 
 ```text
-input_ids  ∈ ℕ^{B × L}          # token IDs, batch B, length L
+input_ids  ∈ ℕ^{B × L}          # INPUT TO MODEL -- token IDs, batch B, length L
    → model(input_ids).logits ∈ ℝ^{B × L × V}     # one vector per position, V = vocab
    → log_softmax + gather    ∈ ℝ^{B × (L-1)}     # log-prob of each observed token
    → (× completion_mask).sum ∈ ℝ^{B}             # one completion log-prob per sequence
 ```
 
+Next: the same path in PyTorch, one line at a time.
+
+---
+
+## Anatomy of one LM training example
+
 ```python
-logits = model(input_ids).logits            # (B, L, V)
-logits = logits[:, :-1, :]                  # shift: logit at t predicts token at t+1
-labels = input_ids[:, 1:]                   # (B, L-1)
-completion_mask = completion_mask[:, 1:]    # (B, L-1) — shift the mask to match labels
-log_probs = logits.log_softmax(dim=-1)
-token_log_probs = log_probs.gather(-1, labels.unsqueeze(-1)).squeeze(-1)  # (B, L-1)
-seq_log_probs = (token_log_probs * completion_mask).sum(dim=-1)           # (B,)
+logits = model(input_ids).logits            # (B, L, V): a score for every vocab token, at every position
+```
+
+---
+
+## Anatomy of one LM training example
+
+```python
+logits = model(input_ids).logits            # (B, L, V): a score for every vocab token, at every position
+logits = logits[:, :-1, :]                  # drop the last position — its prediction has no next token to score
+```
+
+---
+
+## Anatomy of one LM training example
+
+```python
+logits = model(input_ids).logits            # (B, L, V): a score for every vocab token, at every position
+logits = logits[:, :-1, :]                  # drop the last position — its prediction has no next token to score
+labels = input_ids[:, 1:]                   # the target at each position is just the actual next token (the shift)
+```
+
+---
+
+## Anatomy of one LM training example
+
+```python
+logits = model(input_ids).logits            # (B, L, V): a score for every vocab token, at every position
+logits = logits[:, :-1, :]                  # drop the last position — its prediction has no next token to score
+labels = input_ids[:, 1:]                   # the target at each position is just the actual next token (the shift)
+completion_mask = completion_mask[:, 1:]    # shift the mask the same way so it lines up with labels (1 = completion)
+```
+
+---
+
+## Anatomy of one LM training example
+
+```python
+logits = model(input_ids).logits            # (B, L, V): a score for every vocab token, at every position
+logits = logits[:, :-1, :]                  # drop the last position — its prediction has no next token to score
+labels = input_ids[:, 1:]                   # the target at each position is just the actual next token (the shift)
+completion_mask = completion_mask[:, 1:]    # shift the mask the same way so it lines up with labels (1 = completion)
+log_probs = logits.log_softmax(dim=-1)      # normalize logits into log-probabilities over the vocab -> (B, L-1, V)
+```
+
+---
+
+## Anatomy of one LM training example
+
+```python
+logits = model(input_ids).logits            # (B, L, V): a score for every vocab token, at every position
+logits = logits[:, :-1, :]                  # drop the last position — its prediction has no next token to score
+labels = input_ids[:, 1:]                   # the target at each position is just the actual next token (the shift)
+completion_mask = completion_mask[:, 1:]    # shift the mask the same way so it lines up with labels (1 = completion)
+log_probs = logits.log_softmax(dim=-1)      # normalize logits into log-probabilities over the vocab -> (B, L-1, V)
+token_log_probs = log_probs.gather(-1, labels.unsqueeze(-1)).squeeze(-1)  # read off the log-prob of each TRUE next token -> (B, L-1)
+```
+
+---
+
+## Anatomy of one LM training example
+
+```python
+logits = model(input_ids).logits            # (B, L, V): a score for every vocab token, at every position
+logits = logits[:, :-1, :]                  # drop the last position — its prediction has no next token to score
+labels = input_ids[:, 1:]                   # the target at each position is just the actual next token (the shift)
+completion_mask = completion_mask[:, 1:]    # shift the mask the same way so it lines up with labels (1 = completion)
+log_probs = logits.log_softmax(dim=-1)      # normalize logits into log-probabilities over the vocab -> (B, L-1, V)
+token_log_probs = log_probs.gather(-1, labels.unsqueeze(-1)).squeeze(-1)  # read off the log-prob of each TRUE next token -> (B, L-1)
+seq_log_probs = (token_log_probs * completion_mask).sum(dim=-1)           # zero out prompt/pad, then sum per sequence -> (B,)
 ```
 
 The **one-token shift** is the autoregressive step made literal: position $t$'s logits predict token $t+1$. Sum the per-token log-probs and `loss.backward()` — autodiff turns that sum into the corresponding sum of per-token gradients.
 
 ---
 
-## Three masks — don't confuse them
+## Three masks commonly come up in post-training code
 
-Masking is where silent bugs live. Three different masks do three different jobs:
+Masking is where silent bugs live in LLM code. Three different masks do three different jobs:
 
 - **Causal mask** (built into decoder attention) — position $t$ cannot attend to positions $> t$. This is what makes the model autoregressive; you never touch it in training code.
 - **Attention / padding mask** — tells attention to ignore padding tokens (variable-length sequences batched together). Shape `(B, L)`.
 - **Completion / loss mask** — `1` only on completion tokens; the loss is multiplied by it before summing. **Prompt tokens condition the prediction but contribute no loss.**
 
-> Get the completion mask wrong and you either train on the prompt (wastes gradient on tokens you can't change) or on padding (trains on noise). Lecture 4 lists exactly these as the most common silent failures.
+> Get the completion mask wrong and you either train on the prompt (wastes gradient on tokens you can't change) or on padding (trains on noise).
 
 ---
 
-## Teacher forcing vs generation
+## A small decoding review
 
-How the sequence you score gets into the model determines what kind of training you're doing:
+Generation **samples/searches over** $\pi_\theta$ — same weights, many ways to pick each token:
 
-- **SFT** — score a **supplied** target under *teacher forcing*: the model always sees the correct prefix, one token off from the label.
-- **RL** — **sample** a new sequence from the current policy, then score *that sampled* sequence. The model sees its own prefixes, which may be wrong.
-- **Preference optimization** — score **supplied** chosen and rejected sequences (no sampling).
+- **Greedy** — take $\arg\max_v P_\theta(v \mid x_{<t})$ each step. Deterministic but myopic: a locally best token can doom the sequence.
+- **Beam search** — keep the top-$b$ partial sequences by cumulative log-prob, expand and prune to $b$. Great for low-entropy tasks (translation), bland for open-ended text.
+- **Temperature sampling** — $y_t \sim \mathrm{softmax}(z_t / T)$. Higher $T$ → more diverse, lower $T$ → sharper toward greedy.
+- **Truncated sampling** — sample only from the top-$k$ tokens, or the smallest set with cumulative mass $\ge p$ (top-$p$ / nucleus).
+- **Lookahead search (MCTS & friends)** — score simulated future continuations (often with a value/reward model) before committing — decode-time cousin of inference-time reasoning.
 
-A small decoding review:
-
-$$y_t \sim \mathrm{softmax}(z_t / T)$$
-
-with $T$ a temperature (high $T$ → flatter, more random) and truncation methods (top-$k$, top-$p$) shaping the sample. The key distinction: **the model distribution** ($\pi_\theta$) vs **the sampling procedure** applied to it. Teacher-forced training never encounters the model's own errors; rollout training does — this is the root of *on-policy data*, *distribution shift*, and why RL infrastructure is different.
+Key split: **the distribution** $\pi_\theta$ vs **the procedure** that samples it.
 
 ---
 
 ## Training an LM: cross-entropy
 
-To fit the model we **maximize the likelihood** of the training data — equivalently, minimize the **negative log-likelihood (NLL)**, a.k.a. cross-entropy:
+At each position, cross-entropy compares the model's predicted distribution to the **true** next-token label $q_t$. That label is a *one-hot* at the actual token $x_t$, so the sum over the vocabulary collapses to a single term:
+
+$$H(q_t,\, P_\theta) = -\sum_{v \in \mathcal{V}} q_t(v)\,\log P_\theta(v \mid x_{<t}) = -\log P_\theta(x_t \mid x_{<t}).$$
+
+So the "comparison to the true token" is just the one-hot picking out one log-prob. Summing over positions and averaging over data gives the LM loss — equivalently, the **negative log-likelihood (NLL)**:
 
 $$\mathcal{L}_{\text{LM}}(\theta) = -\,\mathbb{E}_{x \sim \mathcal{D}}\left[\sum_{t=1}^{T} \log P_\theta(x_t \mid x_{<t})\right].$$
-
-Read it simply: for each position, compare the model's predicted next-token distribution to the *true* token; penalize putting low probability on it.
 
 "Predict the next token" **is** supervised learning — the label is just the next token in the sequence.
 
@@ -188,10 +257,10 @@ The basic backprop loop is shared across pretraining, mid-training, and fine-tun
 
 ## Pretraining → mid-training → SFT
 
-The boundary at the *end* of pretraining is fuzzy and worth naming:
+The boundary at the *end* of pretraining is fuzzy and very important to post-training:
 
 - **Pretraining** — next-token cross-entropy on massive raw web/code data; **every** token contributes to the loss.
-- **Mid-training** — the annealing / high-quality-data phase at the very end of pretraining, before any instruction data. Quality ramps up here.
+- **Mid-training** — the annealing / high-quality-data phase at the very end of pretraining, before any instruction data. Quality ramps up here. Could be considered part of post-training, but often isn't discussed.
 - **SFT (supervised fine-tuning)** — still cross-entropy, but now on **instruction–response** pairs with a **completion mask**: only the response tokens contribute to the loss, the prompt merely conditions. The model learns to *respond*, not just continue text.
 
 Modern post-training pipelines start from a **mid-trained** checkpoint, so this is where the course's story effectively begins.
@@ -216,9 +285,39 @@ Three things to remember:
 - **Non-negative**, and $0$ only when $p = q$
 - **The** central object of alignment: the RLHF KL penalty (Lectures 3–4) keeps the policy close to its SFT start, and the DPO loss (Lecture 6) is derived from a **KL-regularized reward-maximization** objective
 
-> **Entropy** $H(p) = -\sum_i p_i \log p_i$ is the uncertainty of a distribution (uniform = high, peaked = low). It shows up here as a regularizer that keeps an RLHF'd policy from collapsing onto a single mode, and in Lecture 8's preference distributions.
+Related: **Entropy** $H(p) = -\sum_i p_i \log p_i$ is the uncertainty of a distribution (uniform = high, peaked = low). It shows up in definitions, derivations, and understanding of these systems. Very similar computation.
 
 You will see KL in essentially every alignment lecture.
+
+---
+
+## KL divergence (and entropy)
+
+Three quantities, one information-theoretic picture (measured in *nats* with $\ln$, *bits* with $\log_2$):
+
+- **Entropy** $H(p) = -\sum_i p_i \log p_i$ — the average surprise of samples from $p$; the irreducible cost to encode them. Uniform = high, peaked = low.
+- **Cross-entropy** $H(p, q) = -\sum_i p_i \log q_i$ — the cost of encoding samples from $p$ using a code built for the *wrong* distribution $q$.
+- **KL divergence** $\mathcal{D}_{\text{KL}}(p \,\|\, q) = \sum_i p_i \log \frac{p_i}{q_i}$ — precisely that *extra* cost of using $q$ instead of $p$.
+
+They are one identity:
+
+$$H(p, q) = H(p) + \mathcal{D}_{\text{KL}}(p \,\|\, q).$$
+
+So minimizing cross-entropy **is** minimizing KL to the truth — $H(p)$ is fixed by the data. In LM training the label $p$ is one-hot, so $H(p)=0$ and **cross-entropy = KL = NLL**. In RLHF the KL term is instead added *on purpose*, to keep the policy near its reference.
+
+---
+
+## KL divergence (and entropy)
+
+Over sequences the sum behind KL is intractable — but KL is an **expectation**, so estimate it by **Monte Carlo**: average the log-ratio over samples drawn from the policy.
+
+$$\mathcal{D}_{\text{KL}}(\pi_\theta \,\|\, \pi_{\text{ref}}) = \mathbb{E}_{x \sim \pi_\theta}\!\left[\log \frac{\pi_\theta(x)}{\pi_{\text{ref}}(x)}\right] \approx \frac{1}{N}\sum_{i=1}^{N} \log \frac{\pi_\theta(x_i)}{\pi_{\text{ref}}(x_i)}.$$
+
+- The integrand is just the **log-probability ratio** on each rollout you already generate.
+- The naive average ($\hat k_1 = \log\frac{\pi_\theta}{\pi_{\text{ref}}}$) is unbiased but high-variance and can go negative on a finite sample.
+- RLHF uses the low-variance, always-$\ge 0$ **$k_3$ estimator** $\hat k_3 = r - 1 - \log r$, with $r = \tfrac{\pi_{\text{ref}}}{\pi_\theta}$ [@schulman2020klapprox].
+
+This is the practical face of the information theory: **approximate a target distribution from samples**, paying for the estimate in variance rather than an intractable sum.
 
 ---
 
@@ -234,7 +333,7 @@ Three things to recognize:
 - only **relative** reward differences matter — shifting both rewards by a constant changes nothing
 - $-\log \sigma(\cdot)$ is just **binary negative log-likelihood**
 
-**Lecture 2 derives this Bradley–Terry model in full** to train a reward model; **Lecture 6 reuses the exact same $\sigma(\Delta r)$ shape** inside DPO. This slide is "recognize the pattern" — the derivations come later.
+**Lecture 2 derives this Bradley–Terry model in full** to train a reward model; **Lecture 6 reuses the exact same $\sigma(\Delta r)$ shape** inside DPO.
 
 ---
 
@@ -246,7 +345,7 @@ Three things to recognize:
 
 ## Language models as an MDP
 
-Reinforcement learning studies an agent acting in a **Markov decision process** $(\mathcal{S}, \mathcal{A}, P, r, \gamma)$: states, actions, a transition function, a reward, and a discount. Generation maps cleanly onto one:
+Reinforcement learning studies an agent acting in a **Markov decision process** $(\mathcal{S}, \mathcal{A}, P, r, \gamma)$:
 
 | MDP concept | Language model |
 |-------------|---------------|
@@ -260,10 +359,6 @@ Reinforcement learning studies an agent acting in a **Markov decision process** 
 The policy is the LM, factorized over tokens:
 
 $$\pi_\theta(y \mid x) = \prod_t \pi_\theta(y_t \mid x, y_{<t}).$$
-
-> **The supervision is usually response-level, but the gradient and KL bookkeeping are token-level.** That single distinction explains a large fraction of the notation the course uses later — far more useful than memorizing the bare five-tuple.
-
-**Lecture 3 develops policy gradients, baselines, and PPO/GRPO from this setup; Lecture 4 turns them into code.** More on the algorithms there.
 
 ---
 
@@ -280,8 +375,6 @@ A human preference (or a verifier) is a single scalar at the *end* of a response
 - **No token-level target** — and ordinary gradients can't pass back through the discrete sampled token
 
 So there is no cross-entropy target for "preferred." Policy gradients optimize the expected evaluator score anyway — first by *learning* that signal as a reward model, then by *optimizing* it. That is the whole motivation for RLHF.
-
-> **Lecture 3 derives the policy-gradient math; Lecture 4 turns it into code.** This deck stops at the framing.
 
 ---
 
@@ -302,18 +395,7 @@ That is what the rest of this course is about.
 
 ---
 
-## You are ready if…
-
-You can do all of the following (or know which one to come back to):
-
-- **Shift and gather** — explain why `logits[:, :-1]` predicts `input_ids[:, 1:]` and what `gather` does
-- **Name the three masks** — causal, attention/padding, completion/loss — and which one the loss multiplies by
-- **Distinguish teacher forcing from rollout** — and say why RL infrastructure is different
-- **Read $\mathcal{D}_{\text{KL}}(p \| q)$** — asymmetric, non-negative, and central to alignment
-- **Read a sigmoid score difference** — $P(y_w \succ y_l) = \sigma(r_w - r_l)$, and know only the *difference* matters
-- **State the LM-as-MDP mapping** — and the response-level-vs-token-level takeaway
-
-If any felt rusty:
+## If any felt rusty:
 
 - **RL** — Sutton & Barto, *Reinforcement Learning: An Introduction*; David Silver's UCL course; UC Berkeley CS285
 - **Language models from scratch** — Sebastian Raschka, *Build a Large Language Model (From Scratch)*

--- a/teach/course/lec0-prereq-review.md
+++ b/teach/course/lec0-prereq-review.md
@@ -1,5 +1,5 @@
 ---
-title: "Prerequisite Review"
+title: "The ML Foundations of LLM Post-Training"
 author: "Nathan Lambert"
 fonts:
   heading: "Rubik"
@@ -8,7 +8,7 @@ bibliography: refs.bib
 figure_captions: true
 footer:
   left: "rlhfbook.com/course"
-  center: "Prerequisite Review"
+  center: "ML Foundations of LLM Post-Training"
   right: "Lambert {n}/{N}"
 custom_css: |
   .slide--section-break { background: #84A98C; }
@@ -24,7 +24,7 @@ custom_css: |
 <!-- layout: title-sidebar -->
 <!-- valign: bottom -->
 
-# Prerequisite Review
+# The ML Foundations of LLM Post-Training
 
 <div class="colloquium-title-eyebrow">rlhfbook.com</div>
 
@@ -32,7 +32,7 @@ custom_css: |
 <p class="colloquium-title-name">Nathan Lambert</p>
 </div>
 
-<p class="colloquium-title-note">A 20–30 minute refresher on language models, optimization, probability, and RL framing — before Lecture 1.</p>
+<p class="colloquium-title-note">From cross-entropy to preferences and reinforcement learning — a 20–30 minute refresher before Lecture 1.</p>
 
 <p class="colloquium-title-note" style="font-size: 0.6em; opacity: 0.7;">This deck was drafted with assistance from GLM 5.2.</p>
 
@@ -282,6 +282,23 @@ A human preference (or a verifier) is a single scalar at the *end* of a response
 So there is no cross-entropy target for "preferred." Policy gradients optimize the expected evaluator score anyway — first by *learning* that signal as a reward model, then by *optimizing* it. That is the whole motivation for RLHF.
 
 > **Lecture 3 derives the policy-gradient math; Lecture 4 turns it into code.** This deck stops at the framing.
+
+---
+
+## These tools become post-training
+
+Everything in this deck is the basic machinery — **probabilities, losses, gradients, and sampling**. Post-training is what you get when you point that machinery at a pretrained model with richer feedback than raw next-token prediction:
+
+- **Demonstrations** ("produce this response") → supervised fine-tuning
+- **Preferences** ("make this response more likely than that one") → reward modeling or preference optimization (DPO)
+- **Rewards** ("sample responses that score highly") → reinforcement learning (PPO, GRPO, RLVR)
+- **Constraints** ("don't drift too far from where you started") → regularization, especially the KL penalty
+
+Different data and different objectives; the same underlying goal:
+
+> **Change the model's distribution over responses toward behavior we want.**
+
+That is what the rest of this course is about.
 
 ---
 

--- a/teach/course/lec0-prereq-review.md
+++ b/teach/course/lec0-prereq-review.md
@@ -1,0 +1,244 @@
+---
+title: "Prerequisite Review"
+author: "Nathan Lambert"
+fonts:
+  heading: "Rubik"
+  body: "Poppins"
+bibliography: refs.bib
+figure_captions: true
+footer:
+  left: "rlhfbook.com/course"
+  center: "Prerequisite Review"
+  right: "Lambert {n}/{N}"
+custom_css: |
+  .slide--section-break { background: #84A98C; }
+  :root {
+    --colloquium-progress-fill: #84A98C;
+  }
+  .slide--title-sidebar h1 {
+    font-size: 2.5em;
+    letter-spacing: 0;
+  }
+---
+
+<!-- layout: title-sidebar -->
+<!-- valign: bottom -->
+
+# Prerequisite Review
+
+<div class="colloquium-title-eyebrow">rlhfbook.com</div>
+
+<div class="colloquium-title-meta">
+<p class="colloquium-title-name">Nathan Lambert</p>
+</div>
+
+<p class="colloquium-title-note">A 20–30 minute refresher on language models, optimization, probability, and RL — before Lecture 1.</p>
+
+---
+
+## What this review covers
+
+This course assumes the basics of language modeling / NLP and an intro ML course. The lectures *use* the following ideas without re-teaching them. This deck rebuilds the four pillars you'll lean on:
+
+- **Language models** — what an LM is, the LM head, softmax, cross-entropy
+- **Optimization** — gradient descent, the training loop, pretraining → mid-training → SFT
+- **Probability** — entropy, KL divergence, the log-derivative trick
+- **Reinforcement learning** — policies, returns, policy gradients, why RL for LMs
+
+You do **not** need prior RL or language-modeling background to start the course — this is a refresher, not a gate.
+
+---
+
+<!-- layout: section-break -->
+
+## Language models
+
+---
+
+<!-- columns: 45/55 -->
+## What a language model is
+
+A language model learns the joint probability of a sequence of **tokens** (words / subwords) in an **autoregressive** manner — each prediction depends on the tokens before it.
+
+Given $x = (x_1, \ldots, x_T)$, the model factorizes the sequence probability:
+
+$$P_\theta(x) = \prod_{t=1}^{T} P_\theta(x_t \mid x_1, \ldots, x_{t-1}).$$
+
+Modern LMs (ChatGPT, Claude, Gemini) are **decoder-only Transformers** built on **self-attention**.
+
+|||
+
+![The original Transformer architecture diagram. 2017.](assets/transformer.webp)
+<!-- cite-right: Vaswani2017AttentionIA -->
+
+---
+
+## The LM head
+
+The transformer backbone outputs a vector per token in an internal **embedding space**. The **LM head** is a final linear projection from that embedding space back to the **vocabulary** (tokenizer space).
+
+- Embedding $\xrightarrow{\text{LM head}}$ **logits** (one score per vocab token)
+- **softmax** over logits $\rightarrow$ a probability distribution over the next token
+- Sampling / argmax from that distribution $\rightarrow$ the generated token
+
+The same backbone can carry **different heads** for different jobs. In this course the first example is a **reward-model head** (Chapter 5) — same transformer, new head, new objective.
+
+---
+
+## Softmax & log-probabilities
+
+**Softmax** turns logits $z$ into a distribution:
+
+$$\mathrm{softmax}(z)_i = \frac{e^{z_i}}{\sum_j e^{z_j}}.$$
+
+In practice we almost always work in **log-space**. The log-probability of a sequence is the sum of per-token log-probs:
+
+$$\log P_\theta(x) = \sum_{t=1}^{T} \log P_\theta(x_t \mid x_{<t}).$$
+
+Why log-probs? **Numerical stability** (products of many small probabilities underflow), and sums are easier to differentiate than products.
+
+---
+
+## Training an LM: cross-entropy
+
+To fit the model we **maximize the likelihood** of the training data — equivalently, minimize the **negative log-likelihood (NLL)**, a.k.a. cross-entropy:
+
+$$\mathcal{L}_{\text{LM}}(\theta) = -\,\mathbb{E}_{x \sim \mathcal{D}}\left[\sum_{t=1}^{T} \log P_\theta(x_t \mid x_{<t})\right].$$
+
+Read it simply: for each position, compare the model's predicted next-token distribution to the *true* token; penalize putting low probability on it.
+
+"Predict the next token" **is** supervised learning — the label is just the next token in the sequence.
+
+---
+
+<!-- layout: section-break -->
+
+## Optimization & fine-tuning
+
+---
+
+## Gradient descent & the training loop
+
+Training repeats one step:
+
+$$\theta \leftarrow \theta - \eta \,\nabla_\theta \mathcal{L}(\theta).$$
+
+- $\theta$ — model parameters, $\eta$ — learning rate, $\nabla_\theta \mathcal{L}$ — gradient of the loss
+- In practice everyone uses **Adam** (adaptive, momentum-based) rather than plain SGD
+- One **step** per batch; sweep the dataset in **epochs**; the learning-rate schedule matters as much as the rate itself
+
+The machinery is identical across pretraining, mid-training, and fine-tuning — what changes is the **data** and the **objective**, not the optimizer.
+
+---
+
+## Pretraining → mid-training → SFT
+
+The boundary at the *end* of pretraining is fuzzy and worth naming:
+
+- **Pretraining** — next-token cross-entropy on massive raw web/code data.
+- **Mid-training** — the annealing / high-quality-data phase at the very end of pretraining: "mid-training like annealing / high-quality end of pretraining web data." Quality ramps up here before any instruction data.
+- **SFT (supervised fine-tuning)** — still cross-entropy, but now on **instruction–response** pairs: the model learns to *respond*, not just continue text.
+
+Modern post-training pipelines start from a **mid-trained** checkpoint, so this is where the course's story effectively begins.
+
+---
+
+<!-- layout: section-break -->
+
+## Probability essentials
+
+---
+
+## Entropy
+
+The **entropy** of a distribution $p$ measures its uncertainty / average surprisal:
+
+$$H(p) = -\sum_i p_i \log p_i.$$
+
+- Uniform distributions have **high** entropy; peaked ones have **low** entropy
+- Entropy shows up in this course when we talk about preference distributions (Lecture 8) and as a regularizer that keeps an RLHF'd policy from collapsing onto a single mode
+
+---
+
+## KL divergence
+
+The **Kullback–Leibler divergence** measures how one distribution differs from another:
+
+$$\mathcal{D}_{\text{KL}}(p \,\|\, q) = \sum_i p_i \log \frac{p_i}{q_i}.$$
+
+Three things to remember:
+
+- **Asymmetric** — $\mathcal{D}_{\text{KL}}(p\|q) \neq \mathcal{D}_{\text{KL}}(q\|p)$; direction matters
+- **Non-negative**, and $0$ only when $p = q$
+- **The** central object of alignment: the RLHF KL penalty (Lectures 3–4) keeps the policy close to its SFT start, and the DPO loss (Lecture 6) is derived from a KL-bound objective
+
+You will see KL in essentially every alignment lecture.
+
+---
+
+## Expectations & the log-derivative trick
+
+Many RL quantities are **expectations** under the model's own distribution, e.g. $\mathbb{E}_{p_\theta}[f]$. We need their *gradients*, but we can't differentiate through a sample.
+
+The **log-derivative trick** (a.k.a. score-function / REINFORCE estimator) sidesteps this:
+
+$$\nabla_\theta \,\mathbb{E}_{p_\theta}[f] = \mathbb{E}_{p_\theta}\!\left[\,f \,\nabla_\theta \log p_\theta\,\right].$$
+
+Intuition: $\nabla_\theta \log p_\theta$ is the *score* — it points in the direction that increases the model's log-probability of a sample. Weight it by how good the sample was, and you get a usable gradient. This is the bridge into policy gradients.
+
+---
+
+<!-- layout: section-break -->
+
+## Reinforcement learning basics
+
+---
+
+## RL framing
+
+Reinforcement learning is about learning to **act** by maximizing accumulated **reward**.
+
+- **Agent** takes **actions** in an **environment**; receives **rewards**
+- **Policy** $\pi(a \mid s)$ — a distribution over actions given state
+- **Return** $G_t$ — discounted future reward from time $t$
+- **Value** $V^\pi(s)$ — expected return from state $s$ under $\pi$
+
+The hard part is **credit assignment**: rewards are sparse and delayed, so which action *caused* the payoff?
+<!-- cite-right: sutton2018reinforcement -->
+
+---
+
+## Policy gradients / REINFORCE
+
+Instead of learning a value function, **directly optimize the policy**. The policy-gradient theorem (REINFORCE) gives a gradient of expected return:
+
+$$\nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim \pi_\theta}\!\left[\, R(\tau)\, \nabla_\theta \log \pi_\theta(\tau)\,\right].$$
+
+Read it with slide 13 in hand: $R(\tau)$ is "how good was this trajectory," $\nabla_\theta \log \pi_\theta(\tau)$ is "nudge the policy to make this trajectory more likely." Together: **make good trajectories more probable**.
+
+This is exactly what Lecture 3 builds on — the course just specializes $\pi$ to a language model and $R$ to a reward model.
+<!-- cite-right: williams1992simple -->
+
+---
+
+## Why RL for language models?
+
+A human preference ("response A is better than B") is:
+
+- **Sparse** — one label per whole response, not per token
+- **Non-differentiable** — there's no cross-entropy target for "preferred"
+- **Delayed** — the quality of a token depends on the whole completion
+
+So we can't write human feedback as a loss and backprop. RL lets us **optimize a reward signal we can't differentiate through** — first by *learning* that signal as a reward model, then by *optimizing* it with policy gradients. That is the whole motivation for RLHF.
+
+---
+
+## Where to go deeper
+
+You're now ready for **Lecture 1**. If any pillar felt rusty:
+
+- **RL** — Sutton & Barto, *Reinforcement Learning: An Introduction*; David Silver's UCL course; UC Berkeley CS285
+- **Language models from scratch** — Sebastian Raschka, *Build a Large Language Model (From Scratch)*
+- **The book's own reference** — Appendix A (Definitions) covers the language-modeling overview, KL, and RL vocabulary used throughout
+
+Go down rabbit holes, skip around, and chase what excites you — the course is built for that.

--- a/teach/course/refs.bib
+++ b/teach/course/refs.bib
@@ -1668,3 +1668,11 @@ url={https://openreview.net/forum?id=xJbsmB8UMx}
   year={2009},
   organization={Cognitive Science Society}
 }
+
+@misc{schulman2020klapprox,
+  title        = {Approximating {KL} Divergence},
+  author       = {Schulman, John},
+  year         = {2020},
+  howpublished = {\url{http://joschu.net/blog/kl-approx.html}},
+  note         = {Blog post}
+}


### PR DESCRIPTION
## Summary

Adds a standalone **20-slide prerequisite-review deck** (Lecture 0) that gets students from "I've done intro ML" to "I can follow Lecture 3." The course assumes language-modeling/NLP and intro ML background, but later lectures (3, 6, 8) lean hard on softmax / cross-entropy / entropy / KL / policy gradients without re-teaching them. This deck rebuilds those four pillars.

Authored as `lec0` so it builds with the existing `course-lecture-%` Makefile wildcard, and surfaced on the course page under **Extra Resources** (no recording yet).

## Changes

- **`teach/course/lec0-prereq-review.md`** — new ~20-slide colloquium deck (title + 4 section-breaks: Language models → Optimization & fine-tuning → Probability essentials → RL basics → where to go deeper). Math via KaTeX, notation mirrors `book/chapters/appendix-a-definitions.md` so students see the same symbols in the text. Reuses `assets/transformer.webp`; cites `Vaswani2017AttentionIA`, `sutton2018reinforcement`, `williams1992simple`.
- **`book/templates/course.html`** — new "Prerequisite Review" entry at the top of `#extra-resources`, reusing the existing `.course-entry` / `.talk-actions` / `.btn` pattern with PDF / Slides / Source buttons (no Watch button — no recording yet).
- **`teach/.gitignore`** — ignore `colloquium capture` output (`slides/`) alongside the existing `*.html` build-artifact ignore.

## Verification

- `make course-lecture-lec0-prereq-review` → builds `build/html/teach/course/lec0-prereq-review/{index.html,slides.pdf}` + copied assets (Makefile renames output to `index.html` so the directory URL works; no Makefile change needed — picked up by the `teach/course/*.md` wildcard).
- Live preview served from `teach/course/` (per `serve-course-lecture` skill) — page and `assets/transformer.webp` both return 200; math/columns/section-breaks render correctly.
- Course-page block matches the existing `lec1` entry pattern exactly (same icon IDs, same link shapes).

Draft for now — happy to flip to ready after a pass on wording/coverage.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)