### PR TITLE
Add "Web Version vs. Physical Book (Errata Fixes)" section to introduction

### DIFF
--- a/book/chapters/01-introduction.md
+++ b/book/chapters/01-introduction.md
@@ -355,6 +355,28 @@ This is *not* a comprehensive textbook, but rather a quick book for reminders an
 
 The print edition of this book was published by Manning in July 2026, while the web version continues to collect minor improvements and errata fixes. If you spot a typo or an important omission, please contribute a fix or suggestion on [GitHub](https://github.com/natolambert/rlhf-book).
 
+### Web Version vs. Physical Book (Errata Fixes)
+
+The book will be re-printed roughly 2 and 6 months after the initial print in July 2026.
+This section tracks the differences between the web version and the physical book, and will be updated to note which improvements or fixes make it into which print version.
+
+#### Content additions and fixes
+
+- Added a short subsection on agentic evaluation (Chapter 16) — [#492](https://github.com/natolambert/rlhf-book/pull/492).
+- Clarified the history of outcome reward models, fixed some loose language, and reorganized the reward modeling chapter (Chapter 5) — [#516](https://github.com/natolambert/rlhf-book/pull/516).
+- Cleaned up RL notation, especially the trajectory sampling distribution and time indexing (Chapter 6) — [#466](https://github.com/natolambert/rlhf-book/pull/466).
+
+#### Organizational improvements
+
+- Renamed Chapter 12 to "Synthetic Data & Distillation" — [#469](https://github.com/natolambert/rlhf-book/pull/469).
+- Reordered the regularization chapter for better flow (Chapter 15) — [#486](https://github.com/natolambert/rlhf-book/pull/486).
+
+#### Typos and minor fixes
+
+- Added an extra line to the Bradley-Terry reward model loss derivation (Chapter 5) — [#465](https://github.com/natolambert/rlhf-book/pull/465).
+- Fixed the description of the reference model in the policy ratio (Chapter 6) — [#488](https://github.com/natolambert/rlhf-book/pull/488).
+- Cleaned up assorted typos and minor wording issues — [#495](https://github.com/natolambert/rlhf-book/pull/495).
+
 ### About the Author
 
 Dr. Nathan Lambert is a researcher and writer focusing on building the open science of language models. He came here through a Ph.D. in robotics and building an RLHF team shortly after the release of ChatGPT.

--- a/book/chapters/01-introduction.md
+++ b/book/chapters/01-introduction.md
@@ -355,28 +355,6 @@ This is *not* a comprehensive textbook, but rather a quick book for reminders an
 
 The print edition of this book was published by Manning in July 2026, while the web version continues to collect minor improvements and errata fixes. If you spot a typo or an important omission, please contribute a fix or suggestion on [GitHub](https://github.com/natolambert/rlhf-book).
 
-### Web Version vs. Physical Book (Errata Fixes)
-
-The book will be re-printed roughly 2 and 6 months after the initial print in July 2026.
-This section tracks the differences between the web version and the physical book, and will be updated to note which improvements or fixes make it into which print version.
-
-#### Content additions and fixes
-
-- Added a short subsection on agentic evaluation (Chapter 16) — [#492](https://github.com/natolambert/rlhf-book/pull/492).
-- Clarified the history of outcome reward models, fixed some loose language, and reorganized the reward modeling chapter (Chapter 5) — [#516](https://github.com/natolambert/rlhf-book/pull/516).
-- Cleaned up RL notation, especially the trajectory sampling distribution and time indexing (Chapter 6) — [#466](https://github.com/natolambert/rlhf-book/pull/466).
-
-#### Organizational improvements
-
-- Renamed Chapter 12 to "Synthetic Data & Distillation" — [#469](https://github.com/natolambert/rlhf-book/pull/469).
-- Reordered the regularization chapter for better flow (Chapter 15) — [#486](https://github.com/natolambert/rlhf-book/pull/486).
-
-#### Typos and minor fixes
-
-- Added an extra line to the Bradley-Terry reward model loss derivation (Chapter 5) — [#465](https://github.com/natolambert/rlhf-book/pull/465).
-- Fixed the description of the reference model in the policy ratio (Chapter 6) — [#488](https://github.com/natolambert/rlhf-book/pull/488).
-- Cleaned up assorted typos and minor wording issues — [#495](https://github.com/natolambert/rlhf-book/pull/495).
-
 ### About the Author
 
 Dr. Nathan Lambert is a researcher and writer focusing on building the open science of language models. He came here through a Ph.D. in robotics and building an RLHF team shortly after the release of ChatGPT.

--- a/book/templates/html.html
+++ b/book/templates/html.html
@@ -166,6 +166,7 @@ $endif$
       <li>Added a short subsection on agentic evaluation (Chapter 16) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/492">#492</a>.</li>
       <li>Clarified the history of outcome reward models, fixed some loose language, and reorganized the reward modeling chapter (Chapter 5) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/516">#516</a>.</li>
       <li>Cleaned up RL notation, especially the trajectory sampling distribution and time indexing (Chapter 6) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/466">#466</a>.</li>
+      <li>Expanded the on-policy distillation section, particularly more on self-distillation and OPSD (Chapter 12) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/439">#439</a>.</li>
     </ul>
     <p><strong>Organizational improvements:</strong></p>
     <ul>

--- a/book/templates/html.html
+++ b/book/templates/html.html
@@ -259,6 +259,27 @@ $endif$
     #changelog details[open] .changelog-caret { transform: rotate(90deg); }
     #acknowledgements > h3 { margin-top: 0.4em; }
   </style>
+  <section id="errata" style="padding: 0 20px; margin-top: 2em;">
+    <h3>Web Version vs. Physical Book (Errata Fixes)</h3>
+    <p>The book will be re-printed roughly 2 and 6 months after the initial print in July 2026. This section tracks the differences between the web version and the physical book, and will be updated to note which improvements or fixes make it into which print version.</p>
+    <p><strong>Content additions and fixes:</strong></p>
+    <ul>
+      <li>Added a short subsection on agentic evaluation (Chapter 16) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/492">#492</a>.</li>
+      <li>Clarified the history of outcome reward models, fixed some loose language, and reorganized the reward modeling chapter (Chapter 5) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/516">#516</a>.</li>
+      <li>Cleaned up RL notation, especially the trajectory sampling distribution and time indexing (Chapter 6) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/466">#466</a>.</li>
+    </ul>
+    <p><strong>Organizational improvements:</strong></p>
+    <ul>
+      <li>Renamed Chapter 12 to "Synthetic Data &amp; Distillation" &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/469">#469</a>.</li>
+      <li>Reordered the regularization chapter for better flow (Chapter 15) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/486">#486</a>.</li>
+    </ul>
+    <p><strong>Typos and minor fixes:</strong></p>
+    <ul>
+      <li>Added an extra line to the Bradley-Terry reward model loss derivation (Chapter 5) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/465">#465</a>.</li>
+      <li>Fixed the description of the reference model in the policy ratio (Chapter 6) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/488">#488</a>.</li>
+      <li>Cleaned up assorted typos and minor wording issues &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/495">#495</a>.</li>
+    </ul>
+  </section>
   <section id="changelog" style="padding: 0 20px; margin-top: 2em;">
     <details>
     <summary>

--- a/book/templates/html.html
+++ b/book/templates/html.html
@@ -158,6 +158,27 @@ $if(abstract)$
 $endif$
 </header>
 $endif$
+  <h3 id="errata" style="padding: 0 20px; margin-top: 1.5em;">Web Version vs. Physical Book (Errata Fixes)</h3>
+  <div style="padding: 0 20px; font-size: 0.9em;">
+    <p>The book will be re-printed roughly 2 and 6 months after the initial print in July 2026. This section tracks the differences between the web version and the physical book, and will be updated to note which improvements or fixes make it into which print version.</p>
+    <p><strong>Content additions and fixes:</strong></p>
+    <ul>
+      <li>Added a short subsection on agentic evaluation (Chapter 16) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/492">#492</a>.</li>
+      <li>Clarified the history of outcome reward models, fixed some loose language, and reorganized the reward modeling chapter (Chapter 5) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/516">#516</a>.</li>
+      <li>Cleaned up RL notation, especially the trajectory sampling distribution and time indexing (Chapter 6) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/466">#466</a>.</li>
+    </ul>
+    <p><strong>Organizational improvements:</strong></p>
+    <ul>
+      <li>Renamed Chapter 12 to "Synthetic Data &amp; Distillation" &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/469">#469</a>.</li>
+      <li>Reordered the regularization chapter for better flow (Chapter 15) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/486">#486</a>.</li>
+    </ul>
+    <p><strong>Typos and minor fixes:</strong></p>
+    <ul>
+      <li>Added an extra line to the Bradley-Terry reward model loss derivation (Chapter 5) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/465">#465</a>.</li>
+      <li>Fixed the description of the reference model in the policy ratio (Chapter 6) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/488">#488</a>.</li>
+      <li>Cleaned up assorted typos and minor wording issues &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/495">#495</a>.</li>
+    </ul>
+  </div>
   <h3 id="ecosystem" style="padding: 0 20px; margin-top: 1.5em;">RLHF Book Ecosystem</h3>
   <div style="display: flex; align-items: center; justify-content: space-between; gap: 1em; flex-wrap: wrap; margin: 0.5em 20px 0; padding: 0.8em 1.2em; border: 1px solid var(--color-border); border-radius: 0.35em; background: var(--color-bg-section); box-shadow: 0 4px 12px var(--color-shadow);">
     <div>
@@ -259,27 +280,6 @@ $endif$
     #changelog details[open] .changelog-caret { transform: rotate(90deg); }
     #acknowledgements > h3 { margin-top: 0.4em; }
   </style>
-  <section id="errata" style="padding: 0 20px; margin-top: 2em;">
-    <h3>Web Version vs. Physical Book (Errata Fixes)</h3>
-    <p>The book will be re-printed roughly 2 and 6 months after the initial print in July 2026. This section tracks the differences between the web version and the physical book, and will be updated to note which improvements or fixes make it into which print version.</p>
-    <p><strong>Content additions and fixes:</strong></p>
-    <ul>
-      <li>Added a short subsection on agentic evaluation (Chapter 16) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/492">#492</a>.</li>
-      <li>Clarified the history of outcome reward models, fixed some loose language, and reorganized the reward modeling chapter (Chapter 5) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/516">#516</a>.</li>
-      <li>Cleaned up RL notation, especially the trajectory sampling distribution and time indexing (Chapter 6) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/466">#466</a>.</li>
-    </ul>
-    <p><strong>Organizational improvements:</strong></p>
-    <ul>
-      <li>Renamed Chapter 12 to "Synthetic Data &amp; Distillation" &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/469">#469</a>.</li>
-      <li>Reordered the regularization chapter for better flow (Chapter 15) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/486">#486</a>.</li>
-    </ul>
-    <p><strong>Typos and minor fixes:</strong></p>
-    <ul>
-      <li>Added an extra line to the Bradley-Terry reward model loss derivation (Chapter 5) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/465">#465</a>.</li>
-      <li>Fixed the description of the reference model in the policy ratio (Chapter 6) &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/488">#488</a>.</li>
-      <li>Cleaned up assorted typos and minor wording issues &mdash; <a href="https://github.com/natolambert/rlhf-book/pull/495">#495</a>.</li>
-    </ul>
-  </section>
   <section id="changelog" style="padding: 0 20px; margin-top: 2em;">
     <details>
     <summary>


### PR DESCRIPTION
## Summary
Adds a "Web Version vs. Physical Book (Errata Fixes)" section to the rlhfbook.com main page (between Acknowledgements and the Changelog) to track differences between the web version and the July 2026 Manning print edition. The book will be re-printed roughly 2 and 6 months after the initial print, and this section will be updated to note which fixes land in which printing.

## Changes
- New `#errata` section in `book/templates/html.html` with three lists, each item linking to its PR:
  - **Content additions and fixes**: agentic evaluation subsection (#492), ORM history clarification + RM chapter reorganization (#516), RL notation cleanup (#466)
  - **Organizational improvements**: Chapter 12 rename (#469), Chapter 15 regularization reorder (#486)
  - **Typos and minor fixes**: Bradley-Terry derivation extra step (#465), policy ratio reference model fix (#488), general typo cleanup (#495)
- Verified with `make html` that the section renders in `build/html/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
