### PR TITLE
Course: add Watch link for Q&A 2 video

### DIFF
--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -679,6 +679,7 @@
           <h3>Q&amp;A 2: Reader questions, lec. 5-7</h3>
         </div>
         <div class="talk-actions">
+          <a href="https://www.youtube.com/watch?v=gB-bYUECpzE&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=11" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
           <a href="/teach/course/qa-02/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
           <a href="/teach/course/qa-02/" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
           <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/qa-02.md?plain=1" class="btn btn-source" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>


### PR DESCRIPTION
Adds the missing **Watch** button to the Q&A 2 entry on the course page, linking the newly published video (https://youtu.be/gB-bYUECpzE), matching the pattern used by the other lecture/Q&A entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
