### PR TITLE
Q&A 2 (draft) + Lecture 7 KD-as-RL-advantage correction

### DIFF
--- a/teach/course/lec7-chap12-synthetic-data.md
+++ b/teach/course/lec7-chap12-synthetic-data.md
@@ -532,9 +532,9 @@ Recent implementations take the KD distance directly as a reward: substitute the
 
 $$ D_{\mathrm{KL}}\!\left(\pi_\theta(\cdot \mid s_t) \,\|\, \pi_T(\cdot \mid s_t)\right) = \mathbb{E}_{a_t \sim \pi_\theta(\cdot \mid s_t)}\!\left[\log \pi_\theta(a_t \mid s_t) - \log \pi_T(a_t \mid s_t)\right]. $$
 
-For a single sampled token $a_t$, the advantage is the negative of that integrand (the expectation is supplied by on-policy sampling):
+In practice you never sum over the vocabulary: the single sampled token is an unbiased estimate $\hat{D}_{\mathrm{KL}}$ of that KL [@schulman2020klapprox], and the per-token advantage is its negative:
 
-$$ A_t^{\mathrm{OPD}} = -\left(\log \pi_\theta(a_t \mid s_t) - \log \pi_T(a_t \mid s_t)\right) = \log \pi_T(a_t \mid s_t) - \log \pi_\theta(a_t \mid s_t). $$
+$$ A_t^{\mathrm{OPD}} = -\hat{D}_{\mathrm{KL}} = -\left(\log \pi_\theta(a_t \mid s_t) - \log \pi_T(a_t \mid s_t)\right) = \log \pi_T(a_t \mid s_t) - \log \pi_\theta(a_t \mid s_t). $$
 
 <!-- step -->
 

--- a/teach/course/lec7-chap12-synthetic-data.md
+++ b/teach/course/lec7-chap12-synthetic-data.md
@@ -528,15 +528,18 @@ $$ D_{\mathrm{KL}}(\pi_\theta \,\|\, \pi_T) = \mathbb{E}_{z \sim \pi_\theta}\!\l
 <!-- valign: top -->
 ## KD as an RL advantage
 
-Recent implementations take the KD distance directly as a reward: substitute the negative per-token reverse-KL contribution as the advantage [@lu2025onpolicy]. For a sampled token $a_t$ at state $s_t$:
+Recent implementations take the KD distance directly as a reward: substitute the negative per-token reverse-KL contribution as the advantage [@lu2025onpolicy]. The reverse KL at state $s_t$ is an expectation over *student*-sampled tokens:
 
-$$ A_t^{\mathrm{OPD}} = -D_{\mathrm{KL}}\!\left(\pi_\theta(\cdot \mid s_t) \,\|\, \pi_T(\cdot \mid s_t)\right) = - (\log \pi_\theta(a_t \mid s_t) - \log \pi_T(a_t \mid s_t)).$$
+$$ D_{\mathrm{KL}}\!\left(\pi_\theta(\cdot \mid s_t) \,\|\, \pi_T(\cdot \mid s_t)\right) = \mathbb{E}_{a_t \sim \pi_\theta(\cdot \mid s_t)}\!\left[\log \pi_\theta(a_t \mid s_t) - \log \pi_T(a_t \mid s_t)\right]. $$
 
-$$ A_t^{\mathrm{OPD}} = \log \pi_T(a_t \mid s_t) - \log \pi_\theta(a_t \mid s_t). $$
+For a single sampled token $a_t$, the advantage is the negative of that integrand (the expectation is supplied by on-policy sampling):
+
+$$ A_t^{\mathrm{OPD}} = -\left(\log \pi_\theta(a_t \mid s_t) - \log \pi_T(a_t \mid s_t)\right) = \log \pi_T(a_t \mid s_t) - \log \pi_\theta(a_t \mid s_t). $$
 
 <!-- step -->
 
 - Tokens more likely for the teacher → positive advantage; less likely → negative.
+- Same form, opposite KL: $\log \pi_T - \log \pi_\theta$ *looks* like a forward-KL term -- what makes it **reverse** KL is sampling $a_t \sim \pi_\theta$ (the student), not the sign.
 - The teacher log-prob gap is dense, token-level feedback -- potentially richer than a sparse verifiable reward or a single scalar reward-model score.
 - This layers into modern RL machinery -- e.g. add it alongside GRPO's group-level normalization for more complex reward shaping.
 

