### PR TITLE
[CODE] ruff format fixup for #499

### DIFF
--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,6 +5,7 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
+- 2026-08-01: [PR #500](https://github.com/natolambert/rlhf-book/pull/500) ruff-format fixup for the batched dataset encoding merged in [PR #499](https://github.com/natolambert/rlhf-book/pull/499); formatting only, no behavior change.
 - 2026-08-01: [PR #499](https://github.com/natolambert/rlhf-book/pull/499) Batched dataset encoding
 - 2026-07-30: [PR #495](https://github.com/natolambert/rlhf-book/pull/495) cleaned up stale documentation, commands, reference-run links, documented metric names and configuration defaults, and brand capitalization across the code examples. No training behavior or metric semantics changed.
 - 2026-07-23: [PR #485](https://github.com/natolambert/rlhf-book/pull/485) fixed ORM training failing to load GSM8K under newer `huggingface_hub`, which requires fully-qualified `namespace/name` repo ids: `reward_models/train_orm.py` now uses `DEFAULT_DATASET = "openai/gsm8k"` (was the bare `gsm8k`, rejected with `HfUriError`). Dataset content is unchanged, so metrics remain comparable.

--- a/code/instruction_tuning/utils.py
+++ b/code/instruction_tuning/utils.py
@@ -162,17 +162,13 @@ def _encode_batch(
     )
 
     input_ids, labels = [], []
-    for prompt_ids, full_ids in zip(
-        prompt_ids_batch, full_ids_batch, strict=True
-    ):
+    for prompt_ids, full_ids in zip(prompt_ids_batch, full_ids_batch, strict=True):
         prompt_length = min(len(prompt_ids), len(full_ids))
         if prompt_length == len(full_ids):
             continue
 
         input_ids.append(full_ids)
-        labels.append(
-            [IGNORE_INDEX] * prompt_length + full_ids[prompt_length:]
-        )
+        labels.append([IGNORE_INDEX] * prompt_length + full_ids[prompt_length:])
 
     return {"input_ids": input_ids, "labels": labels}
 


### PR DESCRIPTION
Applies `ruff format` to `code/instruction_tuning/utils.py` — #499 was merged while checks were still running and the format check had failed on two manually-wrapped statements. `ruff check`, `ruff format --check`, and the smoke tests (45 passed) were run locally on this branch. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)