### PR TITLE
Ch 12: rename to "Synthetic Data & Distillation" + wire up code examples

### DIFF
--- a/book/chapters/11-preference-data.md
+++ b/book/chapters/11-preference-data.md
@@ -10,7 +10,7 @@ prev-url: "10-preferences"
 page-title: Preference Data
 search-title: "Chapter 11: Preference Data"
 meta-description: "How preference datasets are designed, collected, filtered, and used for RLHF and post-training language models."
-next-chapter: "Synthetic Data"
+next-chapter: "Synthetic Data & Distillation"
 next-url: "12-synthetic-data"
 ---
 

--- a/book/chapters/12-synthetic-data.md
+++ b/book/chapters/12-synthetic-data.md
@@ -286,10 +286,10 @@ This leaves on-policy distillation as a core post-training method, useful for co
 
 ### Suggested Experiments
 
-The companion code in `code/distillation/` implements on-policy self-distillation (OPSD), the variant illustrated in @fig:sdpo: one policy acts as both the demonstration-conditioned teacher and the question-only student, trained with a per-token reverse KL.
+The companion code in `code/distillation/` implements SDPO [@hubotter2026reinforcement], the on-policy self-distillation setup illustrated in @fig:sdpo (the concurrent OPSD paper [@zhao2026selfdistilled] is closely related): one policy acts as both the demonstration-conditioned teacher and the question-only student, trained with a per-token reverse KL.
 It runs on a small string-reversal task, which makes the on-policy distillation loop cheap enough to watch end-to-end on a single GPU.
 