--- a/teach/course/lec7-chap12-synthetic-data.md
+++ b/teach/course/lec7-chap12-synthetic-data.md
@@ -536,8 +536,14 @@ In practice you never sum over the vocabulary: the single sampled token is an un
 
 $$ A_t^{\mathrm{OPD}} = -\hat{D}_{\mathrm{KL}} = -\left(\log \pi_\theta(a_t \mid s_t) - \log \pi_T(a_t \mid s_t)\right) = \log \pi_T(a_t \mid s_t) - \log \pi_\theta(a_t \mid s_t). $$
 
-<!-- step -->
+---
 
+## KD as an RL advantage
+In practice you never sum over the vocabulary: the single sampled token is an unbiased estimate $\hat{D}_{\mathrm{KL}}$ of that KL [@schulman2020klapprox], and the per-token advantage is its negative:
+
+$$ A_t^{\mathrm{OPD}} = \log \pi_T(a_t \mid s_t) - \log \pi_\theta(a_t \mid s_t). $$
+
+<!-- step -->
 - Tokens more likely for the teacher → positive advantage; less likely → negative.
 - Same form, opposite KL: $\log \pi_T - \log \pi_\theta$ *looks* like a forward-KL term -- what makes it **reverse** KL is sampling $a_t \sim \pi_\theta$ (the student), not the sign.
 - The teacher log-prob gap is dense, token-level feedback -- potentially richer than a sparse verifiable reward or a single scalar reward-model score.

