### PR TITLE
Fix epub code blocks render issue

### DIFF
--- a/book/templates/ebook.css
+++ b/book/templates/ebook.css
@@ -50,3 +50,15 @@ a.citation-backlink {
   margin-left: 0.35em;
   text-decoration: none;
 }
+
+/* Scroll containers cannot fragment reliably in paginated readers. */
+pre,
+pre.sourceCode {
+  overflow: visible !important;
+  break-inside: auto;
+  page-break-inside: auto;
+}
+
+pre > code.sourceCode {
+  white-space: pre-wrap;
+}

--- a/book/templates/ebook.css
+++ b/book/templates/ebook.css
@@ -52,6 +52,7 @@ a.citation-backlink {
 }
 
 /* Scroll containers cannot fragment reliably in paginated readers. */
+div.sourceCode,
 pre,
 pre.sourceCode {
   overflow: visible !important;
@@ -59,6 +60,6 @@ pre.sourceCode {
   page-break-inside: auto;
 }
 
-pre > code.sourceCode {
+pre > code {
   white-space: pre-wrap;
 }


### PR DESCRIPTION
Code blocks were being rendered as blank spaces if it spanned more than 1 page on epub. This fix updates the CSS to allow page overflow. I manually verified that the new epub generate with this change works as intended:

Before: 
<img width="1194" height="834" alt="IMG_0106" src="https://github.com/user-attachments/assets/3b9d4a63-f215-44e8-b49e-1d52fa2f30ab" />

After:
<img width="1194" height="834" alt="IMG_0105" src="https://github.com/user-attachments/assets/020a36f5-b653-48f6-8b35-e3ac4631e420" />


Here is Sol's reasoning on why this change fixes the issue:

Pandoc renders fenced code roughly as:
```html
<pre class="sourceCode">
  <code class="sourceCode">...</code>
</pre>
```

The shared web CSS made `<pre>` a scroll container and told print layouts not to split it. A code block taller than one EPUB page therefore could not be placed, causing some readers to clip or blank it.

The fix in ebook.css:

- `overflow: visible !important` removes the scroll container. `!important` is necessary to override the existing rule.
- `break-inside: auto` lets modern readers split the block between pages.
- `page-break-inside: auto` provides the same behavior for older EPUB engines.
- `white-space: pre-wrap` preserves code indentation and newlines while allowing long lines to wrap.

These rules only permit splitting; short blocks still render normally. Because this is EPUB-specific CSS, the website styling is unchanged.