### PR TITLE
Lec 1: fix rejection-sampling argmax notation

### DIFF
--- a/teach/course/lec1-chap1-3.md
+++ b/teach/course/lec1-chap1-3.md
@@ -861,7 +861,7 @@ Generate many completions, score them, fine-tune on the best:
 3. **Select**: keep the highest-scoring completion(s)
 4. **Fine-tune**: standard SFT loss on the curated set
 
-$$\mathcal{L}_{\mathrm{RS}} = \mathcal{L}_{\mathrm{SFT}}\!\left(\theta;\; \{(x_i, y_i^{\star})\}\right) \quad \text{where } y_i^{\star} = \arg\max_{j} r_\phi(x_i, y_{i,j})$$
+$$\mathcal{L}_{\mathrm{RS}} = \mathcal{L}_{\mathrm{SFT}}\!\left(\theta;\; \{(x_i, y_i^{\star})\}\right) \quad \text{where } y_i^{\star} = y_{i,\, \arg\max_{j} r_\phi(x_i, y_{i,j})}$$
 
 Simple, stable, and widely used: Llama 2 [@touvron2023llama] and DeepSeek R1 [@guo2025deepseek] both include rejection sampling stages.
 


### PR DESCRIPTION
## What

Fixes a notational imprecision on the rejection-sampling slide of Lecture 1 (`teach/course/lec1-chap1-3.md`, slide 41/70).

**Before:**
$$y_i^{\star} = \arg\max_{j} r_\phi(x_i, y_{i,j})$$

**After:**
$$y_i^{\star} = y_{i,\, \arg\max_{j} r_\phi(x_i, y_{i,j})}$$

## Why

`\arg\max_j` returns the **index** `j` that maximizes the reward, not the completion. As written, the chosen completion `y_i^{\star}` (a sequence) was set equal to an integer index — a type mismatch. The corrected form selects the completion *at* the argmax index.

Caught by a YouTube viewer on the Lecture 1 recording. Verified the fix renders correctly on slide 41/70 via `colloquium export`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)