### PR TITLE
Add Lecture 8 video link to course page and chapters 10/11

### DIFF
--- a/book/chapters/10-preferences.md
+++ b/book/chapters/10-preferences.md
@@ -12,6 +12,9 @@ search-title: "Chapter 10: The Nature of Preferences"
 meta-description: "A conceptual chapter on human preferences, preference learning, and why RLHF can optimize hard-to-specify behaviors."
 next-chapter: "Preference Data"
 next-url: "11-preference-data"
+lectures:
+  - video: "https://www.youtube.com/watch?v=Y2tv5vuaxFs&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=13"
+    label: 'Lecture 8: On "Preferences" and Preference Data'
 ---
 
 # The Nature of Preferences

--- a/book/chapters/11-preference-data.md
+++ b/book/chapters/11-preference-data.md
@@ -12,6 +12,9 @@ search-title: "Chapter 11: Preference Data"
 meta-description: "How preference datasets are designed, collected, filtered, and used for RLHF and post-training language models."
 next-chapter: "Synthetic Data & Distillation"
 next-url: "12-synthetic-data"
+lectures:
+  - video: "https://www.youtube.com/watch?v=Y2tv5vuaxFs&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=13"
+    label: 'Lecture 8: On "Preferences" and Preference Data'
 ---
 
 # Preference Data

--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -691,6 +691,7 @@
           <p class="meta">Chapters 10 &amp; 11 &middot; A history of preferences, the preference-data engine, and unanswerable questions</p>
         </div>
         <div class="talk-actions">
+          <a href="https://www.youtube.com/watch?v=Y2tv5vuaxFs&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=13" class="btn btn-watch" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-watch"/></svg> Watch</a>
           <a href="/teach/course/lec8-chap10-11-preferences/slides.pdf" class="btn" download><svg width="14" height="14"><use href="#icon-pdf"/></svg> PDF</a>
           <a href="/teach/course/lec8-chap10-11-preferences/" class="btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-slides"/></svg> Slides</a>
           <a href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec8-chap10-11-preferences.md?plain=1" class="btn btn-source" target="_blank" rel="noopener noreferrer"><svg width="14" height="14"><use href="#icon-github"/></svg> Source</a>


### PR DESCRIPTION
Adds the **Lecture 8: On "Preferences" and Preference Data** recording (https://youtu.be/Y2tv5vuaxFs) in the two standard places:

- **Course page**: Watch button on the Lecture 8 card (first action, matching Lectures 1–7).
- **Chapters 10 & 11**: the `lectures:` frontmatter block, same pattern as chapters 6/7/8/12.

Verified by building chapter 10 — the link and label render in the chapter header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
