### PR TITLE
Add Discord community card to homepage Ecosystem section

### DIFF
--- a/book/templates/html.html
+++ b/book/templates/html.html
@@ -199,6 +199,16 @@ $endif$
       View
     </a>
   </div>
+  <div style="display: flex; align-items: center; justify-content: space-between; gap: 1em; flex-wrap: wrap; margin: 0.8em 20px 0; padding: 0.8em 1.2em; border: 1px solid var(--color-border); border-radius: 0.35em; background: var(--color-bg-section); box-shadow: 0 4px 12px var(--color-shadow);">
+    <div>
+      <h3 style="margin: 0 0 0.15em 0; font-size: 1.05em;">Join the Community</h3>
+      <p style="font-size: 0.88em; color: var(--color-text-muted); margin: 0;">Discuss the book on Discord</p>
+    </div>
+    <a href="https://discord.gg/yz5AwK4gBR" target="_blank" rel="noopener noreferrer" style="display: inline-flex; align-items: center; gap: 0.4em; font-size: 0.85em; padding: 0.35em 0.7em; border-radius: 0.3em; border: 1px solid #5865F2; background: rgba(88,101,242,0.1); color: #5865F2; text-decoration: none; white-space: nowrap;">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.317 4.369a19.79 19.79 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.211.375-.444.864-.608 1.249a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.036A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128c.126-.094.252-.192.371-.291a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.009c.12.099.245.198.372.292a.077.077 0 0 1-.006.127 12.3 12.3 0 0 1-1.873.891.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.84 19.84 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.331c-1.183 0-2.157-1.086-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.211 0 2.176 1.096 2.157 2.42 0 1.332-.955 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.086-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.211 0 2.176 1.096 2.157 2.42 0 1.332-.946 2.418-2.157 2.418z"/></svg>
+      Join
+    </a>
+  </div>
   <section id="acknowledgements" style="padding: 0 20px; margin-top: 2em;">
     <h3>Acknowledgements</h3>
     <p>I would like to thank the following people who helped me directly with this project: Costa Huang, Ross Taylor, Hamish Ivison, John Schulman, Valentina Pyatkin, Daniel Han, Shane Gu, Joanne Jang, LJ Miranda, Sharan Maiya, Andrew Carr, Cameron R. Wolfe, and others in my RL sphere (and of course Claude).</p>


### PR DESCRIPTION
Adds a "Join the Community" card to the Ecosystem section on the homepage, linking to the existing Discord invite (`https://discord.gg/yz5AwK4gBR`).

- Matches the existing Ecosystem card styling
- Inline transparent Discord logo (`fill="currentColor"`) tinted with the Discord brand purple (`#5865F2`), mirroring the red "Watch" button treatment
- "Join" button label, subtitle "Discuss the book on Discord"

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Added an additional discord link since people still seem unaware of the server 

<img width="770" height="492" alt="Screenshot 2026-06-26 at 15 06 13" src="https://github.com/user-attachments/assets/d4437b5c-78cd-44e2-9df1-2777e3ed9ec2" />

