### PR TITLE
Highlight community translations on the homepage Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,11 @@ To cite this book, please use the following format:
 Where I get the credit as the sole "author" and creator of this project, I've been super lucky to have many contributions from early readers. These have massively accelerated the editing progress and flat-out added meaningful content to the book. I'm happy to send substantive contributors free copies of the book and expect the internet goodwill to pay them back in unexpected ways.
 
 See all [contributors](https://github.com/natolambert/rlhf-book/graphs/contributors).
+
+### Translations
+
+Readers maintain unofficial translations of the book in their own repositories. These are community projects — independent of the official print editions and their professional translations — released under the same CC-BY-NC-SA license with attribution back to this book:
+
+- 简体中文 (Simplified Chinese): [jweihe/RLHF-book-Chinese](https://github.com/jweihe/RLHF-book-Chinese)
+
+To add yours: keep it in your own repo (translations are not merged here), follow the license terms above, label it clearly as an unofficial community translation, then open a PR adding it to this list and to the homepage Ecosystem section (`book/templates/html.html`).

--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ See all [contributors](https://github.com/natolambert/rlhf-book/graphs/contribut
 
 ### Translations
 
-Readers maintain unofficial translations of the book in their own repositories. These are community projects — independent of the official print editions and their professional translations — released under the same CC-BY-NC-SA license with attribution back to this book:
+Readers maintain unofficial translations of the book in their own repositories. 
+These are community projects — independent of the official print editions and their professional translations — released under the same CC-BY-NC-SA license with attribution back to this book:
 
 - 简体中文 (Simplified Chinese): [jweihe/RLHF-book-Chinese](https://github.com/jweihe/RLHF-book-Chinese)
 
-To add yours: keep it in your own repo (translations are not merged here), follow the license terms above, label it clearly as an unofficial community translation, then open a PR adding it to this list and to the homepage Ecosystem section (`book/templates/html.html`).
+To add yours: keep it in your own repo (translations are not merged here), follow the license terms above, label it clearly as a community translation, then open a PR adding it to this list and to the homepage Ecosystem section (`book/templates/html.html`).

--- a/book/templates/html.html
+++ b/book/templates/html.html
@@ -220,7 +220,7 @@ $endif$
            linking to your repo or site. Keep the label in the target language. -->
       <a href="https://github.com/jweihe/RLHF-book-Chinese" target="_blank" rel="noopener noreferrer" class="home-card-btn home-card-btn-grey">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-        简体中文
+        简体中文 (Simplified Chinese)
       </a>
       <!-- 繁體中文 (zh-TW) by Twinkle AI pending, see issue #472 -->
     </div>

--- a/book/templates/html.html
+++ b/book/templates/html.html
@@ -106,6 +106,7 @@ $endfor$
 
 <!-- custom js nav -->
 <script src="nav.js" defer></script>
+<script src="header-anchors.js" defer></script>
 <script src="table-scroll.js" defer></script>
 <script src="copy-code.js" defer></script>
 <script src="theme.js" defer></script>
@@ -145,7 +146,7 @@ $if(abstract)$
 $endif$
 </header>
 $endif$
-  <h3 style="padding: 0 20px; margin-top: 1.5em;">RLHF Book Ecosystem</h3>
+  <h3 id="ecosystem" style="padding: 0 20px; margin-top: 1.5em;">RLHF Book Ecosystem</h3>
   <div style="display: flex; align-items: center; justify-content: space-between; gap: 1em; flex-wrap: wrap; margin: 0.5em 20px 0; padding: 0.8em 1.2em; border: 1px solid var(--color-border); border-radius: 0.35em; background: var(--color-bg-section); box-shadow: 0 4px 12px var(--color-shadow);">
     <div>
       <h3 style="margin: 0 0 0.15em 0; font-size: 1.05em;">Welcome to the Course</h3>

--- a/book/templates/html.html
+++ b/book/templates/html.html
@@ -209,6 +209,21 @@ $endif$
       Join
     </a>
   </div>
+  <div style="display: flex; align-items: center; justify-content: space-between; gap: 1em; flex-wrap: wrap; margin: 0.8em 20px 0; padding: 0.8em 1.2em; border: 1px solid var(--color-border); border-radius: 0.35em; background: var(--color-bg-section); box-shadow: 0 4px 12px var(--color-shadow);">
+    <div>
+      <h3 style="margin: 0 0 0.15em 0; font-size: 1.05em;">Community Translations</h3>
+      <p style="font-size: 0.88em; color: var(--color-text-muted); margin: 0;">Unofficial translations maintained by readers, independent of the official print editions</p>
+    </div>
+    <div style="display: flex; align-items: center; gap: 0.5em; flex-wrap: wrap;">
+      <!-- One chip per translation. To add yours: open an issue, then add a chip here
+           linking to your repo or site. Keep the label in the target language. -->
+      <a href="https://github.com/jweihe/RLHF-book-Chinese" target="_blank" rel="noopener noreferrer" class="home-card-btn home-card-btn-grey">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+        简体中文
+      </a>
+      <!-- 繁體中文 (zh-TW) by Twinkle AI pending, see issue #472 -->
+    </div>
+  </div>
   <section id="acknowledgements" style="padding: 0 20px; margin-top: 2em;">
     <h3>Acknowledgements</h3>
     <p>I would like to thank the following people who helped me directly with this project: Costa Huang, Ross Taylor, Hamish Ivison, John Schulman, Valentina Pyatkin, Daniel Han, Shane Gu, Joanne Jang, LJ Miranda, Sharan Maiya, Andrew Carr, Cameron R. Wolfe, and others in my RL sphere (and of course Claude).</p>


### PR DESCRIPTION
## Summary

Draft proposal for how to surface community translations on rlhfbook.com, per the position in [#468 (comment)](https://github.com/natolambert/rlhf-book/pull/468#issuecomment-4848629953): translations live outside this repo, and the homepage links to them from the Ecosystem section. Opened to have something concrete to react to before answering #472.

## Design

A single **Community Translations** card matching the existing Ecosystem card pattern, with one compact language chip per translation (labeled in the target language) and room to grow:

- Subtitle spells out the policy: *"Unofficial translations maintained by readers, independent of the official print editions"* — so there's no confusion with future professionally-translated print versions.
- Chips use the existing `home-card-btn-grey` style with a globe icon; N languages stay one row that wraps.
- An HTML comment documents how contributors add their chip (open an issue, then PR one line).

## Current entries

- **简体中文** → [jweihe/RLHF-book-Chinese](https://github.com/jweihe/RLHF-book-Chinese) — live, clearly attributed, CC-BY-NC-SA like the book, labeled as a translation of this repo.
- **繁體中文 (zh-TW)** → commented-out placeholder pending the Twinkle AI community repo from #472.

## Open questions (why this is a draft)

1. **Inclusion bar** — what does a translation need before it gets a chip? Suggested: correct license (CC-BY-NC-SA), attribution + link back, "unofficial" labeling, and substantial coverage. Could codify in CONTRIBUTING.
2. **zh-CN choice** — #468's fork ([charnugagoo/rlhf-book](https://github.com/charnugagoo/rlhf-book)) doesn't have the translation on its default branch; jweihe's standalone repo is the more linkable artifact today. Both, either, or wait?
3. **Scale** — chips are fine for ~2–6 languages; beyond that this probably becomes a link to a dedicated page or README section.

Closes #472 (once the zh-TW chip lands).

🤖 Generated with [Claude Code](https://claude.ai/code)
