### PR TITLE
Add Lecture 12/13 videos to chapters 16/17 and the course page

### DIFF
--- a/book/chapters/16-evaluation.md
+++ b/book/chapters/16-evaluation.md
@@ -12,6 +12,9 @@ search-title: "Chapter 16: Evaluation"
 meta-description: "Evaluation methods for measuring RLHF, post-training, reward models, open-ended generation, and model behavior."
 next-chapter: "Crafting Model Character and Products"
 next-url: "17-product"
+lectures:
+  - video: "https://www.youtube.com/watch?v=dFafQmClYq4&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=19"
+    label: "Lecture 12: The Evolution of Frontier Model Evaluation"
 ---
 
 # Evaluation

--- a/book/chapters/17-product.md
+++ b/book/chapters/17-product.md
@@ -12,6 +12,9 @@ search-title: "Chapter 17: Crafting Model Character and Products"
 meta-description: "How RLHF and post-training shape model character, product behavior, UX, and deployed AI systems."
 next-chapter: "Definitions"
 next-url: "appendix-a-definitions"
+lectures:
+  - video: "https://www.youtube.com/watch?v=xECWRYBxq1E&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=20"
+    label: "Lecture 13: An Introduction to Character Training"
 ---
 
 # Crafting Model Character and Products

--- a/book/templates/course.html
+++ b/book/templates/course.html
@@ -861,7 +861,7 @@
         <h3>Lecture 13: An Introduction to Character Training</h3>
         <div class="course-row-lower">
           <p class="meta">Chapter 17 &middot; Character training and constitutions, persona vectors and the Assistant Axis, model specs and product cycles</p>
-          <div class="row-actions"><a class="action" href="/teach/course/lec13-chap17-character/slides.pdf" download>PDF</a><span class="sep">&middot;</span><a class="action" href="/teach/course/lec13-chap17-character/" target="_blank" rel="noopener noreferrer">Slides</a><span class="sep">&middot;</span><a class="action action-source" href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec13-chap17-character.md?plain=1" target="_blank" rel="noopener noreferrer">Source</a></div>
+          <div class="row-actions"><a class="action action-watch" href="https://www.youtube.com/watch?v=xECWRYBxq1E&list=PLL1tdVxB1CpVpEtMHxwuR4uI4Lxjw00_y&index=20" target="_blank" rel="noopener noreferrer"><svg width="12" height="12"><use href="#icon-watch"/></svg> Watch</a><span class="sep">&middot;</span><a class="action" href="/teach/course/lec13-chap17-character/slides.pdf" download>PDF</a><span class="sep">&middot;</span><a class="action" href="/teach/course/lec13-chap17-character/" target="_blank" rel="noopener noreferrer">Slides</a><span class="sep">&middot;</span><a class="action action-source" href="https://github.com/natolambert/rlhf-book/blob/main/teach/course/lec13-chap17-character.md?plain=1" target="_blank" rel="noopener noreferrer">Source</a></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Landed after #498's squash-merge cut off, so re-applied on a fresh branch.

## Changes
- Chapter 17 `lectures:` frontmatter block with the Lecture 13 recording (playlist index 20)
- Chapter 16 gets its missing Lecture 12 recording (index 19) — it had only been added to the course page
- Course page: Watch action on the Lecture 13 row

🤖 Generated with [Claude Code](https://claude.com/claude-code)