### PR TITLE
Fix Chapter 6 policy-gradient notation errata

### DIFF
--- a/book/chapters/06-policy-gradients.md
+++ b/book/chapters/06-policy-gradients.md
@@ -119,7 +119,7 @@ The core implementation detail is how to compute said gradient.
 
 ### Deriving the Policy Gradient
 
-Let $p_\theta(\tau)$ denote the trajectory distribution induced by the initial-state distribution $d_0$, the policy $\pi_\theta$, and the environment transition dynamics.
+Let $p_\theta(\tau)$ denote the trajectory distribution induced by the initial-state distribution $d_0$, the policy $\pi_\theta$, and the environment transition dynamics, as expanded in @eq:trajectory_probability below.
 Another way to pose the RL objective we want to maximize is as follows:
 $$
 J(\theta) = \mathbb{E}_{\tau \sim p_\theta} \left[ R(\tau) \right],

--- a/book/chapters/06-policy-gradients.md
+++ b/book/chapters/06-policy-gradients.md
@@ -94,7 +94,9 @@ $$ {#eq:policy_objective}
 
 In a finite MDP this is a sum over possible starting states, but in practice we never compute it exactly.
 Instead, we estimate it from data by sampling rollouts from the current policy.
-In RLHF this typically means sampling prompts $x_i$ from a dataset and generating completions $y_i \sim \pi_\theta(\cdot\mid x_i)$, then taking an empirical average such as:
+In RLHF this typically means sampling prompts $x_i$ from a dataset and generating completions $y_i \sim \pi_\theta(\cdot\mid x_i)$.
+Let $R(x_i, y_i)$ denote the scalar sequence-level reward assigned to that prompt-completion pair; if $\tau_i$ is the corresponding episode, this is the trajectory reward $R(\tau_i)$.
+We then take an empirical average such as:
 
 $$
 \hat{J}(\theta) = \frac{1}{B}\sum_{i=1}^{B} R(x_i, y_i),

--- a/book/chapters/06-policy-gradients.md
+++ b/book/chapters/06-policy-gradients.md
@@ -72,12 +72,12 @@ The rest of this chapter goes very deep on the different ways to do this, and wh
 
 Now, let us formalize this a bit further.
 Reinforcement learning algorithms are designed to maximize the future, discounted reward across a trajectory of states, $s \in \mathcal{S}$, and actions, $a \in \mathcal{A}$ (for more notation, see Appendix A, Definitions).
-The objective of the agent, often called the *return*, is the sum of discounted future rewards (where $\gamma\in [0,1]$ is a factor that prioritizes near-term rewards) at a given time $t$:
+The objective of the agent, often called the *return*, is the sum of discounted rewards starting at a given time $t$ (where $\gamma\in [0,1]$ is a factor that prioritizes near-term rewards):
 
-$$G_t = R_{t+1} + \gamma R_{t+2} + \cdots = \sum_{k=0}^\infty \gamma^k R_{t+k+1}.$$ {#eq:return_definition}
+$$G_t = r_t + \gamma r_{t+1} + \cdots = \sum_{k=0}^\infty \gamma^k r_{t+k}.$$ {#eq:return_definition}
 
-The return definition can also be estimated as:
-$$G_{t} = \gamma{G_{t+1}} + R_{t+1}.$$ {#eq:recursive_return}
+The return definition can also be written recursively as:
+$$G_{t} = r_t + \gamma G_{t+1}.$$ {#eq:recursive_return}
 
 This return is the basis for learning a value function $V(s)$ that is the estimated future return given a current state:
 
@@ -85,14 +85,14 @@ $$V(s) = \mathbb{E}\left[G_t \mid S_t = s \right].$$ {#eq:value_function}
 
 All policy gradient algorithms optimize a policy $\pi_\theta(a\mid s)$ to maximize expected return; this objective can be expressed using the induced value function $V^{\pi_\theta}(s)$.
 
-Where $d^{\pi_\theta}(s)$ is the state-visitation distribution induced by policy $\pi_\theta(a \mid s)$, the objective we maximize can be written as:
+Let $d_0(s)$ be the initial-state distribution. The episodic objective we maximize can be written as:
 $$
 J(\theta)
 \;=\;
-\sum_{s} d^{\pi_\theta}(s) V^{\pi_\theta}(s),
+\sum_{s} d_0(s) V^{\pi_\theta}(s),
 $$ {#eq:policy_objective}
 
-In a finite MDP this is a sum over all states, but in practice we never compute it exactly.
+In a finite MDP this is a sum over possible starting states, but in practice we never compute it exactly.
 Instead, we estimate it from data by sampling rollouts from the current policy.
 In RLHF this typically means sampling prompts $x_i$ from a dataset and generating completions $y_i \sim \pi_\theta(\cdot\mid x_i)$, then taking an empirical average such as:
 
@@ -117,9 +117,10 @@ The core implementation detail is how to compute said gradient.
 
 ### Deriving the Policy Gradient
 
+Let $p_\theta(\tau)$ denote the trajectory distribution induced by the initial-state distribution $d_0$, the policy $\pi_\theta$, and the environment transition dynamics.
 Another way to pose the RL objective we want to maximize is as follows:
 $$
-J(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ R(\tau) \right],
+J(\theta) = \mathbb{E}_{\tau \sim p_\theta} \left[ R(\tau) \right],
 $$ {#eq:policy_objective_expectation}
 
 where $\tau = (s_0, a_0, s_1, a_1, \ldots)$ is a trajectory and $R(\tau) = \sum_{t=0}^\infty r_t$ is the total reward of the trajectory. Alternatively, we can write the expectation as an integral over all possible trajectories:
@@ -127,9 +128,9 @@ $$
 J(\theta) = \int_\tau p_\theta (\tau) R(\tau) d\tau
 $$ {#eq:policy_objective_integral}
 
-Notice that we can express the trajectory probability as follows, where $\pi_\theta(a_t|s_t) p(s_{t+1}|s_t, a_t)$ is the transition probability to a group of next states from one state and action:
+Notice that we can express the trajectory probability as follows, where $\pi_\theta(a_t|s_t) p(s_{t+1}|s_t, a_t)$ combines the policy probability with the environment transition probability from one state-action pair to the next state:
 $$
-p_\theta (\tau) = p(s_0) \prod_{t=0}^\infty \pi_\theta(a_t|s_t) p(s_{t+1}|s_t, a_t),
+p_\theta (\tau) = d_0(s_0) \prod_{t=0}^\infty \pi_\theta(a_t|s_t) p(s_{t+1}|s_t, a_t),
 $$ {#eq:trajectory_probability}
 
 If we take the gradient of the objective (@eq:policy_objective_expectation) with respect to the policy parameters $\theta$: 
@@ -149,23 +150,23 @@ Using this log-derivative trick:
 $$
 \begin{aligned}
 \nabla_\theta J(\theta) &= \int_\tau \nabla_\theta p_\theta (\tau) R(\tau) d\tau \\
-&= \int_\tau p_\theta (\tau) \nabla_\theta \log p_\theta (\tau) R(\tau) d\tau \\
-&= \mathbb{E}_{\tau \sim \pi_\theta} \left[ \nabla_\theta \log p_\theta (\tau) R(\tau) \right]
+&= \int_\tau p_\theta (\tau) R(\tau) \nabla_\theta \log p_\theta (\tau) d\tau \\
+&= \mathbb{E}_{\tau \sim p_\theta} \left[ R(\tau) \nabla_\theta \log p_\theta (\tau) \right]
 \end{aligned}
 $$ {#eq:policy_gradient_expectation}
 
 Where the final step uses the definition of an expectation under the trajectory distribution $p_\theta(\tau)$: for any function $f$, $\mathbb{E}_{\tau \sim p_\theta}[f(\tau)] = \int_\tau f(\tau)\,p_\theta(\tau)\,d\tau$ (or a sum in the discrete case). 
-Writing it as an expectation is useful because we can approximate it with Monte Carlo rollouts, e.g., $\frac{1}{B}\sum_{i=1}^{B} f(\tau_i)$ for trajectories $\tau_i \sim \pi_\theta$.
+Writing it as an expectation is useful because we can approximate it with Monte Carlo rollouts, e.g., $\frac{1}{B}\sum_{i=1}^{B} f(\tau_i)$ for trajectories $\tau_i \sim p_\theta$ induced by the current policy.
 
 Back to the derivation, expanding the log probability of the trajectory:
 
 $$
-\log p_\theta (\tau) = \log p(s_0) + \sum_{t=0}^\infty \log \pi_\theta(a_t|s_t) + \sum_{t=0}^\infty \log p(s_{t+1}|s_t, a_t)
+\log p_\theta (\tau) = \log d_0(s_0) + \sum_{t=0}^\infty \log \pi_\theta(a_t|s_t) + \sum_{t=0}^\infty \log p(s_{t+1}|s_t, a_t)
 $$ {#eq:trajectory_log_prob}
 
 Now, if we take the gradient of the above, we get:  
 
-- $\nabla_\theta \log p(s_0) = 0$ (initial state doesn't depend on $\theta$)
+- $\nabla_\theta \log d_0(s_0) = 0$ (initial state distribution doesn't depend on $\theta$)
 - $\nabla_\theta \log p(s_{t+1}|s_t, a_t) = 0$ (environment transition dynamics don't depend on $\theta$)
 - only $\nabla_\theta \log \pi_\theta(a_t|s_t)$ survives
 
@@ -190,18 +191,18 @@ You'll see this throughout the chapter. Now, back to the formal policy gradient 
 
 Substituting this back in @eq:policy_gradient_expectation, we get:
 $$
-\nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \sum_{t=0}^\infty \nabla_\theta \log \pi_\theta(a_t|s_t) R(\tau) \right]
+\nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim p_\theta} \left[ \sum_{t=0}^\infty R(\tau) \nabla_\theta \log \pi_\theta(a_t|s_t) \right]
 $$ {#eq:policy_gradient_returns}
 
 Quite often, people use a more general formulation of the policy gradient: 
 $$
-g = \nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \sum_{t=0}^\infty \nabla_\theta \log \pi_\theta(a_t|s_t) \Psi_t \right]
+g = \nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim p_\theta} \left[ \sum_{t=0}^\infty \Psi_t \nabla_\theta \log \pi_\theta(a_t|s_t) \right]
 $$ {#eq:general_gradient}
 
 Where $\Psi_t$ can be the following (where the rewards can also often be discounted by $\gamma$), a taxonomy adopted from Schulman et al. 2015 [@schulman2015high]:
 
 1. $R(\tau) = \sum_{t=0}^{\infty} r_t$: total reward of the trajectory.
-2. $\sum_{t'=t}^{\infty} r_{t'}$: reward following action $a_t$, also described as the return, $G$.
+2. $\sum_{t'=t}^{\infty} r_{t'}$: reward following action $a_t$, also described as the return from time $t$, $G_t$.
 3. $\sum_{t'=t}^{\infty} r_{t'} - b(s_t)$: baselined version of previous formula.
 4. $Q^{\pi}(s_t, a_t)$: state-action value function.
 5. $A^{\pi}(s_t, a_t)$: advantage function, which yields the lowest possible theoretical variance if it can be computed accurately.
@@ -221,9 +222,9 @@ This final form is exactly the temporal difference (TD) residual (item 6 above) 
 ### Vanilla Policy Gradient
 
 The vanilla policy gradient implementation optimizes the above expression for $J(\theta)$ by differentiating with respect to the policy parameters.
-A simple version, with respect to the overall return, is:
+A simple version, with respect to the time-$t$ return, is:
 
-$$\nabla_\theta J(\theta) = \mathbb{E}_\tau \left[ \sum_{t=0}^T \nabla_\theta \log \pi_\theta(a_t|s_t) G_t \right]$$ {#eq:vanilla_policy_gradient}
+$$\nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim p_\theta} \left[ \sum_{t=0}^T G_t \nabla_\theta \log \pi_\theta(a_t|s_t) \right]$$ {#eq:vanilla_policy_gradient}
 
 A common problem with vanilla policy gradient algorithms is the high variance in gradient updates, which can be mitigated in multiple ways.
 The high variance comes from the gradient updates being computed by estimating the return $G$ from an often small set of rollouts in the environment that tend to be susceptible to noise (e.g. the stochastic nature of generating from language models with temperature $>0$).
@@ -235,7 +236,7 @@ Even these action-independent baselines can reduce variance without changing the
 
 Many of the policy gradient algorithms discussed in this chapter build on the advantage formulation of policy gradient:
 
-$$\nabla_\theta J(\theta) = \mathbb{E}_\tau \left[ \sum_{t=0}^T \nabla_\theta \log \pi_\theta(a_t|s_t) A^{\pi_\theta}(s_t, a_t) \right]$$ {#eq:advantage_policy_gradient}
+$$\nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim p_\theta} \left[ \sum_{t=0}^T A^{\pi_\theta}(s_t, a_t) \nabla_\theta \log \pi_\theta(a_t|s_t) \right]$$ {#eq:advantage_policy_gradient}
 
 
 ### REINFORCE
@@ -261,9 +262,9 @@ With more modern notation and the generalized return $G$, the REINFORCE operator
 $$
 \nabla_{\theta}\,J(\theta)
 \;=\;
-\mathbb{E}_{\tau \sim \pi_{\theta}}\!\left[
+\mathbb{E}_{\tau \sim p_{\theta}}\!\left[
     \sum_{t=0}^{T}
-    \nabla_{\theta} \log \pi_{\theta}(a_t \mid s_t)\,(G_t - b(s_t))
+    (G_t - b(s_t))\,\nabla_{\theta} \log \pi_{\theta}(a_t \mid s_t)
 \right],
 $$ {#eq:REINFORCE_with_baseline}
 
@@ -272,9 +273,9 @@ Here, the value $G_t - b(s_t)$ is the *advantage* of the policy at the current s
 $$
 \nabla_{\theta}\,J(\theta)
 \;=\;
-\mathbb{E}_{\tau \sim \pi_{\theta}}\!\left[
+\mathbb{E}_{\tau \sim p_{\theta}}\!\left[
     \sum_{t=0}^{T}
-    \nabla_{\theta} \log \pi_{\theta}(a_t \mid s_t)\,A_t
+    A_t\,\nabla_{\theta} \log \pi_{\theta}(a_t \mid s_t)
 \right],
 $$ {#eq:REINFORCE_with_advantage}
 
@@ -335,9 +336,9 @@ Here, $\pi_\theta(a|s)$ is the current policy being optimized and $\pi_{\theta_{
 The ratio between these two policies emerges from *importance sampling*, which allows us to reuse data collected under an old policy to estimate gradients for a new policy.
 
 Recall from the advantage formulation of the policy gradient (@eq:advantage_policy_gradient) that we have:
-$$\nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim \pi_\theta} \left[ \sum_{t=0}^T \nabla_\theta \log \pi_\theta(a_t|s_t) A^{\pi_\theta}(s_t, a_t) \right].$$ {#eq:advantage_policy_gradient_recall}
+$$\nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim p_\theta} \left[ \sum_{t=0}^T A^{\pi_\theta}(s_t, a_t) \nabla_\theta \log \pi_\theta(a_t|s_t) \right].$$ {#eq:advantage_policy_gradient_recall}
 
-This expectation is taken over trajectories sampled from $\pi_\theta$, but in practice we want to take multiple gradient steps on a batch of data that was collected from a fixed policy $\pi_{\theta_{\text{old}}}$.
+This expectation is taken over trajectories sampled from the trajectory distribution induced by $\pi_\theta$, but in practice we want to take multiple gradient steps on a batch of data that was collected from a fixed policy $\pi_{\theta_{\text{old}}}$.
 To correct for this distribution mismatch, we multiply by the importance weight $\frac{\pi_\theta(a|s)}{\pi_{\theta_{\text{old}}}(a|s)}$, which reweights samples to account for how much more or less likely they are under the current policy versus the data-collection policy.
 Without constraints, optimizing this importance-weighted objective can lead to destructively large policy updates when the ratio diverges far from 1.
 PPO addresses this by clipping the ratio to the range $[1-\varepsilon, 1+\varepsilon]$, ensuring that the policy cannot change too drastically in a single update.

--- a/teach/course/lec3-chap6-p1.md
+++ b/teach/course/lec3-chap6-p1.md
@@ -235,7 +235,7 @@ Same policy gradient algorithms, different reward source. We will cover tricks f
 
 **Classical RL**: agent in an MDP $(\mathcal{S}, \mathcal{A}, P, r, \gamma)$
 - Reward is a known function from the environment per step
-- Optimize cumulative return: $J(\pi) = \mathbb{E}_{\tau \sim \pi}\!\left[\sum_{t} \gamma^t r(s_t, a_t)\right]$
+- Optimize cumulative return: $J(\pi) = \mathbb{E}_{\tau \sim p_\pi}\!\left[\sum_{t} \gamma^t r(s_t, a_t)\right]$
 
 **RLHF**: prompts from a dataset, no environment
 - Reward is **learned** from human preferences
@@ -293,11 +293,13 @@ Two views of this MDP: **token-level** (each token is a separate action, used in
 
 Choose policy parameters $\theta$ that maximize reward **on average** under the current policy.
 
-$$J(\theta) = \mathbb{E}_{\tau \sim \pi_\theta}[R(\tau)]$$
+Let $p_\theta(\tau)$ be the trajectory distribution induced by the current policy.
+
+$$J(\theta) = \mathbb{E}_{\tau \sim p_\theta}[R(\tau)]$$
 
 In practice, we estimate this expectation with sampled rollouts:
 
-$$J(\theta) \approx \frac{1}{N}\sum_{i=1}^{N} R(\tau_i), \qquad \tau_i \sim \pi_\theta$$
+$$J(\theta) \approx \frac{1}{N}\sum_{i=1}^{N} R(\tau_i), \qquad \tau_i \sim p_\theta$$
 
 We craft a gradient/derivative that lets us optimize this.
 
@@ -348,7 +350,7 @@ The rest of this section is about choosing a smart $\Psi_t$ — different choice
 
 A preview of where we end up:
 
-$$\nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim \pi_\theta}\!\left[\sum_{t=0}^{T} \nabla_\theta \log \pi_\theta(a_t \mid s_t) \cdot \Psi_t\right]$$
+$$\nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim p_\theta}\!\left[\sum_{t=0}^{T} \Psi_t \nabla_\theta \log \pi_\theta(a_t \mid s_t)\right]$$
 
 The core idea is that we *sample over trials in the environment* and **estimate** the gradient.
 
@@ -363,7 +365,7 @@ Three quantities appear throughout this lecture:
 
 **Value function** $V(s)$: expected future return from state $s$
 
-$$V(s) = \mathbb{E}\big[G_t \mid S_t = s\big] \quad \text{where } G_t = \sum_{k=0}^{\infty} \gamma^k R_{t+k+1}$$
+$$V(s) = \mathbb{E}\big[G_t \mid S_t = s\big] \quad \text{where } G_t = \sum_{k=0}^{\infty} \gamma^k r_{t+k}$$
 
 **Action-value** $Q(s, a)$: expected return after taking action $a$ in state $s$
 
@@ -407,7 +409,7 @@ Ideally, we want $\nabla_\theta J(\theta)$, but we can't do that (the state samp
 
 Written as an integral, the objective is:
 
-$$J(\theta) = \mathbb{E}_{\tau \sim \pi_\theta}[R(\tau)] = \int_\tau p_\theta(\tau) R(\tau) \, d\tau$$
+$$J(\theta) = \mathbb{E}_{\tau \sim p_\theta}[R(\tau)] = \int_\tau p_\theta(\tau) R(\tau) \, d\tau$$
 
 ---
 
@@ -417,7 +419,7 @@ Ideally, we want $\nabla_\theta J(\theta)$, but we can't do that (the state samp
 
 Written as an integral, the objective is:
 
-$$J(\theta) = \mathbb{E}_{\tau \sim \pi_\theta}[R(\tau)] = \int_\tau p_\theta(\tau) R(\tau) \, d\tau$$
+$$J(\theta) = \mathbb{E}_{\tau \sim p_\theta}[R(\tau)] = \int_\tau p_\theta(\tau) R(\tau) \, d\tau$$
 
 Taking the gradient directly:
 
@@ -438,9 +440,9 @@ $$
 \nabla_\theta J(\theta)
 &= \int_\tau \nabla_\theta p_\theta(\tau) R(\tau) \, d\tau
 && \text{differentiate the objective} \\
-&= \int_\tau p_\theta(\tau) \nabla_\theta \log p_\theta(\tau) R(\tau) \, d\tau
+&= \int_\tau p_\theta(\tau) R(\tau) \nabla_\theta \log p_\theta(\tau) \, d\tau
 && \text{log-derivative identity (chain rule)} \\
-&= \mathbb{E}_{\tau \sim \pi_\theta}\!\left[\nabla_\theta \log p_\theta(\tau) \cdot R(\tau)\right]
+&= \mathbb{E}_{\tau \sim p_\theta}\!\left[R(\tau) \nabla_\theta \log p_\theta(\tau)\right]
 && \text{expectation form}
 \end{aligned}
 $$
@@ -491,11 +493,11 @@ At a high level, rollout generation handles the sampling, and the loss code hand
 
 The trajectory probability factorizes:
 
-$$p_\theta(\tau) = p(s_0) \prod_{t=0}^{T} \pi_\theta(a_t \mid s_t) \, p(s_{t+1} \mid s_t, a_t)$$
+$$p_\theta(\tau) = d_0(s_0) \prod_{t=0}^{T} \pi_\theta(a_t \mid s_t) \, p(s_{t+1} \mid s_t, a_t)$$
 
 Taking the log:
 
-$$\log p_\theta(\tau) = \log p(s_0) + \sum_{t=0}^{T} \log \pi_\theta(a_t \mid s_t) + \sum_{t=0}^{T} \log p(s_{t+1} \mid s_t, a_t)$$
+$$\log p_\theta(\tau) = \log d_0(s_0) + \sum_{t=0}^{T} \log \pi_\theta(a_t \mid s_t) + \sum_{t=0}^{T} \log p(s_{t+1} \mid s_t, a_t)$$
 
 For language models, this is the familiar autoregressive pattern: a sequence log-probability becomes a sum of token log-probabilities.
 
@@ -505,11 +507,11 @@ For language models, this is the familiar autoregressive pattern: a sequence log
 
 <div class="text-sm">
 
-$$\log p_\theta(\tau) = \log p(s_0) + \sum_{t=0}^{T} \log \pi_\theta(a_t \mid s_t) + \sum_{t=0}^{T} \log p(s_{t+1} \mid s_t, a_t)$$
+$$\log p_\theta(\tau) = \log d_0(s_0) + \sum_{t=0}^{T} \log \pi_\theta(a_t \mid s_t) + \sum_{t=0}^{T} \log p(s_{t+1} \mid s_t, a_t)$$
 
 Now take the gradient w.r.t. $\theta$:
 
-- $\nabla_\theta \log p(s_0) = 0$ — initial state doesn't depend on $\theta$
+- $\nabla_\theta \log d_0(s_0) = 0$ — initial state distribution doesn't depend on $\theta$
 - $\nabla_\theta \log p(s_{t+1} \mid s_t, a_t) = 0$ — environment dynamics don't depend on $\theta$
 - Only $\nabla_\theta \log \pi_\theta(a_t \mid s_t)$ survives!
 
@@ -522,11 +524,11 @@ $$\nabla_\theta \log p_\theta(\tau) = \sum_{t=0}^{T} \nabla_\theta \log \pi_\the
 
 <div class="text-sm">
 
-$$\log p_\theta(\tau) = \log p(s_0) + \sum_{t=0}^{T} \log \pi_\theta(a_t \mid s_t) + \sum_{t=0}^{T} \log p(s_{t+1} \mid s_t, a_t)$$
+$$\log p_\theta(\tau) = \log d_0(s_0) + \sum_{t=0}^{T} \log \pi_\theta(a_t \mid s_t) + \sum_{t=0}^{T} \log p(s_{t+1} \mid s_t, a_t)$$
 
 Now take the gradient w.r.t. $\theta$:
 
-- $\nabla_\theta \log p(s_0) = 0$ — initial state doesn't depend on $\theta$
+- $\nabla_\theta \log d_0(s_0) = 0$ — initial state distribution doesn't depend on $\theta$
 - $\nabla_\theta \log p(s_{t+1} \mid s_t, a_t) = 0$ — environment dynamics don't depend on $\theta$
 - Only $\nabla_\theta \log \pi_\theta(a_t \mid s_t)$ survives!
 
@@ -548,11 +550,11 @@ Autodiff turns that summed log-probability into the corresponding sum of per-tok
 
 An action at time $t$ can't affect past rewards. So instead of weighting by the full trajectory reward $R(\tau)$:
 
-$$\nabla_\theta J = \mathbb{E}\!\left[\sum_{t=0}^{T} \nabla_\theta \log \pi_\theta(a_t \mid s_t) \cdot R(\tau)\right]$$
+$$\nabla_\theta J = \mathbb{E}_{\tau \sim p_\theta}\!\left[\sum_{t=0}^{T} R(\tau) \nabla_\theta \log \pi_\theta(a_t \mid s_t)\right]$$
 
-We can replace $R(\tau)$ with the **return-to-go** $G_t = \sum_{t'=t}^{T} R_{t'}$ — only future rewards from $t$ onward:
+We can replace $R(\tau)$ with the **return-to-go** $G_t = \sum_{t'=t}^{T} r_{t'}$ — only future rewards from $t$ onward:
 
-$$\nabla_\theta J = \mathbb{E}\!\left[\sum_{t=0}^{T} \nabla_\theta \log \pi_\theta(a_t \mid s_t) \cdot G_t\right]$$
+$$\nabla_\theta J = \mathbb{E}_{\tau \sim p_\theta}\!\left[\sum_{t=0}^{T} G_t \nabla_\theta \log \pi_\theta(a_t \mid s_t)\right]$$
 
 This doesn't change the expected gradient, but removes noise from past rewards that the current action couldn't have influenced. This is the step from $\Psi_t$ option 1 → option 2 in our taxonomy.
 
@@ -594,16 +596,16 @@ Use a centered return, $\Psi_t = G_t - b(s_t)$.
 Subtracting this baseline doesn't change the expected gradient:
 
 $$
-\mathbb{E}[\nabla_\theta \log \pi_\theta(a \mid s) \cdot (G_t - b(s))]
-= \mathbb{E}[\nabla_\theta \log \pi_\theta(a \mid s) \cdot G_t]
-- \mathbb{E}[\nabla_\theta \log \pi_\theta(a \mid s) \cdot b(s)]
+\mathbb{E}[(G_t - b(s)) \nabla_\theta \log \pi_\theta(a \mid s)]
+= \mathbb{E}[G_t \nabla_\theta \log \pi_\theta(a \mid s)]
+- \mathbb{E}[b(s) \nabla_\theta \log \pi_\theta(a \mid s)]
 $$
 
 The first term is the original estimator. The second vanishes:
 
 $$
 \begin{aligned}
-\mathbb{E}[\nabla_\theta \log \pi_\theta(a \mid s) \cdot b(s)]
+\mathbb{E}[b(s) \nabla_\theta \log \pi_\theta(a \mid s)]
 &= b(s) \cdot \sum_a \nabla_\theta \pi_\theta(a \mid s) \\
 &= b(s) \cdot \nabla_\theta \underbrace{\sum_a \pi_\theta(a \mid s)}_{= 1} \\
 &= 0
@@ -640,7 +642,7 @@ A *baseline* $b(s_t)$ is any value subtracted from the reward signal to reduce v
 
 Combining the log-derivative trick, return-to-go, and baseline subtraction:
 
-$$\nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim \pi_\theta}\!\left[\sum_{t=0}^{T} \nabla_\theta \log \pi_\theta(a_t \mid s_t) \cdot \Psi_t\right]$$
+$$\nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim p_\theta}\!\left[\sum_{t=0}^{T} \Psi_t \nabla_\theta \log \pi_\theta(a_t \mid s_t)\right]$$
 
 This is the **policy gradient theorem**. Every algorithm in this lecture is an instantiation with a specific choice of $\Psi_t$ and regularization.
 
@@ -653,14 +655,14 @@ For language models, this means the sum runs over generated tokens in the comple
 $$
 \begin{aligned}
 J(\theta)
-&= \mathbb{E}_{\tau \sim \pi_\theta}[R(\tau)]
+&= \mathbb{E}_{\tau \sim p_\theta}[R(\tau)]
 && \text{objective} \\
 &= \int_\tau p_\theta(\tau) R(\tau)\, d\tau
 && \text{integral form} \\
 \nabla_\theta J(\theta)
 &= \int_\tau \nabla_\theta p_\theta(\tau) R(\tau)\, d\tau
 && \text{differentiate} \\
-&= \mathbb{E}_{\tau \sim \pi_\theta}\!\left[\sum_{t=0}^{T} \nabla_\theta \log \pi_\theta(a_t \mid s_t) \cdot \Psi_t\right]
+&= \mathbb{E}_{\tau \sim p_\theta}\!\left[\sum_{t=0}^{T} \Psi_t \nabla_\theta \log \pi_\theta(a_t \mid s_t)\right]
 && \text{final estimator}
 \end{aligned}
 $$
@@ -808,7 +810,7 @@ Three components:
 
 The update rule:
 
-$$\Delta\theta = \alpha \, \nabla_\theta \log \pi_\theta(a_t \mid s_t) \cdot (G_t - b(s_t))$$
+$$\Delta\theta = \alpha \, (G_t - b(s_t)) \nabla_\theta \log \pi_\theta(a_t \mid s_t)$$
 
 
 ---
@@ -825,7 +827,7 @@ The gradient is high variance because the raw return mixes the quality of the ac
 
 Subtracting a baseline $b(s)$ centers the signal: now the gradient weight is $(G_t - b)$, which answers "was this action better or worse than expected from this state?"
 
-$$\mathbb{E}_{a \sim \pi(\cdot \mid s)}[\nabla_\theta \log \pi_\theta(a \mid s) \cdot b(s)] = b(s) \cdot \mathbb{E}_{a \sim \pi(\cdot \mid s)}[\nabla_\theta \log \pi_\theta(a \mid s)] = 0$$
+$$\mathbb{E}_{a \sim \pi(\cdot \mid s)}[b(s) \nabla_\theta \log \pi_\theta(a \mid s)] = b(s) \cdot \mathbb{E}_{a \sim \pi(\cdot \mid s)}[\nabla_\theta \log \pi_\theta(a \mid s)] = 0$$
 
 Because $b(s)$ does not depend on which action was sampled, it factors out and cancels. The expected gradient is unchanged — but the variance drops dramatically.
 
@@ -835,7 +837,7 @@ Because $b(s)$ does not depend on which action was sampled, it factors out and c
 
 The full REINFORCE gradient:
 
-$$\nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim \pi_\theta}\!\left[\sum_{t=0}^{T} \nabla_\theta \log \pi_\theta(a_t \mid s_t)(G_t - b(s_t))\right]$$
+$$\nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim p_\theta}\!\left[\sum_{t=0}^{T} (G_t - b(s_t)) \nabla_\theta \log \pi_\theta(a_t \mid s_t)\right]$$
 
 Here, $G_t - b(s_t)$ is already an advantage estimate: how much better the realized return was than expected from state $s_t$.
 
@@ -1120,7 +1122,7 @@ This Monte Carlo estimate is simple and unbiased, but it can be high variance. T
 
 The temporal difference (TD) residual measures how much the actual reward exceeded the value prediction:
 
-$$\delta_t^V = R_t + \gamma V_\phi(s_{t+1}) - V_\phi(s_t)$$
+$$\delta_t^V = r_t + \gamma V_\phi(s_{t+1}) - V_\phi(s_t)$$
 
 This is the **1-step advantage estimate**: low variance (uses learned $V_\phi$) but potentially high bias (if $V_\phi$ is inaccurate).
 
@@ -1337,7 +1339,7 @@ $$\hat{\rho}_{i,t} = \text{clip}\!\left(\frac{\pi_\theta(a_{i,t} \mid s_t)}{\pi_
 
 **In most RLHF setups, data quality and reward signal quality dominate; algorithm choice mostly determines stability, efficiency, and engineering burden.** All methods optimize the **same** policy gradient objective:
 
-$$\nabla_\theta J(\theta) = \mathbb{E}\!\left[\sum_t \nabla_\theta \log \pi_\theta(a_t \mid s_t) \cdot \Psi_t\right]$$
+$$\nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim p_\theta}\!\left[\sum_t \Psi_t \nabla_\theta \log \pi_\theta(a_t \mid s_t)\right]$$
 
 They differ in:
 

--- a/teach/course/lec4-chap6-p2.md
+++ b/teach/course/lec4-chap6-p2.md
@@ -167,9 +167,9 @@ content: |
 
 The objective and its gradient:
 
-$$J(\theta) = \mathbb{E}_{\tau \sim \pi_\theta}[R(\tau)]$$
+$$J(\theta) = \mathbb{E}_{\tau \sim p_\theta}[R(\tau)]$$
 
-$$\nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim \pi_\theta}\!\left[\sum_{t=0}^{T} \nabla_\theta \log \pi_\theta(a_t \mid s_t) \cdot \Psi_t\right]$$
+$$\nabla_\theta J(\theta) = \mathbb{E}_{\tau \sim p_\theta}\!\left[\sum_{t=0}^{T} \Psi_t \nabla_\theta \log \pi_\theta(a_t \mid s_t)\right]$$
 
 The gradient says: for each token, compute the direction that makes it more likely ($\nabla \log \pi$), then scale by how good it was ($\Psi_t$).
 
@@ -207,7 +207,7 @@ In code, we compute the **log-probs** and let autodiff handle the gradient:
 ```python
 seq_log_probs = (token_log_probs * completion_mask).sum(dim=-1)
 loss = -(seq_log_probs * advantages).mean()
-loss.backward()  # autodiff gives ∑ ∇ log π · Ψ_t
+loss.backward()  # autodiff gives ∑ Ψ_t ∇ log π
 ```
 
 Every loss function in this lecture is a variation on this pattern.


### PR DESCRIPTION
## Summary
- standardize Chapter 6 return notation to zero-indexed lowercase rewards
- correct the policy objective to use the initial-state distribution `d_0`
- make trajectory expectations explicit with `p_\theta(\tau)`
- move scalar return/advantage factors before score-function gradients for readability
- sweep RL course Lectures 3 and 4 for downstream propagated notation issues and align their source slides

Equation labels in Chapter 6 are preserved so existing cross-references remain stable.

## Validation
- `make html`
- inspected generated Chapter 6 HTML for updated equations and resolved cross-references
- confirmed no leftover `R_{t+1}`, bare `\mathbb{E}_\tau`, or raw `@eq:` references in rendered Chapter 6 output
- built Lecture 3 and Lecture 4 HTML with `make course-lecture-lec3-chap6-p1 course-lecture-lec4-chap6-p2`
- confirmed rendered lecture HTML has no leftover `R_t`/`R_{t...}` per-step reward indexing, `\tau \sim \pi_\theta`, or bare `\mathbb{E}_\tau` patterns; uppercase `R_i` sequence rewards remain for RLOO/GRPO

Note: Colloquium HTML builds completed for the lecture decks, but PDF export reported no compatible browser for headless export in this environment.

Fixes #464