-1. **Run the OPSD string-reversal example.**
+1. **Run the SDPO string-reversal example.**
 
    ```bash
    cd code/

--- a/book/chapters/12-synthetic-data.md
+++ b/book/chapters/12-synthetic-data.md
@@ -7,8 +7,8 @@
 ---
 prev-chapter: "Preference Data"
 prev-url: "11-preference-data"
-page-title: Synthetic Data
-search-title: "Chapter 12: Synthetic Data"
+page-title: Synthetic Data & Distillation
+search-title: "Chapter 12: Synthetic Data & Distillation"
 meta-description: "Synthetic data, distillation, Constitutional AI, and AI feedback methods used throughout modern post-training."
 next-chapter: "Tool Use and Function Calling"
 next-url: "13-tools"
@@ -17,7 +17,7 @@ lectures:
     label: "Lecture 7: Synthetic Data and Modern Post-training Methods"
 ---
 
-# Synthetic Data
+# Synthetic Data & Distillation
 
 Reinforcement learning from *human feedback* is deeply rooted in the idea of keeping a human influence on the models we are building.
 When the first models were trained successfully with RLHF, human data was *the only* viable way to improve the models in this way.
@@ -283,6 +283,25 @@ This leaves on-policy distillation as a core post-training method, useful for co
 ![Three distillation regimes, compared by where the rollout comes from and how supervision flows. **Sequence KD** (left): the teacher generates an output offline and the student is trained to match it with a cross-entropy (CE) loss. **On-policy distillation (OPD)** (center): the student generates the rollout on-policy (e.g. within a RL framework) and a separate teacher scores each visited token, training the student with a per-token KL divergence (KL). **On-policy self-distillation (OPSD)** (right): one model plays both roles -- privileged information (a hint) added to the context creates a teacher trajectory, and the no-hint generation is distilled toward it with a KL loss, with no separate teacher model.](images/distillation_directionality_tikz.png){#fig:distillation-directionality data-dark-src="images/distillation_directionality_tikz-dark.png"}
 
 ![On-policy self-distillation (OPSD) on a string-reversal task. One policy $\pi_\theta$ is forwarded twice over the same student-sampled completion $y$: a **teacher** pass conditioned on the question plus a correct sibling demonstration (yellow), and a **student** pass conditioned on the question only (green). The per-token reverse KL between the two passes, with a stop-gradient on the teacher, pulls the question-only policy toward its demonstration-conditioned self; highlighted columns are the incorrectly sampled tokens where the distributions diverge most.](images/sdpo_tikz.png){#fig:sdpo data-dark-src="images/sdpo_tikz-dark.png"}
+
+### Suggested Experiments
+
+The companion code in `code/distillation/` implements on-policy self-distillation (OPSD), the variant illustrated in @fig:sdpo: one policy acts as both the demonstration-conditioned teacher and the question-only student, trained with a per-token reverse KL.
+It runs on a small string-reversal task, which makes the on-policy distillation loop cheap enough to watch end-to-end on a single GPU.
+
+1. **Run the OPSD string-reversal example.**
+
+   ```bash
+   cd code/
+   uv run python -m distillation.train --config distillation/configs/sdpo.yaml
+   ```
+
+   Watch `reward`, `loss`, and `skipped`, along with the teacher/student rollout samples printed in the loop.
+   The `skipped` count is the number of polled prompts whose sampled group contained no correct rollout; as the student improves, fewer prompts are skipped and `reward` climbs toward 1.
+
+2. **Vary the on-policy knobs.**
+   Copy `distillation/configs/sdpo.yaml` and sweep `num_rollouts`, `kl_top_k`, and `prompts_per_step` while holding the task fixed.
+   More rollouts per prompt make a correct sibling demonstration easier to find (lowering `skipped`) at the cost of more generation per step; `kl_top_k` trades off how much of the teacher distribution the reverse KL matches against compute.
 
 ## AI Feedback
 

--- a/book/chapters/13-tools.md
+++ b/book/chapters/13-tools.md
@@ -5,7 +5,7 @@
   Full license: https://github.com/natolambert/rlhf-book/blob/main/LICENSE-CHAPTERS
 -->
 ---
-prev-chapter: "Synthetic Data"
+prev-chapter: "Synthetic Data & Distillation"
 prev-url: "12-synthetic-data"
 page-title: Tool Use and Function Calling
 search-title: "Chapter 13: Tool Use and Function Calling"

--- a/book/chapters/bib.bib
+++ b/book/chapters/bib.bib
@@ -2455,6 +2455,17 @@ url={https://openreview.net/forum?id=a147pIS2Co}
   url={https://arxiv.org/abs/2601.18734}
 }
 
+@misc{hubotter2026reinforcement,
+  title={Reinforcement Learning via Self-Distillation},
+  author={H{\"u}botter, Jonas and L{\"u}beck, Frederike and Behric, Lejs and Baumann, Anton and Bagatella, Marco and Marta, Daniel and Hakimi, Ido and Shenfeld, Idan and Kleine Buening, Thomas and Guestrin, Carlos and Krause, Andreas},
+  year={2026},
+  eprint={2601.20802},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG},
+  doi={10.48550/arXiv.2601.20802},
+  url={https://arxiv.org/abs/2601.20802}
+}
+
 @article{lee2023rlaif,
   title={Rlaif: Scaling reinforcement learning from human feedback with ai feedback},
   author={Lee, Harrison and Phatale, Samrat and Mansoor, Hassan and Lu, Kellie Ren and Mesnard, Thomas and Ferret, Johan and Bishop, Colton and Hall, Ethan and Carbune, Victor and Rastogi, Abhinav},

--- a/book/templates/nav.js
+++ b/book/templates/nav.js
@@ -58,7 +58,7 @@ class NavigationDropdown extends HTMLElement {
         <ol start="10">
           <li><a href="/c/10-preferences">The Nature of Preferences</a></li>
           <li><a href="/c/11-preference-data">Preference Data</a></li>
-          <li><a href="/c/12-synthetic-data">Synthetic Data</a></li>
+          <li><a href="/c/12-synthetic-data">Synthetic Data &amp; Distillation</a> [<a href="https://github.com/natolambert/rlhf-book/tree/main/code/distillation">code</a>]</li>
         </ol>
       </div>
 

--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,6 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
+- 2026-06-30: [PR #NNN](https://github.com/natolambert/rlhf-book/pull/NNN) added Chapter 12 to the `code/README.md` reader-experiment table and "Good first sweeps", surfacing the distillation (SDPO/OPSD) example alongside the other code-backed chapters.
 - 2026-06-30: [PR #429](https://github.com/natolambert/rlhf-book/pull/429) folded the unused no-grad `SDPOLoss.forward` into the autograd path: the chunked backward-accumulation method is now the canonical `forward` (called via `objective(...)`), removing the duplicate eval-only loss. No change to training behavior or metrics.
 - 2026-06-30: [PR #429](https://github.com/natolambert/rlhf-book/pull/429) added an SDPO method schematic (`book/images/sdpo_tikz.png`, source `diagrams/tikz/12-synthetic-data/sdpo_tikz.tex`) to the top of `distillation/README.md`, illustrating the per-token reverse-KL self-distillation between the demonstration-conditioned self-teacher and the question-only student over completions sampled from the student.
 - 2026-06-30: [PR #429](https://github.com/natolambert/rlhf-book/pull/429) added the SDPO training-results figure (`code/images/wandb_distillation.png`) to the `distillation/` and `code/` READMEs, and corrected the `code/README.md` On-Policy Distillation blurb (LiveCodeBench/execution-feedback → Reasoning Gym `spell_backward` with sibling-demonstration distillation). Reference wandb run IDs remain pending a maintainer run.

--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,7 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
-- 2026-06-30: [PR #NNN](https://github.com/natolambert/rlhf-book/pull/NNN) added Chapter 12 to the `code/README.md` reader-experiment table and "Good first sweeps", surfacing the distillation (SDPO/OPSD) example alongside the other code-backed chapters.
+- 2026-06-30: [PR #469](https://github.com/natolambert/rlhf-book/pull/469) added Chapter 12 to the `code/README.md` reader-experiment table and "Good first sweeps", surfacing the distillation (SDPO/OPSD) example alongside the other code-backed chapters.
 - 2026-06-30: [PR #429](https://github.com/natolambert/rlhf-book/pull/429) folded the unused no-grad `SDPOLoss.forward` into the autograd path: the chunked backward-accumulation method is now the canonical `forward` (called via `objective(...)`), removing the duplicate eval-only loss. No change to training behavior or metrics.
 - 2026-06-30: [PR #429](https://github.com/natolambert/rlhf-book/pull/429) added an SDPO method schematic (`book/images/sdpo_tikz.png`, source `diagrams/tikz/12-synthetic-data/sdpo_tikz.tex`) to the top of `distillation/README.md`, illustrating the per-token reverse-KL self-distillation between the demonstration-conditioned self-teacher and the question-only student over completions sampled from the student.
 - 2026-06-30: [PR #429](https://github.com/natolambert/rlhf-book/pull/429) added the SDPO training-results figure (`code/images/wandb_distillation.png`) to the `distillation/` and `code/` READMEs, and corrected the `code/README.md` On-Policy Distillation blurb (LiveCodeBench/execution-feedback → Reasoning Gym `spell_backward` with sibling-demonstration distillation). Reference wandb run IDs remain pending a maintainer run.

--- a/code/README.md
+++ b/code/README.md
@@ -40,7 +40,7 @@ Good first sweeps:
 - **Rejection sampling**: keep generation/scoring settings identical while comparing `top_*` configs to their `random_*` controls.
 - **Distillation**: copy `distillation/configs/sdpo.yaml` and vary `num_rollouts`, `kl_top_k`, and `prompts_per_step`, watching how `skipped` and `reward` respond as the self-distillation loop converges.
 
-The book chapters now include suggested exercises in Chapters 4, 5, 6, 8, 9, and 12.
+The book chapters now include suggested exercises at the end of Chapters 4, 5, 6, 8, 9, and 12.
 
 ## Attribution
 

--- a/code/README.md
+++ b/code/README.md
@@ -29,6 +29,7 @@ If you are running these with a coding assistant, launch long training/eval comm
 | Chapter 6: Policy Gradients | GRPO on `spell_backward` | `uv run python -m policy_gradients.train --config policy_gradients/configs/grpo.yaml` | `avg_correctness`, `avg_format`, `avg_binary`, and whether groups contain contrast |
 | Chapter 8: Direct Alignment | DPO on UltraFeedback | `uv run python -m direct_alignment.train --loss dpo --max_samples 1000` | `accuracy`, `margins`, `chosen_rewards`, `rejected_rewards`, sample generations |
 | Chapter 9: Rejection Sampling | GSM8K reward selection versus random controls | `uv run python -m rejection_sampling.train --config rejection_sampling/configs/top_per_prompt.yaml` | Final exact-match accuracy against the matched random baseline |
+| Chapter 12: Synthetic Data | SDPO / on-policy self-distillation on string-reversal | `uv run python -m distillation.train --config distillation/configs/sdpo.yaml` | `reward`, `loss`, `skipped`, and the in-loop teacher/student rollout samples |
 
 Good first sweeps:
 
@@ -37,8 +38,9 @@ Good first sweeps:
 - **Direct alignment**: hold the dataset fixed and compare `dpo.yaml`, `ipo.yaml`, and `dpo_norm.yaml`; read IPO through margins/accuracy, not raw loss scale.
 - **Reward models**: vary `--samples`, `--lr`, and `--model-id` before changing the model architecture.
 - **Rejection sampling**: keep generation/scoring settings identical while comparing `top_*` configs to their `random_*` controls.
+- **Distillation**: copy `distillation/configs/sdpo.yaml` and vary `num_rollouts`, `kl_top_k`, and `prompts_per_step`, watching how `skipped` and `reward` respond as the self-distillation loop converges.
 
-The book chapters now include suggested exercises at the end of Chapters 4, 5, 6, 8, and 9.
+The book chapters now include suggested exercises in Chapters 4, 5, 6, 8, 9, and 12.
 
 ## Attribution
 


### PR DESCRIPTION
## What

Brings Chapter 12 up to parity with the other code-backed chapters now that `code/distillation/` (SDPO / on-policy self-distillation) exists.

- **`book/templates/nav.js`** — rename the nav entry to **"Synthetic Data & Distillation"** and add the `[code]` link pointing at `code/distillation` (matching the pattern used by chapters 4/5/6/8/9).
- **`book/chapters/12-synthetic-data.md`** — rename `page-title`, `search-title`, and the H1 to match; add a **Suggested Experiments** subsection *inside* "The Path to On-Policy, Teacher-Student Distillation" (a mini-methods section rather than at the chapter end). It runs the SDPO/OPSD string-reversal example and ties back to `fig:sdpo`.
- **`code/README.md`** — add a Chapter 12 row to the "Reader Experiment Path" table, a distillation "Good first sweeps" bullet, and list Ch 12 in the suggested-exercises note.
- **`code/CHANGELOG.md`** — changelog entry (required by CI for `code/` changes).

The course (`teach/`) is intentionally left unchanged. `code/distillation/README.md` already has its own algorithms list, so it is untouched.

## Verification

- `make 'build/html/c//12-synthetic-data.html'` builds clean; H1/search-title read "Synthetic Data & Distillation", the new section renders, and `@fig:sdpo` resolves to "fig. 3".
- `code/` CI parity: `ruff check`, `ruff format --check` clean; `pytest` → 45 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
