### PR TITLE
[CODE] batched dataset encoding

### DIFF
--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,6 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
+- 2026-08-01: Batched dataset encoding
 - 2026-07-30: [PR #495](https://github.com/natolambert/rlhf-book/pull/495) cleaned up stale documentation, commands, reference-run links, documented metric names and configuration defaults, and brand capitalization across the code examples. No training behavior or metric semantics changed.
 - 2026-07-23: [PR #485](https://github.com/natolambert/rlhf-book/pull/485) fixed ORM training failing to load GSM8K under newer `huggingface_hub`, which requires fully-qualified `namespace/name` repo ids: `reward_models/train_orm.py` now uses `DEFAULT_DATASET = "openai/gsm8k"` (was the bare `gsm8k`, rejected with `HfUriError`). Dataset content is unchanged, so metrics remain comparable.
 - 2026-07-21: [PR #482](https://github.com/natolambert/rlhf-book/pull/482) added a "Hyperparameters for harder tasks" section to `distillation/README.md`: a hyperparameter table for stable SDPO runs on harder datasets in a vendored verl-fork setting (mini batch size as the biggest lever, flat 1e-6 LR, EMA teacher, teacher/rollout IS clips, top-K reverse KL, train vs eval sampling), notes on demonstration selection and privileged context, and a reference plot (`code/images/sdpo_sokoban.png`) from a Qwen3-4B-Instruct Reasoning Gym Sokoban run. Docs and image only; no code changes.

--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,7 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
-- 2026-08-01: Batched dataset encoding
+- 2026-08-01: [PR #499](https://github.com/natolambert/rlhf-book/pull/499) Batched dataset encoding
 - 2026-07-30: [PR #495](https://github.com/natolambert/rlhf-book/pull/495) cleaned up stale documentation, commands, reference-run links, documented metric names and configuration defaults, and brand capitalization across the code examples. No training behavior or metric semantics changed.
 - 2026-07-23: [PR #485](https://github.com/natolambert/rlhf-book/pull/485) fixed ORM training failing to load GSM8K under newer `huggingface_hub`, which requires fully-qualified `namespace/name` repo ids: `reward_models/train_orm.py` now uses `DEFAULT_DATASET = "openai/gsm8k"` (was the bare `gsm8k`, rejected with `HfUriError`). Dataset content is unchanged, so metrics remain comparable.
 - 2026-07-21: [PR #482](https://github.com/natolambert/rlhf-book/pull/482) added a "Hyperparameters for harder tasks" section to `distillation/README.md`: a hyperparameter table for stable SDPO runs on harder datasets in a vendored verl-fork setting (mini batch size as the biggest lever, flat 1e-6 LR, EMA teacher, teacher/rollout IS clips, top-K reverse KL, train vs eval sampling), notes on demonstration selection and privileged context, and a reference plot (`code/images/sdpo_sokoban.png`) from a Qwen3-4B-Instruct Reasoning Gym Sokoban run. Docs and image only; no code changes.

--- a/code/instruction_tuning/utils.py
+++ b/code/instruction_tuning/utils.py
@@ -130,7 +130,12 @@ def compute_loss(model, batch: "SFTBatch") -> torch.Tensor:
     )
 
 
-def _encode_batch(batch, tokenizer, max_length):
+def _encode_batch(
+    batch: dict[str, list],
+    tokenizer: PreTrainedTokenizer,
+    max_length: int,
+) -> dict[str, list[list[int]]]:
+    """Render each conversation with the chat template and mask all but the final assistant turn."""
     conversations = [
         messages
         for messages in batch["messages"]

--- a/code/instruction_tuning/utils.py
+++ b/code/instruction_tuning/utils.py
@@ -130,34 +130,46 @@ def compute_loss(model, batch: "SFTBatch") -> torch.Tensor:
     )
 
 
-def _encode_row(
-    messages: list[dict],
-    tokenizer: PreTrainedTokenizer,
-    max_length: int,
-) -> dict[str, torch.Tensor] | None:
-    """Render ``messages`` with the chat template and mask all but the final assistant turn."""
-    if not messages or messages[-1]["role"] != "assistant":
-        return None
+def _encode_batch(batch, tokenizer, max_length):
+    conversations = [
+        messages
+        for messages in batch["messages"]
+        if messages and messages[-1]["role"] == "assistant"
+    ]
+    if not conversations:
+        return {"input_ids": [], "labels": []}
 
-    prompt_ids = tokenizer.apply_chat_template(
-        messages[:-1], tokenize=True, add_generation_prompt=True, return_dict=False
+    prompt_ids_batch = tokenizer.apply_chat_template(
+        [messages[:-1] for messages in conversations],
+        tokenize=True,
+        add_generation_prompt=True,
+        return_dict=False,
+        truncation=True,
+        max_length=max_length,
     )
-    full_ids = tokenizer.apply_chat_template(
-        messages, tokenize=True, add_generation_prompt=False, return_dict=False
+    full_ids_batch = tokenizer.apply_chat_template(
+        conversations,
+        tokenize=True,
+        add_generation_prompt=False,
+        return_dict=False,
+        truncation=True,
+        max_length=max_length,
     )
-    labels = [IGNORE_INDEX] * len(prompt_ids) + list(full_ids[len(prompt_ids) :])
 
-    if max_length is not None and len(full_ids) > max_length:
-        full_ids = full_ids[:max_length]
-        labels = labels[:max_length]
+    input_ids, labels = [], []
+    for prompt_ids, full_ids in zip(
+        prompt_ids_batch, full_ids_batch, strict=True
+    ):
+        prompt_length = min(len(prompt_ids), len(full_ids))
+        if prompt_length == len(full_ids):
+            continue
 
-    if all(label == IGNORE_INDEX for label in labels):
-        return None
+        input_ids.append(full_ids)
+        labels.append(
+            [IGNORE_INDEX] * prompt_length + full_ids[prompt_length:]
+        )
 
-    return {
-        "input_ids": torch.tensor(full_ids, dtype=torch.long),
-        "labels": torch.tensor(labels, dtype=torch.long),
-    }
+    return {"input_ids": input_ids, "labels": labels}
 
 
 class SFTDataset(Dataset):
@@ -196,14 +208,18 @@ def create_dataloader(cfg: Config, tokenizer: PreTrainedTokenizer) -> DataLoader
     if cfg.max_samples is not None and len(raw) > cfg.max_samples:
         raw = raw.select(range(cfg.max_samples))
 
-    encoded: list[dict[str, torch.Tensor]] = []
-    skipped = 0
-    for example in raw:
-        row = _encode_row(example["messages"], tokenizer, cfg.max_length)
-        if row is None:
-            skipped += 1
-            continue
-        encoded.append(row)
+    encoded = raw.map(
+        _encode_batch,
+        batched=True,
+        batch_size=256,
+        remove_columns=raw.column_names,
+        fn_kwargs={"tokenizer": tokenizer, "max_length": cfg.max_length},
+        load_from_cache_file=True,
+        desc="Encoding conversations",
+    )
+
+    skipped = len(raw) - len(encoded)
+    encoded = encoded.with_format("torch")
 
     if not encoded:
         raise RuntimeError("No trainable rows after tokenization.")


### PR DESCRIPTION
Updating `utils.py` so the dataset encoding is done in batches rather than per-row. Using the natived `.map` hf method allows us to encode in batches and it also caches (`load_from_cache_file=True`) results, so if a user is doing multiple runs or sweeps they dont pay the price of encoding every time. Sol created a small speedup script and here are the results for this change:

### HuggingFaceH4/no_robots
```
Original dataloader timing metrics:
  min: 8.415834 seconds
  max: 9.407058 seconds
  mean: 8.911446 seconds
  median: 8.911446 seconds
Batched dataloader timing metrics:
  min: 3.516653 seconds
  max: 3.725266 seconds
  mean: 3.620960 seconds
  median: 3.620960 seconds
Speedup:
  min: 2.39x
  max: 2.53x
  mean: 2.46x
  median: 2.46x
```

### HuggingFaceH4/ultrachat_200k
```
Original dataloader timing metrics:
  min: 922.287329 seconds
  max: 958.376028 seconds
  mean: 940.331679 seconds
  median: 940.331679 seconds
Batched dataloader timing metrics:
  min: 159.140423 seconds
  max: 160.104137 seconds
  mean: 159.622280 seconds
  median: 159.622280 seconds
Speedup:
  min: 5.76x
  max: 6.02x
  mean: 5.89x
  median: 5.89x
```
