### PR TITLE
Add Google Scholar citation meta tags to the book homepage

### DIFF
--- a/book/templates/html.html
+++ b/book/templates/html.html
@@ -47,6 +47,18 @@ $endif$
 $if(keywords)$
   <meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$" />
 $endif$
+
+  <!-- Google Scholar / Highwire Press citation tags so the book is indexed as a
+       citable work (not just a website). See
+       https://scholar.google.com/intl/en/scholar/inclusion.html
+       Kept consistent with the arXiv record (arXiv:2504.12501) -- matching title,
+       author, and year lets Scholar group both versions into one citation cluster.
+       Only emitted on the canonical index.html (chapter pages use chapter.html). -->
+  <meta name="citation_title" content="$if(title)$$title$$else$Reinforcement Learning from Human Feedback$endif$" />
+  <meta name="citation_author" content="Lambert, Nathan" />
+  <meta name="citation_publication_date" content="2025" />
+  <meta name="citation_pdf_url" content="https://rlhfbook.com/book.pdf" />
+
   <!-- <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title> -->
    <!-- SEO and Open Graph titles -->
   <title>$if(seo-title)$$seo-title$$else$RLHF Book: Reinforcement Learning from Human Feedback and LLM Post-Training$endif$</title>


### PR DESCRIPTION
## What

Adds Highwire Press `citation_*` meta tags to the `<head>` of the canonical `index.html`, via the `book/templates/html.html` Pandoc template.

```html
<meta name="citation_title" content="Reinforcement Learning from Human Feedback" />
<meta name="citation_author" content="Lambert, Nathan" />
<meta name="citation_publication_date" content="2025" />
<meta name="citation_pdf_url" content="https://rlhfbook.com/book.pdf" />
```

## Why

Right now `rlhfbook.com` exposes **no scholarly metadata**, so Google Scholar can't index the book as a citable work — it only "sees" the arXiv version (arXiv:2504.12501), and citations that use the `Online, 2024, https://rlhfbook.com` form don't consolidate. Adding these tags is [Google Scholar's documented inclusion mechanism](https://scholar.google.com/intl/en/scholar/inclusion.html).

Values are deliberately aligned with the arXiv record (same title, `Lambert, Nathan`, year `2025`) so Scholar can group both versions into a single citation cluster rather than scattering cites.

## Scope / safety

- Tags are emitted **only** on `index.html` (the full-text single-page build that already has a Bibliography section). Chapter pages use `chapter.html` and are intentionally left untouched to avoid Scholar registering dozens of duplicate records.
- `citation_pdf_url` points at the existing `https://rlhfbook.com/book.pdf` (verified 200).
- Verified locally: rendered the template with `pandoc --wrap=none` and confirmed all four tags emit as clean single-line meta tags.

## Notes / not in scope

- Scholar crawl→index takes weeks; if it lands as a separate record rather than auto-merging with the arXiv cluster, the duplicates can be merged from the author profile.
- The AI-crawler `Disallow` entries in the served `robots.txt` are injected by Cloudflare at the edge (not in this repo) and do not affect Scholar's crawler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)