--- a/teach/course/qa-02.md
+++ b/teach/course/qa-02.md
@@ -1,0 +1,166 @@
+---
+title: "Q&A 2: Reader questions"
+author: "Nathan Lambert"
+fonts:
+  heading: "Rubik"
+  body: "Poppins"
+bibliography: refs.bib
+figure_captions: true
+footer:
+  left: "rlhfbook.com/course"
+  center: "Q&A 2"
+  right: "Lambert {n}/{N}"
+custom_css: |
+  .slide--section-break { background: #F28482; }
+  :root {
+    --colloquium-progress-fill: #F28482;
+  }
+---
+
+<!-- DRAFT: question slides for Lectures 5-7 are placeholders to fill from the issue
+     tracker, Discord, and YouTube comments. The Corrections section is final. -->
+
+<!-- layout: title-banner -->
+
+# Q&A 2: RLHF course student questions
+
+<div class="colloquium-title-eyebrow">rlhfbook.com/course</div>
+<div class="colloquium-title-rule"></div>
+
+<div class="colloquium-title-meta">
+<p class="colloquium-title-name">Nathan Lambert</p>
+<p>2026 — draft</p>
+</div>
+
+<p class="colloquium-title-note">Corrections and reader questions from the issue tracker, Discord, and YouTube comments.</p>
+
+---
+
+<!-- layout: section-break -->
+<!-- title: center -->
+
+## Corrections
+
+---
+
+## Correction: the KD-as-RL-advantage slide (Lecture 7)
+
+---
+
+## Correction: the KD-as-RL-advantage slide (Lecture 7)
+
+What I showed conflated the *full* reverse KL with a *single-token* term:
+
+$$ A_t^{\mathrm{OPD}} = -D_{\mathrm{KL}}\!\left(\pi_\theta(\cdot \mid s_t) \,\|\, \pi_T(\cdot \mid s_t)\right) = -\left(\log \pi_\theta(a_t \mid s_t) - \log \pi_T(a_t \mid s_t)\right) $$
+
+The left side is a sum over the whole vocabulary; the right is one sampled token. They are equal only **in expectation**.
+
+<!-- footnote-right: Source: correction to [Lecture 7](https://www.youtube.com/watch?v=6nyJ8y8ghsE&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=10) -->
+
+---
+
+## Correction: the KD-as-RL-advantage slide (Lecture 7)
+
+The reverse KL at state $s_t$ is an expectation over *student*-sampled tokens:
+
+$$ D_{\mathrm{KL}}\!\left(\pi_\theta(\cdot \mid s_t) \,\|\, \pi_T(\cdot \mid s_t)\right) = \mathbb{E}_{a_t \sim \pi_\theta(\cdot \mid s_t)}\!\left[\log \pi_\theta(a_t \mid s_t) - \log \pi_T(a_t \mid s_t)\right] $$
+
+The per-token advantage is the negative integrand (on-policy sampling supplies the expectation):
+
+$$ A_t^{\mathrm{OPD}} = -\left(\log \pi_\theta(a_t \mid s_t) - \log \pi_T(a_t \mid s_t)\right) = \log \pi_T(a_t \mid s_t) - \log \pi_\theta(a_t \mid s_t) $$
+
+- Same form, opposite KL: $\log \pi_T - \log \pi_\theta$ *looks* like a forward-KL term -- it's **reverse** KL because we sample $a_t \sim \pi_\theta$ (the student), not because of the sign.
+
+<!-- footnote-right: Source: correction to [Lecture 7](https://www.youtube.com/watch?v=6nyJ8y8ghsE&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=10) -->
+
+---
+
+<!-- layout: section-break -->
+<!-- title: center -->
+
+## Reasoning & inference-time scaling
+
+<!-- DRAFT placeholders below — fill from Lecture 5 comments/issues -->
+
+---
+
+## [DRAFT] Reasoning question
+
+<!-- TODO: pull a real Lecture 5 reader question + source link -->
+
+---
+
+<!-- layout: section-break -->
+<!-- title: center -->
+
+## Direct alignment algorithms
+
+<!-- DRAFT placeholders below — fill from Lecture 6 comments/issues -->
+
+---
+
+## [DRAFT] Direct alignment question
+
+<!-- TODO: pull a real Lecture 6 reader question + source link -->
+
+---
+
+<!-- layout: section-break -->
+<!-- title: center -->
+
+## Synthetic data & distillation
+
+<!-- DRAFT placeholders below — fill from Lecture 7 comments/issues -->
+
+---
+
+## [DRAFT] Synthetic data question
+
+<!-- TODO: pull a real Lecture 7 reader question + source link -->
+
+---
+
+<!-- columns: 50/50 -->
+## What comes next?
+
+```box
+title: Catch up
+tone: accent
+compact: true
+content: |
+  - [Course page](https://rlhfbook.com/course)
+  - [Q&A 1](https://rlhfbook.com/course)
+  - [Lecture 5: Reasoning & inference-time scaling](https://www.youtube.com/watch?v=x-MqKBzoxkI&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=6)
+  - [Lecture 6: Direct alignment algorithms](https://www.youtube.com/watch?v=o4AB5xHIDdM&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=7)
+  - [Lecture 7: Synthetic data & modern post-training](https://www.youtube.com/watch?v=6nyJ8y8ghsE&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=10)
+```
+
+|||
+
+```box
+title: Upcoming lectures
+tone: surface
+compact: true
+content: |
+  - **Lecture 8:** Preferences & preference data
+  - **Later:** Tools, over-optimization, evaluation, product, and style
+```
+
+---
+
+<!-- rows: 85/15 -->
+## Thanks for watching
+
+Questions, comments, and future Q&A prompts:
+
+- Course: [rlhfbook.com/course](https://rlhfbook.com/course)
+- Discord: [discord.gg/yz5AwK4gBR](https://discord.gg/yz5AwK4gBR)
+- GitHub: [github.com/natolambert/rlhf-book](https://github.com/natolambert/rlhf-book)
+- Newsletter: [interconnects.ai](https://www.interconnects.ai/)
+- Contact: nathan@natolambert.com
+
+===
+
+```builtwith
+repo: natolambert/colloquium
+```

--- a/teach/course/qa-02.md
+++ b/teach/course/qa-02.md
@@ -49,13 +49,13 @@ custom_css: |
 
 ## Correction: the KD-as-RL-advantage slide (Lecture 7)
 
-What I showed conflated the *full* reverse KL with a *single-token* term:
+A sharp-eyed viewer flagged the "KD as an RL advantage" slide:
 
-$$ A_t^{\mathrm{OPD}} = -D_{\mathrm{KL}}\!\left(\pi_\theta(\cdot \mid s_t) \,\|\, \pi_T(\cdot \mid s_t)\right) = -\left(\log \pi_\theta(a_t \mid s_t) - \log \pi_T(a_t \mid s_t)\right) $$
+> The slide is missing a $\pi_\theta(a_t \mid s_t)$ multiplier for $A_t^{\mathrm{OPD}}$ (since it's for a single token, else it would be the expectation). Also, the negative reverse-KL on the top line looks like the forward-KL on the second line, which can be confusing.
 
-The left side is a sum over the whole vocabulary; the right is one sampled token. They are equal only **in expectation**.
+Both points are right. The *idea* was fine -- the notation was loose.
 
-<!-- footnote-right: Source: correction to [Lecture 7](https://www.youtube.com/watch?v=6nyJ8y8ghsE&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=10) -->
+<!-- footnote-right: Source: viewer feedback on [Lecture 7](https://www.youtube.com/watch?v=6nyJ8y8ghsE&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=10) -->
 
 ---
 
@@ -65,13 +65,17 @@ The reverse KL at state $s_t$ is an expectation over *student*-sampled tokens:
 
 $$ D_{\mathrm{KL}}\!\left(\pi_\theta(\cdot \mid s_t) \,\|\, \pi_T(\cdot \mid s_t)\right) = \mathbb{E}_{a_t \sim \pi_\theta(\cdot \mid s_t)}\!\left[\log \pi_\theta(a_t \mid s_t) - \log \pi_T(a_t \mid s_t)\right] $$
 
-The per-token advantage is the negative integrand (on-policy sampling supplies the expectation):
+You never sum over the vocabulary: the single sampled token is an **unbiased estimate** $\hat{D}_{\mathrm{KL}}$ of that KL, and the advantage is its negative:
 
-$$ A_t^{\mathrm{OPD}} = -\left(\log \pi_\theta(a_t \mid s_t) - \log \pi_T(a_t \mid s_t)\right) = \log \pi_T(a_t \mid s_t) - \log \pi_\theta(a_t \mid s_t) $$
+$$ A_t^{\mathrm{OPD}} = -\hat{D}_{\mathrm{KL}} = -\left(\log \pi_\theta(a_t \mid s_t) - \log \pi_T(a_t \mid s_t)\right) = \log \pi_T(a_t \mid s_t) - \log \pi_\theta(a_t \mid s_t) $$
 
-- Same form, opposite KL: $\log \pi_T - \log \pi_\theta$ *looks* like a forward-KL term -- it's **reverse** KL because we sample $a_t \sim \pi_\theta$ (the student), not because of the sign.
+- The old slide wrote a hard "$=$" to the full $D_{\mathrm{KL}}$; it's an *estimate*, equal only in expectation.
+- Same form, opposite KL: $\log \pi_T - \log \pi_\theta$ *looks* like forward KL -- it's **reverse** because we sample $a_t \sim \pi_\theta$ (the student).
+- Fixed slide + details: [Lecture 7 deck](https://rlhfbook.com/teach/course/lec7-chap12-synthetic-data/) · [PR #459](https://github.com/natolambert/rlhf-book/pull/459).
 
-<!-- footnote-right: Source: correction to [Lecture 7](https://www.youtube.com/watch?v=6nyJ8y8ghsE&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=10) -->
+<!-- footnote-right: Sources: [@lu2025onpolicy], [@schulman2020klapprox] -->
+
+
 
 ---
 

--- a/teach/course/qa-02.md
+++ b/teach/course/qa-02.md
@@ -62,7 +62,7 @@ $$ A_t^{\mathrm{OPD}} = \log \pi_T(a_t \mid s_t) - \log \pi_\theta(a_t \mid s_t)
 
 Both points are right: the *idea* was fine, but the hard "$=$" to the full $D_{\mathrm{KL}}$ is loose.
 
-<!-- footnote-right: Source: viewer feedback on [Lecture 7](https://www.youtube.com/watch?v=6nyJ8y8ghsE&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=10) -->
+<!-- footnote-right: Source: viewer feedback on [Lecture 7](https://www.youtube.com/watch?v=6nyJ8y8ghsE&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=11) -->
 
 ---
 
@@ -141,9 +141,9 @@ compact: true
 content: |
   - [Course page](https://rlhfbook.com/course)
   - [Q&A 1](https://rlhfbook.com/course)
-  - [Lecture 5: Reasoning & inference-time scaling](https://www.youtube.com/watch?v=x-MqKBzoxkI&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=6)
-  - [Lecture 6: Direct alignment algorithms](https://www.youtube.com/watch?v=o4AB5xHIDdM&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=7)
-  - [Lecture 7: Synthetic data & modern post-training](https://www.youtube.com/watch?v=6nyJ8y8ghsE&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=10)
+  - [Lecture 5: Reasoning & inference-time scaling](https://www.youtube.com/watch?v=o4AB5xHIDdM&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=8)
+  - [Lecture 6: Direct alignment algorithms](https://www.youtube.com/watch?v=6g6b4gvO-y0&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=9)
+  - [Lecture 7: Synthetic data & modern post-training](https://www.youtube.com/watch?v=6nyJ8y8ghsE&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=11)
 ```
 
 |||

--- a/teach/course/qa-02.md
+++ b/teach/course/qa-02.md
@@ -53,7 +53,14 @@ A sharp-eyed viewer flagged the "KD as an RL advantage" slide:
 
 > The slide is missing a $\pi_\theta(a_t \mid s_t)$ multiplier for $A_t^{\mathrm{OPD}}$ (since it's for a single token, else it would be the expectation). Also, the negative reverse-KL on the top line looks like the forward-KL on the second line, which can be confusing.
 
-Both points are right. The *idea* was fine -- the notation was loose.
+<!-- step -->
+
+What the slide showed:
+
+$$ A_t^{\mathrm{OPD}} = -D_{\mathrm{KL}}\!\left(\pi_\theta(\cdot \mid s_t) \,\|\, \pi_T(\cdot \mid s_t)\right) = -\left(\log \pi_\theta(a_t \mid s_t) - \log \pi_T(a_t \mid s_t)\right) $$
+$$ A_t^{\mathrm{OPD}} = \log \pi_T(a_t \mid s_t) - \log \pi_\theta(a_t \mid s_t) $$
+
+Both points are right: the *idea* was fine, but the hard "$=$" to the full $D_{\mathrm{KL}}$ is loose.
 
 <!-- footnote-right: Source: viewer feedback on [Lecture 7](https://www.youtube.com/watch?v=6nyJ8y8ghsE&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=10) -->
 


### PR DESCRIPTION
## Summary
Draft Q&A 2 deck plus a notation fix to the Lecture 7 "KD as an RL advantage" slide.

## The fix
The slide wrote a hard equality `A_t = -D_KL(π_θ‖π_T) = -(log π_θ − log π_T)`. The *idea* was right — the single sampled-token log-ratio is an **unbiased single-sample estimate** of the reverse KL (Schulman's k1 estimator), which is exactly what the [Thinking Machines OPD implementation](https://thinkingmachines.ai/blog/on-policy-distillation/) (`@lu2025onpolicy`) actually computes (it never sums over the vocabulary). But:
1. It's an estimate `D̂_KL`, equal to the full KL only **in expectation** — the slide's `=` should reflect that.
2. The second line `log π_T − log π_θ` has the same form as a *forward*-KL integrand; it's reverse only because `a_t ~ π_θ`.

Both decks now show the reverse KL as an expectation over student-sampled tokens, then the per-token advantage as `-D̂_KL` (single-sample estimate). Cites `@schulman2020klapprox`.

## Changes
- **`lec7-chap12-synthetic-data.md`**: estimator framing + Schulman citation + the forward/reverse clarification bullet.
- **`qa-02.md`** (new draft Q&A 2 deck, modeled on `qa-01.md`): leads with this correction, quotes the original viewer feedback verbatim, and links the fixed Lecture 7 slide + this PR. Reader-question sections for Lectures 5-7 are clearly-marked `[DRAFT]` placeholders.

The book chapter 12 (`eq:opd_kl_advantage`) was already correct — it never wrote the false equality — so it is **not** touched here.

Builds clean: 0 KaTeX errors, 0 unresolved citations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)