### PR TITLE
Add Lecture 11 video to course page and tools chapter

### DIFF
--- a/book/chapters/13-tools.md
+++ b/book/chapters/13-tools.md
@@ -12,6 +12,9 @@ search-title: "Chapter 13: Tool Use and Function Calling"
 meta-description: "Tool use and function calling as post-training targets for building more capable language model products and agents."
 next-chapter: "Over-Optimization"
 next-url: "14-over-optimization"
+lectures:
+  - video: "https://www.youtube.com/watch?v=GMry2DzC304&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=17"
+    label: "Lecture 11: Tool Use, Function Calling and The Road to Agents"
 ---
 
 # Tool Use and Function Calling

--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -739,7 +739,7 @@
         <h3>Lecture 11: Tool Use, Function Calling and The Road to Agents</h3>
         <div class="course-row-lower">
           <p class="meta">Chapter 13 &middot; Why models need tools, MCP and harnesses, and tool-use RL</p>
-          <div class="row-actions"><a class="action" href="/teach/course/lec11-chap13-tools/slides.pdf" download>PDF</a><span class="sep">&middot;</span><a class="action" href="/teach/course/lec11-chap13-tools/" target="_blank" rel="noopener noreferrer">Slides</a><span class="sep">&middot;</span><a class="action action-source" href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec11-chap13-tools.md?plain=1" target="_blank" rel="noopener noreferrer">Source</a></div>
+          <div class="row-actions"><a class="action action-watch" href="https://www.youtube.com/watch?v=GMry2DzC304&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=17" target="_blank" rel="noopener noreferrer"><svg width="12" height="12"><use href="#icon-watch"/></svg> Watch</a><span class="sep">&middot;</span><a class="action" href="/teach/course/lec11-chap13-tools/slides.pdf" download>PDF</a><span class="sep">&middot;</span><a class="action" href="/teach/course/lec11-chap13-tools/" target="_blank" rel="noopener noreferrer">Slides</a><span class="sep">&middot;</span><a class="action action-source" href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec11-chap13-tools.md?plain=1" target="_blank" rel="noopener noreferrer">Source</a></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Wires the newly published Lecture 11 video into the site.

## Changes
- Course page: added the "Watch" action to the Lecture 11 row, matching the Lecture 9/10 pattern
- Chapter 13 (Tool Use): added the `lectures:` frontmatter block so the chapter page links the lecture, matching chapters 14/15

Video verified via YouTube oEmbed: "How Language Models Use Tools and the Path to Agents | RLHF & Post-Training Course, Lecture 11".

🤖 Generated with [Claude Code](https://claude.com/claude-code)