### PR TITLE
[CODE] Release code v0.4.0

### DIFF
--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -5,6 +5,8 @@ On release, entries get moved under a version heading.
 
 ## Unreleased
 
+## v0.4.0
+
 - 2026-08-07: [PR #517](https://github.com/natolambert/rlhf-book/pull/517) Updated ORM reward model training script to use final tokens score for completion correctness predicted label instead of using all completion tokens
 - 2026-08-06: [PR #514](https://github.com/natolambert/rlhf-book/pull/514) added per-module `resolve_device()` helpers with `device: auto` default (CUDA → CPU) to `policy_gradients/`, `direct_alignment/`, `rejection_sampling/`, `distillation/`, and `instruction_tuning/`, replacing hardcoded CUDA. MPS is intentionally omitted (unstable / bf16 gaps).
 - 2026-08-04: [PR #507](https://github.com/natolambert/rlhf-book/pull/507) enforced YAML config for `train_orm`: `--config` is now required and the previously documented CLI overrides, including `--samples` and `--no-wandb`, were removed. This is a breaking CLI change; existing commands must move those overrides into the YAML file.

--- a/code/pyproject.toml
+++ b/code/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rlhf-book-code"
-version = "0.3.0"
+version = "0.4.0"
 description = "Educational code examples for RLHF Book (https://rlhfbook.com)"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
Cut the long-overdue code release: rolls the `Unreleased` changelog (May 5 – Aug 7, 22 entries) into `v0.4.0` and bumps `code/pyproject.toml` to 0.4.0. After merge, this gets tagged `code/v0.4` with a GitHub release.

## Highlights since v0.3.0
**New modules**
- `instruction_tuning/` — single-GPU SFT example for Chapter 4, with reference wandb run (#416, #424)
- `distillation/` SDPO rework — migrated from LiveCodeBench to Reasoning Gym, poll-until-full rollout collection, reference plots and hard-task hyperparameter guidance (#429, #482)

**Breaking changes**
- `train_orm` and `train_preference_rm` are YAML-config-only: `--config` required, CLI overrides removed (#507, #502)
- Preference RM: config-driven training with validation split, namespaced metrics, and changed defaults — prior runs not name-comparable (#476)
- Degenerate preference-pair dropping and chat-template tokenization change run comparability (#504, #450)

**Improvements**
- `device: auto` (CUDA → CPU) across all training modules (#514)
- ORM predicted label now uses the final completion token (#517)
- Batched dataset encoding (#499/#500), GSM8K repo-id fix (#485), `dpo_norm` variant (#400), smoke tests (#396), docs cleanup (#495, #417–#425)

45/45 code smoke tests pass locally with the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)